### PR TITLE
Improvement how pictures are displayed when upload

### DIFF
--- a/source/SIL.AppBuilder.Portal.Frontend/src/ui/routes/profile/picture/index.tsx
+++ b/source/SIL.AppBuilder.Portal.Frontend/src/ui/routes/profile/picture/index.tsx
@@ -48,9 +48,7 @@ class ImageProfile extends React.Component<IProps, IState> {
 
   render() {
 
-    const { imageData, width, height } = this.state;
-
-    console.log(width, height);
+    const { imageData } = this.state;
 
     return (
       <div data-test-picture-profile>
@@ -61,7 +59,6 @@ class ImageProfile extends React.Component<IProps, IState> {
           <div className='thumbnail'>
             <img
               src={imageData}
-              className={width < height ? 'portrait' : ''}
               data-test-picture-uploaded
             />
           </div>

--- a/source/SIL.AppBuilder.Portal.Frontend/src/ui/routes/profile/picture/index.tsx
+++ b/source/SIL.AppBuilder.Portal.Frontend/src/ui/routes/profile/picture/index.tsx
@@ -37,7 +37,7 @@ class ImageProfile extends React.Component<IProps, IState> {
             this.props.onChange(reader.result);
           });
         };
-      }
+      };
 
       i.src = URL.createObjectURL(file);
 

--- a/source/SIL.AppBuilder.Portal.Frontend/src/ui/routes/profile/picture/index.tsx
+++ b/source/SIL.AppBuilder.Portal.Frontend/src/ui/routes/profile/picture/index.tsx
@@ -6,26 +6,41 @@ export interface IProps {
 
 export interface IState {
   imageData: string;
+  width: number;
+  height: number;
 }
 
 class ImageProfile extends React.Component<IProps, IState> {
 
   state = {
-    imageData: null
+    imageData: null,
+    width: null,
+    height: null
   };
 
   handleNewImage = e => {
 
     if (e.target.files && e.target.files[0]) {
-      const reader = new FileReader();
 
-      reader.readAsDataURL(e.target.files[0]);
+      const i = new Image();
+      const file = e.target.files[0];
 
-      reader.onload = () => {
-        this.setState({ imageData: reader.result },() => {
-          this.props.onChange(reader.result);
-        });
-      };
+      i.onload = () => {
+        const reader = new FileReader();
+        reader.readAsDataURL(file);
+        reader.onload = () => {
+          this.setState({
+            imageData: reader.result,
+            width: i.width,
+            height: i.height
+          }, () => {
+            this.props.onChange(reader.result);
+          });
+        };
+      }
+
+      i.src = URL.createObjectURL(file);
+
     }
 
 
@@ -33,7 +48,9 @@ class ImageProfile extends React.Component<IProps, IState> {
 
   render() {
 
-    const { imageData } = this.state;
+    const { imageData, width, height } = this.state;
+
+    console.log(width, height);
 
     return (
       <div data-test-picture-profile>
@@ -41,11 +58,13 @@ class ImageProfile extends React.Component<IProps, IState> {
           <div className='default-profile-image'>
             <span>JL</span>
           </div> :
-          <img
-            className='profile-image'
-            src={imageData}
-            data-test-picture-uploaded
-          />
+          <div className='thumbnail'>
+            <img
+              src={imageData}
+              className={width < height ? 'portrait' : ''}
+              data-test-picture-uploaded
+            />
+          </div>
         }
         <div>
           <label

--- a/source/SIL.AppBuilder.Portal.Frontend/src/ui/routes/profile/profile.scss
+++ b/source/SIL.AppBuilder.Portal.Frontend/src/ui/routes/profile/profile.scss
@@ -83,11 +83,27 @@
     }
   }
 
-  .profile-image {
+  .thumbnail {
+    position: relative;
     width: 128px;
     height: 128px;
+    overflow: hidden;
+    margin: 0px auto 20px;
     border-radius: 50%;
-    margin-bottom: 20px;
+  }
+  .thumbnail img {
+    position: absolute;
+    left: 50%;
+    top: 50%;
+    height: 100%;
+    width: auto;
+    -webkit-transform: translate(-50%,-50%);
+        -ms-transform: translate(-50%,-50%);
+            transform: translate(-50%,-50%);
+  }
+  .thumbnail img.portrait {
+    width: 100%;
+    height: auto;
   }
 
   .upload-button {

--- a/source/SIL.AppBuilder.Portal.Frontend/src/ui/routes/profile/profile.scss
+++ b/source/SIL.AppBuilder.Portal.Frontend/src/ui/routes/profile/profile.scss
@@ -83,28 +83,21 @@
     }
   }
 
-  .thumbnail {
-    position: relative;
+.thumbnail {
+  overflow: hidden;
     width: 128px;
     height: 128px;
-    overflow: hidden;
     margin: 0px auto 20px;
     border-radius: 50%;
+
+    img {
+      width: 100%;
+      height: 100%;
+      object-fit: cover;
+      object-position: 50% 50%;
+    }
   }
-  .thumbnail img {
-    position: absolute;
-    left: 50%;
-    top: 50%;
-    height: 100%;
-    width: auto;
-    -webkit-transform: translate(-50%,-50%);
-        -ms-transform: translate(-50%,-50%);
-            transform: translate(-50%,-50%);
-  }
-  .thumbnail img.portrait {
-    width: 100%;
-    height: auto;
-  }
+
 
   .upload-button {
     border-radius: 4px;


### PR DESCRIPTION
When you upload pictures that are in portrait I adjust it to try to fit it in a square of 128px

![potrait](https://user-images.githubusercontent.com/501129/42786006-2767edc8-891a-11e8-9aa1-412704bd17c9.png)
![portrait](https://user-images.githubusercontent.com/501129/42786005-2749d176-891a-11e8-8928-d7a79fff31cc.png)

Same for landscape

![landscape](https://user-images.githubusercontent.com/501129/42786085-6d5d87de-891a-11e8-8bd2-ed15b1f46147.png)
![landscape-upload](https://user-images.githubusercontent.com/501129/42786084-6d3eba48-891a-11e8-9d0a-7aeb2b892be3.png)

