### PR TITLE
Always allow current user to get own profile

### DIFF
--- a/source/OptimaJet.DWKit.StarterApplication/Repositories/UserRepository.cs
+++ b/source/OptimaJet.DWKit.StarterApplication/Repositories/UserRepository.cs
@@ -49,6 +49,18 @@ namespace OptimaJet.DWKit.StarterApplication.Repositories
                        .Where(u => u.OrganizationMemberships.Any(o => o.OrganizationId == OrganizationContext.OrganizationId));
         }
 
+        public override async Task<User> GetAsync(int id)
+        {
+            // The default implementation filters by selected organization.  The 
+            // current user might not be in that organization.
+            // Always allow getting the current user. 
+            var currentUser = await GetByAuth0Id(CurrentUserContext.Auth0Id);
+            if (currentUser != null && currentUser.Id == id) {
+                return await DefaultGet().Where(e => e.Id == id).FirstAsync();
+            }
+            return await base.GetAsync(id);
+        }
+
         public async Task<User> GetByAuth0Id(string auth0Id)
             => await base.Get()
                 .Where(e => e.ExternalId == auth0Id)


### PR DESCRIPTION
* getting users can get filtered by the current organization (which
  the user might not be in).