### PR TITLE
Feature/assign a group to aproject

### DIFF
--- a/source/SIL.AppBuilder.Portal.Frontend/src/data/containers/resources/project/with-data-actions.tsx
+++ b/source/SIL.AppBuilder.Portal.Frontend/src/data/containers/resources/project/with-data-actions.tsx
@@ -1,0 +1,70 @@
+import * as React from 'react';
+import { withData as withOrbit, WithDataProps } from 'react-orbitjs';
+
+import { defaultOptions } from '@data';
+import { ProjectAttributes } from '@data/models/project';
+
+
+export interface IProvidedProps {
+  updateAttributes: (attrs: ProjectAttributes) => any;
+  updateGroup: (groupId: Id) => any;
+  updateOwner: (userId: Id) => any;
+}
+
+interface IOwnProps {
+  project: JSONAPI<ProjectAttributes>;
+}
+
+type IProps =
+  & IOwnProps
+  & WithDataProps;
+
+export function withDataActions<T>(WrappedComponent) {
+  class ProjectDataActionWrapper extends React.Component<IProps & T> {
+    updateAttributes = (attributes: ProjectAttributes) => {
+      const { project, updateStore } = this.props;
+      const { id, type } = project;
+
+      return updateStore(q => q.replaceRecord({
+        id, type, attributes
+      }), defaultOptions());
+    }
+
+    updateGroup = (groupId: Id) => {
+      const { project, updateStore } = this.props;
+      const { id, type } = project;
+
+      return updateStore(q => q.replaceRelatedRecord(
+        { type, id }, 'group',
+        { type: 'group', id: groupId }
+      ), defaultOptions());
+    }
+
+    updateOwner = (userId: Id) => {
+      const { project, updateStore } = this.props;
+      const { id, type } = project;
+
+      return updateStore(q => q.replaceRelatedRecord(
+        { type, id }, 'owner',
+        { type: 'user', id: userId }
+      ), defaultOptions());
+    }
+
+    addReviewer = (email: string) => {
+      console.error('not implemented');
+    }
+
+    render() {
+      const props = {
+        ...this.props,
+        updateAttributes: this.updateAttributes,
+        updateGroup: this.updateGroup,
+        updateOwner: this.updateOwner
+      };
+
+      return <WrappedComponent { ...props } />;
+    }
+  }
+
+  return withOrbit({})(ProjectDataActionWrapper);
+}

--- a/source/SIL.AppBuilder.Portal.Frontend/src/data/containers/with-current-organization.tsx
+++ b/source/SIL.AppBuilder.Portal.Frontend/src/data/containers/with-current-organization.tsx
@@ -26,9 +26,12 @@ export function withCurrentOrganization(InnerComponent) {
   });
 
   function mapRecordsToProps(passedProps) {
+    const { currentOrganizationId: id } = passedProps;
+
+    if (!id || id === '') { return {}; }
+
     return {
-      fromCache: q =>
-        q.findRecord({ type: TYPE_NAME, id: passedProps.currentOrganizationId })
+      fromCache: q => q.findRecord({ type: TYPE_NAME, id })
     };
   }
 
@@ -38,7 +41,7 @@ export function withCurrentOrganization(InnerComponent) {
     getOrganization = async () => {
       const { queryStore, currentOrganizationId: id }  = this.props;
 
-      if (id === '') { return; }
+      if (!id || id === '') { return; }
 
       // TODO: do we need to get any common related things?
 

--- a/source/SIL.AppBuilder.Portal.Frontend/src/data/schema.ts
+++ b/source/SIL.AppBuilder.Portal.Frontend/src/data/schema.ts
@@ -76,7 +76,8 @@ const schemaDefinition: SchemaSettings = {
         tasks: { type: 'hasMany', model: 'task', inverse: 'project'},
         products: { type: 'hasMany', model: 'product', inverse: 'project' },
         organization: { type: 'hasOne', model: 'organization', inverse: 'projects'},
-        owner: { type: 'hasOne', model: 'user', inverse: 'projects' }
+        owner: { type: 'hasOne', model: 'user', inverse: 'projects' },
+        group: { type: 'hasOne', model: 'group', inverse: 'projects' }
       }
     },
     product: {
@@ -139,6 +140,7 @@ const schemaDefinition: SchemaSettings = {
       relationships: {
         users: { type: 'hasMany', model: 'user', inverse: 'groups' },
         groupMemberships: { type: 'hasMany', model: 'groupMembership', inverse: 'group' },
+        projects: { type: 'hasMany', model: 'project', inverse: 'group' },
       }
     },
     user: {

--- a/source/SIL.AppBuilder.Portal.Frontend/src/translations/locales/en-us.ts
+++ b/source/SIL.AppBuilder.Portal.Frontend/src/translations/locales/en-us.ts
@@ -130,6 +130,7 @@ export default {
     notFoundDescription: 'Something went wrong and the page or resource could not be found!',
     groupRequired: 'You must be a member of at least one group.',
     userForbidden: 'An error occurred: Forbidden. Please contact your organization administrator.',
+    notAMemberOfOrg: 'You are not a member of that organization',
     orgMembershipRequired: 'Organization Membership is Required',
     orgMembershipRequiredText: `
       In order to use Scriptoria, you must be a member of at least one organization.

--- a/source/SIL.AppBuilder.Portal.Frontend/src/ui/components/inputs/group-select/__tests__/page.ts
+++ b/source/SIL.AppBuilder.Portal.Frontend/src/ui/components/inputs/group-select/__tests__/page.ts
@@ -1,0 +1,37 @@
+import {
+  interactor,
+  clickable,
+  text,
+  selectable,
+  isPresent,
+  fillable,
+  is,
+  collection
+} from '@bigtest/interactor';
+
+@interactor
+export class GroupSelectInteractor {
+  constructor(selector?: string) { }
+
+  isDisabled = is('.disabled');
+  selectedGroup = text('.selected');
+
+  options = collection('.item');
+
+  chooseGroup(optionText: string) {
+    return this
+      .when(() => {
+        const el = this
+          .$$('.item')
+          .find(item => item.innerText.includes(optionText));
+
+        if (!el) {
+          throw new Error(`cannot find ".item" with text "${optionText}"`);
+        }
+
+        return el;
+      }).do(el => el.click());
+  }
+}
+
+export default new GroupSelectInteractor('[data-test-group-select]');

--- a/source/SIL.AppBuilder.Portal.Frontend/src/ui/components/inputs/group-select/display.tsx
+++ b/source/SIL.AppBuilder.Portal.Frontend/src/ui/components/inputs/group-select/display.tsx
@@ -8,6 +8,7 @@ import { IProvidedProps as IDataProps } from './with-data';
 interface IOwnProps {
   selected: Id;
   onChange: (groupId: Id) => void;
+  disableSelection?: boolean;
 }
 
 type IProps =
@@ -34,17 +35,19 @@ export default class GroupSelectDisplay extends React.Component<IProps> {
   }
 
   render() {
-    const { groups, selected } = this.props;
+    const { groups, selected, disableSelection } = this.props;
 
-    const groupOptions = groups.map(group => ({
-      text: attributesFor(group).name,
-      value: group.id
-    }));
+    const groupOptions = groups
+      .filter(group => attributesFor(group).name)
+      .map(group => ({
+        text: attributesFor(group).name,
+        value: group.id
+      }));
 
     return (
       <Dropdown
         data-test-group-select
-        inline
+        disabled={disableSelection || false}
         options={groupOptions}
         value={selected}
         onChange={this.onSelect}

--- a/source/SIL.AppBuilder.Portal.Frontend/src/ui/routes/project-directory/filters/index.tsx
+++ b/source/SIL.AppBuilder.Portal.Frontend/src/ui/routes/project-directory/filters/index.tsx
@@ -9,14 +9,13 @@ import MomentLocaleUtils, {
   parseDate,
 } from 'react-day-picker/moment';
 
+import { attributesFor } from '@data';
 import { OrganizationAttributes } from '@data/models/organization';
 import { IFilter } from '@data/containers/with-filtering';
 import {
   withCurrentOrganization,
   IProvidedProps as ICurrentOrgProps
 } from '@data/containers/with-current-organization';
-
-import { attributesFor } from '@data';
 
 import 'react-day-picker/lib/style.css';
 import './filters.scss';

--- a/source/SIL.AppBuilder.Portal.Frontend/src/ui/routes/project/__tests__/acceptance-test.tsx
+++ b/source/SIL.AppBuilder.Portal.Frontend/src/ui/routes/project/__tests__/acceptance-test.tsx
@@ -22,21 +22,23 @@ describe('Acceptance | Archive Project', () => {
     });
   });
 
-  describe('an active prjoject exists', () => {
+  describe('an active project exists', () => {
     beforeEach(function() {
-      this.mockGet(200, 'projects/1', {
-        data: {
+      this.mockGet(200, '/groups', { data: [] });
+      this.mockGet(200, 'projects/1', { data: {
           type: 'projects',
           id: '1',
           attributes: {
             'date-archived': null,
           },
           relationships: {
-            organization: { data: { id: 1, type: 'organizations' } }
+            organization: { data: { id: 1, type: 'organizations' } },
+            group: { data: { id: 1, type: 'groups' } }
           }
         },
         included: [
-          { type: 'organizations', id: 1, }
+          { type: 'organizations', id: 1, },
+          { type: 'groups', id: 1, attributes: { name: 'Some Group' } }
         ]
       });
     });
@@ -68,6 +70,7 @@ describe('Acceptance | Archive Project', () => {
 
   describe('an archived project exists', () => {
     beforeEach(function() {
+      this.mockGet(200, '/groups', { data: [] });
       this.mockGet(200, 'projects/1', {
         data: {
           type: 'projects',
@@ -76,11 +79,13 @@ describe('Acceptance | Archive Project', () => {
             'date-archived': "2018-08-10T23:59:55.259Z"
           },
           relationships: {
-            organization: { data: { id: 1, type: 'organizations' } }
+            organization: { data: { id: 1, type: 'organizations' } },
+            group: { data: { id: 1, type: 'groups' } }
           }
         },
         included: [
-          { type: 'organizations', id: 1, }
+          { type: 'organizations', id: 1, },
+          { type: 'groups', id: 1, attributes: { name: 'Some Group' } }
         ]
       });
     });
@@ -94,12 +99,11 @@ describe('Acceptance | Archive Project', () => {
             attributes: {
               'date-archived': null
             },
-            relationships: {},
           }});
       });
 
       describe('the reactivate button is clicked', () => {
-        beforeEach(async () => {
+        beforeEach(async function() {
           await visit('/project/1');
           await page.clickArchiveLink();
         });

--- a/source/SIL.AppBuilder.Portal.Frontend/src/ui/routes/project/__tests__/group-and-access-acceptance-test.ts
+++ b/source/SIL.AppBuilder.Portal.Frontend/src/ui/routes/project/__tests__/group-and-access-acceptance-test.ts
@@ -9,7 +9,7 @@ import {
 } from 'tests/helpers/index';
 
 import {
-  userInDifferntOrganization,
+  userInDifferentOrganization,
   userInSameOrgDifferentGroup,
   userInSameOrgAndGroup
 } from './user-scenarios';
@@ -60,7 +60,7 @@ describe('Acceptance | Project Edit', () => {
     });
 
     describe('the user is not in the same organization as the project', () => {
-      userInDifferntOrganization(2);
+      userInDifferentOrganization(2);
 
       beforeEach(async function() {
         await visit('/project/1');

--- a/source/SIL.AppBuilder.Portal.Frontend/src/ui/routes/project/__tests__/group-and-access-acceptance-test.ts
+++ b/source/SIL.AppBuilder.Portal.Frontend/src/ui/routes/project/__tests__/group-and-access-acceptance-test.ts
@@ -1,0 +1,135 @@
+
+import { describe, it, beforeEach } from '@bigtest/mocha';
+import { visit, location } from '@bigtest/react';
+import { expect } from 'chai';
+
+import {
+  setupApplicationTest, setupRequestInterceptor, useFakeAuthentication,
+  fakeAuth0Id
+} from 'tests/helpers/index';
+
+import {
+  userInDifferntOrganization,
+  userInSameOrgDifferentGroup,
+  userInSameOrgAndGroup
+} from './user-scenarios';
+
+import page from './page';
+
+describe('Acceptance | Project Edit', () => {
+  setupApplicationTest();
+  setupRequestInterceptor();
+
+  describe('re-assigning the group', () => {
+    beforeEach(function() {
+      this.mockGet(200, 'projects/1', { data: {
+          type: 'projects',
+          id: '1',
+          attributes: { name: 'some project' },
+          relationships: {
+            organization: { data: { id: 1, type: 'organizations' } },
+            group: { data: { id: 1, type: 'groups' } }
+          }
+        },
+        included: [
+          { type: 'organizations', id: 1, },
+          { type: 'groups', id: 1, attributes: { name: 'Group 1' } }
+        ]
+      });
+
+      this.mockGet(200, 'groups', { data: [
+        { id: 1, type: 'groups' ,
+          attributes: { name: 'Group 1' },
+          relationships: {
+            organization: { data: { id: 1, type: 'organizations' } }
+          }
+        },
+        { id: 2, type: 'groups' ,
+          attributes: { name: 'Group 2' },
+          relationships: {
+            organization: { data: { id: 1, type: 'organizations' } }
+          }
+        },
+        { id: 3, type: 'groups' ,
+          attributes: { name: 'Group 3' },
+          relationships: {
+            organization: { data: { id: 1, type: 'organizations' } }
+          }
+        }
+      ] });
+    });
+
+    describe('the user is not in the same organization as the project', () => {
+      userInDifferntOrganization(2);
+
+      beforeEach(async function() {
+        await visit('/project/1');
+      });
+
+      it('redirects them away from the project', () => {
+        expect(location().pathname).to.not.eq('/project/1');
+        expect(location().pathname).to.eq('/');
+      });
+    });
+
+    describe('the user is in the same organization as the project, but not in the same group', () => {
+      userInSameOrgDifferentGroup(1, 2);
+
+      beforeEach(async function() {
+        await visit('/project/1');
+      });
+
+      it('does not redirect', () => {
+        expect(location().pathname).to.eq('/project/1');
+      });
+
+      it('shows the group the project is in', () => {
+        expect(page.groupSelect.selectedGroup).to.eq('Group 1');
+      });
+
+      xit('the group dropdown only has one option', () => {
+        expect(page.groupSelect.options.length).to.eq(1);
+      });
+
+      it('the group dropdown is disabled', () => {
+        expect(page.groupSelect.isDisabled).to.be.true;
+      });
+    });
+
+    describe('the user is in both the same organization and the same group as the project', () => {
+      userInSameOrgAndGroup(1, 1);
+
+      beforeEach(async function() {
+        await visit('/project/1');
+      });
+
+      it('does not redirect', () => {
+        expect(location().pathname).to.eq('/project/1');
+      });
+
+      it('defaults to the project group', () => {
+        expect(page.groupSelect.selectedGroup).to.eq('Group 1');
+      });
+
+      it('allows the user to change the group', () => {
+        expect(page.groupSelect.isDisabled).to.be.false;
+      });
+
+      it('shows all the users groups for the organization', () => {
+        const options = page.groupSelect.options();
+        const optionsText = options.map(o => o.text).join();
+
+        expect(optionsText).to.contain('Group 1');
+        expect(optionsText).to.contain('Group 3');
+        expect(options.length).to.eq(2);
+      });
+
+      it('does not show groups the user is not a member of', () => {
+        const options = page.groupSelect.options().map(o => o.text).join();
+
+        expect(options).to.not.contain('Group 2');
+      });
+    });
+  });
+
+});

--- a/source/SIL.AppBuilder.Portal.Frontend/src/ui/routes/project/__tests__/page.ts
+++ b/source/SIL.AppBuilder.Portal.Frontend/src/ui/routes/project/__tests__/page.ts
@@ -3,6 +3,8 @@ import {
   clickable, text
 } from '@bigtest/interactor';
 
+import groupInteractor from '@ui/components/inputs/group-select/__tests__/page';
+
 @interactor
 export class ProjectInteractor {
   constructor(selector?: string) { }
@@ -10,6 +12,7 @@ export class ProjectInteractor {
   clickArchiveLink = clickable('[data-test-archive]');
   archiveText = text('[data-test-archive] span');
 
+  groupSelect = groupInteractor;
 }
 
 export default new ProjectInteractor('[data-test-project]');

--- a/source/SIL.AppBuilder.Portal.Frontend/src/ui/routes/project/__tests__/user-scenarios.ts
+++ b/source/SIL.AppBuilder.Portal.Frontend/src/ui/routes/project/__tests__/user-scenarios.ts
@@ -1,6 +1,6 @@
 import { useFakeAuthentication, fakeAuth0Id } from 'tests/helpers/index';
 
-export function userInDifferntOrganization(orgId: number) {
+export function userInDifferentOrganization(orgId: number) {
   useFakeAuthentication({
     data: {
       id: 1,

--- a/source/SIL.AppBuilder.Portal.Frontend/src/ui/routes/project/__tests__/user-scenarios.ts
+++ b/source/SIL.AppBuilder.Portal.Frontend/src/ui/routes/project/__tests__/user-scenarios.ts
@@ -1,0 +1,152 @@
+import { useFakeAuthentication, fakeAuth0Id } from 'tests/helpers/index';
+
+export function userInDifferntOrganization(orgId: number) {
+  useFakeAuthentication({
+    data: {
+      id: 1,
+      type: 'users',
+      attributes: { id: 1, auth0Id: fakeAuth0Id },
+      relationships: {
+        ['organization-memberships']: {
+          data: [
+            { id: 1, type: 'organization-memberships' },
+          ]
+        }
+      }
+    },
+    included: [
+      { id: 1, type: 'organization-memberships',
+        attributes: {},
+        relationships: {
+          user: { data: { id: 1, type: 'users' } },
+          organization: { data: { id: orgId, type: 'organizations' } }
+      }},
+      { id: 2, type: 'organizations',
+        attributes: {},
+        relationships: {
+          ['organization-memberships']: {
+            data: [
+              { id: 1, type: 'organization-memberships' }
+            ]
+          }
+        }
+      }
+    ]
+  }, {
+    data: [{ type: 'organizations', id: orgId, attributes: {} }],
+    included: [
+      { id: 1, type: 'organization-memberships',
+        attributes: {},
+        relationships: {
+          user: { data: { id: 1, type: 'users' } },
+          organization: { data: { id: orgId, type: 'organizations' } }
+        }
+      },
+    ]
+  });
+}
+
+
+export function userInSameOrgDifferentGroup(orgId, groupId) {
+  useFakeAuthentication({
+    data: {
+      id: 1,
+      type: 'users',
+      attributes: { id: 1, auth0Id: fakeAuth0Id },
+      relationships: {
+        ['organization-memberships']: {
+          data: [
+            { id: 1, type: 'organization-memberships' },
+          ]
+        },
+        ['group-memberships']: {
+          data: [
+            { id: 2, type: 'group-memberships' },
+          ]
+        }
+      }
+    },
+    included: [
+      { id: 1, type: 'organization-memberships',
+        attributes: {},
+        relationships: {
+          user: { data: { id: 1, type: 'users' } },
+          organization: { data: { id: orgId, type: 'organizations' } }
+      }},
+      { id: 2, type: 'group-memberships',
+        attributes: {},
+        relationships: {
+          user: { data: { id: 1, type: 'users' } },
+          group: { data: { id: groupId, type: 'group' } }
+        }
+      }
+    ]
+  }, {
+    data: [{ type: 'organizations', id: orgId, attributes: {} }],
+    included: [
+      { id: 1, type: 'organization-memberships',
+        attributes: {},
+        relationships: {
+          user: { data: { id: 1, type: 'users' } },
+          organization: { data: { id: orgId, type: 'organizations' } }
+        }
+      },
+    ]
+  });
+}
+
+export function userInSameOrgAndGroup(orgId, groupId) {
+  useFakeAuthentication({
+    data: {
+      id: 1,
+      type: 'users',
+      attributes: { id: 1, auth0Id: fakeAuth0Id },
+      relationships: {
+        ['organization-memberships']: {
+          data: [
+            { id: 1, type: 'organization-memberships' },
+          ]
+        },
+        ['group-memberships']: {
+          data: [
+            { id: 1, type: 'group-memberships' },
+            { id: 2, type: 'group-memberships' },
+          ]
+        }
+      }
+    },
+    included: [
+      { id: 1, type: 'organization-memberships',
+        attributes: {},
+        relationships: {
+          user: { data: { id: 1, type: 'users' } },
+          organization: { data: { id: orgId, type: 'organizations' } }
+      }},
+      { id: 1, type: 'group-memberships',
+        attributes: {},
+        relationships: {
+          user: { data: { id: 1, type: 'users' } },
+          group: { data: { id: groupId, type: 'group' } }
+        }
+      },
+      { id: 2, type: 'group-memberships',
+        attributes: {},
+        relationships: {
+          user: { data: { id: 1, type: 'users' } },
+          group: { data: { id: groupId + 2, type: 'group' } }
+        }
+      }
+    ]
+  }, {
+    data: [{ type: 'organizations', id: orgId, attributes: {} }],
+    included: [
+      { id: 1, type: 'organization-memberships',
+        attributes: {},
+        relationships: {
+          user: { data: { id: 1, type: 'users' } },
+          organization: { data: { id: orgId, type: 'organizations' } }
+        }
+      },
+    ]
+  });
+}

--- a/source/SIL.AppBuilder.Portal.Frontend/src/ui/routes/project/index.tsx
+++ b/source/SIL.AppBuilder.Portal.Frontend/src/ui/routes/project/index.tsx
@@ -7,6 +7,7 @@ import { translate, InjectedTranslateProps as i18nProps } from 'react-i18next';
 import { Tab, Dropdown, Icon } from 'semantic-ui-react';
 
 import { TYPE_NAME, ProjectAttributes } from '@data/models/project';
+import { withCurrentUser } from '@data/containers/with-current-user';
 import { withLayout } from '@ui/components/layout';
 
 import Details from './details';
@@ -17,6 +18,7 @@ import Owners from './owners';
 import Reviewers from './reviewers';
 import { withData } from './with-data';
 import { withProjectOperations } from './with-project-operations';
+import { withAccessRestriction } from './with-access-restriction';
 
 
 import './project.scss';
@@ -71,7 +73,9 @@ class Project extends React.Component<IProps> {
 
   toggleArchivedProject = (e) => {
     e.preventDefault();
+
     const { project, toggleArchiveProject } = this.props;
+
     toggleArchiveProject(project);
   }
 
@@ -129,4 +133,6 @@ export default compose(
   translate('translations'),
   withProjectOperations,
   withData,
+  withCurrentUser(),
+  withAccessRestriction
 )(Project);

--- a/source/SIL.AppBuilder.Portal.Frontend/src/ui/routes/project/owners/index.tsx
+++ b/source/SIL.AppBuilder.Portal.Frontend/src/ui/routes/project/owners/index.tsx
@@ -2,7 +2,18 @@ import * as React from 'react';
 
 import { translate, InjectedTranslateProps as i18nProps } from 'react-i18next';
 import { compose } from 'recompose';
+import { withData as withOrbit } from 'react-orbitjs';
+
+import { attributesFor } from '@data';
 import { ProjectAttributes } from '@data/models/project';
+import {
+  withDataActions, IProvidedProps as IDataActionProps
+} from '@data/containers/resources/project/with-data-actions';
+
+import * as toast from '@lib/toast';
+
+
+import GroupSelect from '@ui/components/inputs/group-select';
 
 interface Params {
   project: JSONAPI<ProjectAttributes>;
@@ -10,15 +21,35 @@ interface Params {
 
 type IProps =
   & Params
+  & IDataActionProps
   & i18nProps;
+
+const mapRecordsToProps = (passedProps) => {
+  const { project } = passedProps;
+  const { type, id } = project;
+
+  return {
+    group: q => q.findRelatedRecord({ type, id }, 'group'),
+    organization: q => q.findRelatedRecord({ type, id }, 'organization')
+  };
+};
 
 
 class Owners extends React.Component<IProps> {
+  updateGroup = async (groupId) => {
+    const { updateGroup, t } = this.props;
 
+    try {
+      await updateGroup(groupId);
+    } catch (e) {
+      toast.error(t('errors.generic', { errorMessage: e.message }));
+    }
+  }
   render() {
-
-    const { t, project } = this.props;
-    const { language, type } = project.attributes;
+    const { t, project, group, organization } = this.props;
+    const { language, type } = attributesFor(project);
+    const groupId = group.id;
+    const organizationId = organization.id;
 
     return (
       <div className='owner'>
@@ -41,7 +72,12 @@ class Owners extends React.Component<IProps> {
         </div>
         <div>
           <h4>{t('project.side.projectGroup')}</h4>
-          <div>Central Asia</div>
+
+          <GroupSelect
+            data-test-group-select
+            scopeToCurrentUser={true}
+            selected={groupId}
+            onChange={this.updateGroup} />
         </div>
       </div>
     );
@@ -51,5 +87,7 @@ class Owners extends React.Component<IProps> {
 }
 
 export default compose(
-  translate('translations')
+  translate('translations'),
+  withOrbit(mapRecordsToProps),
+  withDataActions
 )(Owners);

--- a/source/SIL.AppBuilder.Portal.Frontend/src/ui/routes/project/with-access-restriction.tsx
+++ b/source/SIL.AppBuilder.Portal.Frontend/src/ui/routes/project/with-access-restriction.tsx
@@ -1,0 +1,48 @@
+import * as React from 'react';
+import { Redirect } from 'react-router-dom';
+import { compose } from 'recompose';
+import { withData as withOrbit } from 'react-orbitjs';
+
+import * as toast from '@lib/toast';
+import { hasRelationship, relationshipFor } from '@data';
+
+// The current user must:
+// - have at least organization membership that matches the
+//   the organization that the project is assigned to
+export function withAccessRestriction(WrappedComponent) {
+  const mapRecordsToProps = (passedProps) => {
+    const { currentUser, project } = passedProps;
+
+    return {
+      userOrgMemberships: q => q.findRelatedRecords(
+        { type: currentUser.type, id: currentUser.id }, 'organizationMemberships'),
+      projectOrg: q => q.findRelatedRecord(
+        { type: project.type, id: project.id }, 'organization')
+    };
+  };
+
+
+  const DataWrapper = props => {
+    const { t, userOrgMemberships, projectOrg } = props;
+
+    const userOrgIds = userOrgMemberships.filter(om => {
+      const org = relationshipFor(om, 'organization').data || {};
+
+      return org.id === projectOrg.id;
+    });
+
+    const isAMember = userOrgIds.length > 0;
+
+    if (isAMember) {
+      return <WrappedComponent { ...props } />;
+    }
+
+    toast.error(t('errors.notAMemberOfOrg'));
+
+    return <Redirect to={'/'} />;
+  };
+
+  return compose(
+    withOrbit(mapRecordsToProps)
+  )(DataWrapper);
+}

--- a/source/SIL.AppBuilder.Portal.Frontend/src/ui/routes/projects/new/__tests__/acceptance-test.ts
+++ b/source/SIL.AppBuilder.Portal.Frontend/src/ui/routes/projects/new/__tests__/acceptance-test.ts
@@ -109,7 +109,7 @@ describe('Acceptance | New Project', () => {
         beforeEach(() => {
           page.fillLanguage('english');
           page.fillType('SAB');
-          page.chooseGroup('Group 1');
+          page.groupSelect.chooseGroup('Group 1');
         });
 
 
@@ -126,7 +126,7 @@ describe('Acceptance | New Project', () => {
         });
 
         it('has a value', () => {
-          expect(page.selectedGroup).to.equal('Group 1');
+          expect(page.groupSelect.selectedGroup).to.equal('Group 1');
         });
 
         it('has enabled the save button', () => {

--- a/source/SIL.AppBuilder.Portal.Frontend/src/ui/routes/projects/new/__tests__/page.ts
+++ b/source/SIL.AppBuilder.Portal.Frontend/src/ui/routes/projects/new/__tests__/page.ts
@@ -8,6 +8,9 @@ import {
   is
 } from '@bigtest/interactor';
 
+
+import groupInteractor from '@ui/components/inputs/group-select/__tests__/page';
+
 @interactor
 export class CreateProjectInteractor {
   constructor(selector?: string) { }
@@ -21,22 +24,7 @@ export class CreateProjectInteractor {
 
   isVisibilityChecked = isPresent('[data-test-visibility].checked');
 
-
-  selectedGroup = text('.selected');
-  chooseGroup(optionText: string) {
-    return this
-      .when(() => {
-        const el = this
-          .$$('.item')
-          .find(item => item.innerText.includes(optionText));
-
-        if (!el) {
-          throw new Error(`cannot find ".item" with text "${optionText}"`);
-        }
-
-        return el;
-      }).do(el => el.click());
-  }
+  groupSelect = groupInteractor;
 }
 
 export default new CreateProjectInteractor('[data-test-new-project-form]');

--- a/source/SIL.AppBuilder.Portal.Frontend/tests/helpers/mounting.tsx
+++ b/source/SIL.AppBuilder.Portal.Frontend/tests/helpers/mounting.tsx
@@ -12,6 +12,12 @@ import { ReduxProvider } from '@store/index';
 import { DataProvider } from '@data/index';
 
 
+import 'semantic-ui-css/semantic.min.css';
+import 'vendor/legacy-support';
+import '@ui/styles/app.scss';
+import '@ui/../global-config';
+
+
 import i18n from '../../src/translations';
 
 // the same as @ui/application, but allows


### PR DESCRIPTION
Note: this depends on the work done in https://github.com/sillsdev/appbuilder-portal/pull/92 


 - [x] **Available group options for that organization are displayed**
     - Note: this is a subset of groups available to the user
     - Note: groups shown should be (groups the user is in for the project organization) + (the current group the project is in)
 - [x] **If user is only in one group cannot select a different group (but still display what the project's group name)**
 - [x] **A project cannot be in multiple groups**
   - This is a consequence of our data model / design
 - [x] **Project to group assignment by default will be based on the group the app builder belongs to (if multiple, pick the first one)**
   - Note, this is implemented in PR #92
 - [x] Acceptance Tests

I updated some of the test stuff: 
![image](https://user-images.githubusercontent.com/199018/44554978-083fb980-a701-11e8-9d5c-142b4770cb46.png)

![image](https://user-images.githubusercontent.com/199018/44533022-93e62580-a6c2-11e8-8efb-826595c04af2.png)


Blockers / Questions:
 - For "Available group options for organization are displayed?"
   - is this all groups in the org?
   - would someone who isn't in the group the project is assigned to be able to see this list?
   - Note: anyone from a different organization gets redirected, so non issue there
