### PR TITLE
Fix all the JSONAPI types.

### DIFF
--- a/source/SIL.AppBuilder.Portal.Frontend/package.json
+++ b/source/SIL.AppBuilder.Portal.Frontend/package.json
@@ -5,6 +5,7 @@
   "main": "src/index.html",
   "scripts": {
     "ts-node": "./node_modules/.bin/ts-node",
+    "tsc": "./node_modules/.bin/tsc",
     "karma": "./node_modules/.bin/karma",
     "webpack": "./node_modules/.bin/webpack-cli",
     "polly": "./node_modules/.bin/polly",
@@ -19,7 +20,8 @@
     "test:ci": "CI=true yarn karma:start --single-run",
     "lint": "yarn tslint",
     "lint:fix": "yarn lint --fix",
-    "tslint-check": "./node_modules/.bin/tslint-config-prettier-check ./tslint.json"
+    "tslint-check": "./node_modules/.bin/tslint-config-prettier-check ./tslint.json",
+    "typecheck": "yarn tsc --noEmit"
   },
   "dependencies": {
     "@orbit/coordinator": "^0.15.14",
@@ -118,6 +120,7 @@
     "http-proxy-middleware": "^0.18.0",
     "http-shutdown": "^1.2.0",
     "jquery": "^3.3.1",
+    "jsonapi-typescript": "^0.0.9",
     "karma": "^3.0.0",
     "karma-chai": "^0.1.0",
     "karma-chrome-launcher": "^2.2.0",

--- a/source/SIL.AppBuilder.Portal.Frontend/src/data/containers/resources/project/with-data-actions.tsx
+++ b/source/SIL.AppBuilder.Portal.Frontend/src/data/containers/resources/project/with-data-actions.tsx
@@ -3,6 +3,7 @@ import { withData as withOrbit, WithDataProps } from 'react-orbitjs';
 
 import { defaultOptions } from '@data';
 import { ProjectAttributes } from '@data/models/project';
+import { ResourceObject } from 'jsonapi-typescript';
 
 
 export interface IProvidedProps {
@@ -12,7 +13,7 @@ export interface IProvidedProps {
 }
 
 interface IOwnProps {
-  project: JSONAPI<ProjectAttributes>;
+  project: ResourceObject<'projects', ProjectAttributes>;
 }
 
 type IProps =

--- a/source/SIL.AppBuilder.Portal.Frontend/src/data/containers/resources/project/with-data-actions.tsx
+++ b/source/SIL.AppBuilder.Portal.Frontend/src/data/containers/resources/project/with-data-actions.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import { withData as withOrbit, WithDataProps } from 'react-orbitjs';
 
-import { defaultOptions } from '@data';
+import { defaultOptions, PROJECTS_TYPE } from '@data';
 import { ProjectAttributes } from '@data/models/project';
 import { ResourceObject } from 'jsonapi-typescript';
 
@@ -13,7 +13,7 @@ export interface IProvidedProps {
 }
 
 interface IOwnProps {
-  project: ResourceObject<'projects', ProjectAttributes>;
+  project: ResourceObject<PROJECTS_TYPE, ProjectAttributes>;
 }
 
 type IProps =

--- a/source/SIL.AppBuilder.Portal.Frontend/src/data/containers/with-current-organization.tsx
+++ b/source/SIL.AppBuilder.Portal.Frontend/src/data/containers/with-current-organization.tsx
@@ -5,20 +5,20 @@ import { compose } from 'recompose';
 
 import { OrganizationAttributes, TYPE_NAME } from '../models/organization';
 import { isEmpty } from '@lib/collection';
-import { defaultSourceOptions } from '@data';
+import { defaultSourceOptions, ORGANIZATIONS_TYPE } from '@data';
 
 import PageLoader from '@ui/components/loaders/page';
 import PageError from '@ui/components/errors/page';
 import { ResourceObject } from 'jsonapi-typescript';
 
 interface IState {
-  fromNetwork?: ResourceObject<'organizations', OrganizationAttributes>;
+  fromNetwork?: ResourceObject<ORGANIZATIONS_TYPE, OrganizationAttributes>;
   error?: any;
 }
 
 export interface IProvidedProps {
   currentOrganizationId: string | number;
-  organization: ResourceObject<'organizations', OrganizationAttributes>;
+  organization: ResourceObject<ORGANIZATIONS_TYPE, OrganizationAttributes>;
 }
 
 export function withCurrentOrganization(InnerComponent) {

--- a/source/SIL.AppBuilder.Portal.Frontend/src/data/containers/with-current-organization.tsx
+++ b/source/SIL.AppBuilder.Portal.Frontend/src/data/containers/with-current-organization.tsx
@@ -9,15 +9,16 @@ import { defaultSourceOptions } from '@data';
 
 import PageLoader from '@ui/components/loaders/page';
 import PageError from '@ui/components/errors/page';
+import { ResourceObject } from 'jsonapi-typescript';
 
 interface IState {
-  fromNetwork?: JSONAPI<OrganizationAttributes>;
+  fromNetwork?: ResourceObject<'organizations', OrganizationAttributes>;
   error?: any;
 }
 
 export interface IProvidedProps {
   currentOrganizationId: string | number;
-  organization: JSONAPI<OrganizationAttributes>;
+  organization: ResourceObject<'organizations', OrganizationAttributes>;
 }
 
 export function withCurrentOrganization(InnerComponent) {

--- a/source/SIL.AppBuilder.Portal.Frontend/src/data/containers/with-current-user.tsx
+++ b/source/SIL.AppBuilder.Portal.Frontend/src/data/containers/with-current-user.tsx
@@ -4,7 +4,7 @@ import { withData, WithDataProps } from 'react-orbitjs';
 import { compose } from 'recompose';
 import { SingleResourceDoc } from 'jsonapi-typescript';
 
-import { defaultSourceOptions, pushPayload } from '@data';
+import { defaultSourceOptions, pushPayload, USERS_TYPE } from '@data';
 import { UserAttributes, TYPE_NAME } from '@data/models/user';
 
 import { getAuth0Id } from '@lib/auth0';
@@ -20,7 +20,7 @@ import { withTranslations, i18nProps } from '@lib/i18n';
 
 import * as toast from '@lib/toast';
 
-type UserPayload = SingleResourceDoc<'users', UserAttributes>;
+type UserPayload = SingleResourceDoc<USERS_TYPE, UserAttributes>;
 
 const mapRecordsToProps = () => {
   const auth0Id = getAuth0Id();

--- a/source/SIL.AppBuilder.Portal.Frontend/src/data/containers/with-current-user.tsx
+++ b/source/SIL.AppBuilder.Portal.Frontend/src/data/containers/with-current-user.tsx
@@ -2,6 +2,7 @@ import * as React from 'react';
 import { Redirect } from 'react-router-dom';
 import { withData, WithDataProps } from 'react-orbitjs';
 import { compose } from 'recompose';
+import { SingleResourceDoc } from 'jsonapi-typescript';
 
 import { defaultSourceOptions, pushPayload } from '@data';
 import { UserAttributes, TYPE_NAME } from '@data/models/user';
@@ -19,7 +20,7 @@ import { withTranslations, i18nProps } from '@lib/i18n';
 
 import * as toast from '@lib/toast';
 
-type UserPayload = JSONAPIDocument<UserAttributes>;
+type UserPayload = SingleResourceDoc<'users', UserAttributes>;
 
 const mapRecordsToProps = () => {
   const auth0Id = getAuth0Id();

--- a/source/SIL.AppBuilder.Portal.Frontend/src/data/helpers.ts
+++ b/source/SIL.AppBuilder.Portal.Frontend/src/data/helpers.ts
@@ -1,12 +1,22 @@
-type IJsonApiPayload<T> =
-  | JSONAPIDocument<T>
-  | JSONAPI<T>;
+import { SingleResourceDoc, AttributesObject, ResourceObject, RelationshipsObject, RelationshipsWithData, ErrorObject, ResourceLinkage } from "jsonapi-typescript";
 
-export function attributesFor<T>(payload: IJsonApiPayload<T>): T | object {
-  if (!payload) { return {}; }
-  if (payload.data) { return attributesFor(payload.data); }
+type IJsonApiPayload<TType extends string, TAttrs extends AttributesObject> =
+  | SingleResourceDoc<TType, TAttrs>
+  | ResourceObject<TType, TAttrs>;
 
-  return payload.attributes || {};
+export function attributesFor<
+  TType extends string, 
+  TAttrs extends AttributesObject
+  >(payload: IJsonApiPayload<TType, TAttrs>): TAttrs {
+
+  if (!payload) { return ({} as TAttrs); }
+
+  const data = (payload as SingleResourceDoc<TType, TAttrs>).data;
+  if (data) { return attributesFor(data); }
+
+  const attributes = (payload as ResourceObject<TType, TAttrs>).attributes;
+  
+  return (attributes || {}) as TAttrs;
 }
 
 export function idFor(payload: any): string {
@@ -15,41 +25,47 @@ export function idFor(payload: any): string {
   return payload.id;
 }
 
-export function relationshipsFor(payload: IJsonApiPayload<T>): T | object {
+export function relationshipsFor<
+  TType extends string, 
+  TAttrs extends AttributesObject
+  >(payload: IJsonApiPayload<TType, TAttrs>): RelationshipsObject {
   if (!payload) { return {}; }
-  if (payload.data) { return relationshipsFor(payload.data); }
 
-  return payload.relationships || {};
+  const data = (payload as SingleResourceDoc<TType, TAttrs>).data;
+  if (data) { return relationshipsFor(data); }
+
+
+  const relationships = (payload as ResourceObject<TType, TAttrs>).relationships;
+
+  return relationships || {};
 }
 
 export function hasRelationship(payload, name: string): boolean {
-  const relationships = relationshipsFor(payload);
-  const filtered = relationships[name] || {};
-  const data = filtered.data || [];
+  const filtered = relationshipFor(payload, name);
+  const data = (filtered.data || []) as Array<any>;
 
   return data.length > 0;
 }
 
-export function relationshipFor(payload: any, relationshipName: string) {
+export function relationshipFor(payload: any, relationshipName: string): RelationshipsWithData {
   const relationships = relationshipsFor(payload);
   const relation = relationships[relationshipName] || {};
 
-  return relation;
+  return relation as RelationshipsWithData;
 }
 
-export function isRelatedTo(payload: any, relationshipName: string, id: string) {
-  const relationships = relationshipsFor(payload);
-  const relation = relationships[relationshipName] || {};
-  const relationData = relation.data || {} as object | object[];
+export function isRelatedTo(payload: any, relationshipName: string, id: string): boolean {
+  const relation = relationshipFor(payload, relationshipName);
+  const relationData = relation.data || {} as ResourceLinkage;
 
   if (Array.isArray(relationData)) {
-    return relationData.find(r => r.id === id);
+    return !!relationData.find(r => r.id === id);
   }
 
   return relationData.id === id;
 }
 
-export function firstError(json) {
+export function firstError(json): ErrorObject {
   if (!json || !json.errors) { return {}; }
 
   const errors = json.errors || [];

--- a/source/SIL.AppBuilder.Portal.Frontend/src/data/helpers.ts
+++ b/source/SIL.AppBuilder.Portal.Frontend/src/data/helpers.ts
@@ -5,7 +5,7 @@ type IJsonApiPayload<TType extends string, TAttrs extends AttributesObject> =
   | ResourceObject<TType, TAttrs>;
 
 export function attributesFor<
-  TType extends string, 
+  TType extends string,
   TAttrs extends AttributesObject
   >(payload: IJsonApiPayload<TType, TAttrs>): TAttrs {
 
@@ -15,7 +15,7 @@ export function attributesFor<
   if (data) { return attributesFor(data); }
 
   const attributes = (payload as ResourceObject<TType, TAttrs>).attributes;
-  
+
   return (attributes || {}) as TAttrs;
 }
 
@@ -26,7 +26,7 @@ export function idFor(payload: any): string {
 }
 
 export function relationshipsFor<
-  TType extends string, 
+  TType extends string,
   TAttrs extends AttributesObject
   >(payload: IJsonApiPayload<TType, TAttrs>): RelationshipsObject {
   if (!payload) { return {}; }
@@ -42,7 +42,7 @@ export function relationshipsFor<
 
 export function hasRelationship(payload, name: string): boolean {
   const filtered = relationshipFor(payload, name);
-  const data = (filtered.data || []) as Array<any>;
+  const data = (filtered.data || []) as any[];
 
   return data.length > 0;
 }

--- a/source/SIL.AppBuilder.Portal.Frontend/src/data/index.ts
+++ b/source/SIL.AppBuilder.Portal.Frontend/src/data/index.ts
@@ -21,3 +21,14 @@ export async function pushPayload(updateStore, payload) {
     q => resources.map(
       resource => q.addRecord(resource)), { skipRemote: true });
 }
+
+
+
+export type ORGANIZATIONS_TYPE = 'organizations';
+export type GROUPS_TYPE = 'groups';
+export type PROJECTS_TYPE = 'projects';
+export type USERS_TYPE = 'users';
+export type PRODUCTS_TYPE = 'products';
+export type TASKS_TYPE = 'tasks';
+export type ORGANIZATION_MEMBERSHIPS_TYPE = 'organization-memberships';
+export type GROUP_MEMBERSHIPS_TYPES = 'group-memberships';

--- a/source/SIL.AppBuilder.Portal.Frontend/src/data/index.ts
+++ b/source/SIL.AppBuilder.Portal.Frontend/src/data/index.ts
@@ -31,4 +31,5 @@ export type USERS_TYPE = 'users';
 export type PRODUCTS_TYPE = 'products';
 export type TASKS_TYPE = 'tasks';
 export type ORGANIZATION_MEMBERSHIPS_TYPE = 'organization-memberships';
-export type GROUP_MEMBERSHIPS_TYPES = 'group-memberships';
+export type GROUP_MEMBERSHIPS_TYPE = 'group-memberships';
+export type NOTIFICATIONS_TYPE = 'notifications';

--- a/source/SIL.AppBuilder.Portal.Frontend/src/data/models/group-membership.ts
+++ b/source/SIL.AppBuilder.Portal.Frontend/src/data/models/group-membership.ts
@@ -1,5 +1,7 @@
+import { AttributesObject } from "jsonapi-typescript";
+
 export const TYPE_NAME = 'group-membership';
 export const PLURAL_NAME = 'group-memberships';
 
-export interface GroupMembershipAttributes {
+export interface GroupMembershipAttributes extends AttributesObject {
 }

--- a/source/SIL.AppBuilder.Portal.Frontend/src/data/models/group.ts
+++ b/source/SIL.AppBuilder.Portal.Frontend/src/data/models/group.ts
@@ -1,7 +1,9 @@
+import { AttributesObject } from "jsonapi-typescript";
+
 export const TYPE_NAME = 'group';
 export const PLURAL_NAME = 'groups';
 
-export interface GroupAttributes {
+export interface GroupAttributes extends AttributesObject {
   name: string;
   abbreviation: string;
 }

--- a/source/SIL.AppBuilder.Portal.Frontend/src/data/models/notification.ts
+++ b/source/SIL.AppBuilder.Portal.Frontend/src/data/models/notification.ts
@@ -1,6 +1,8 @@
+import { AttributesObject } from "jsonapi-typescript";
+
 export const TYPE_NAME = 'notification';
 
-export interface NotificationAttributes {
+export interface NotificationAttributes extends AttributesObject {
   title: string;
   description: string;
   time: Date;

--- a/source/SIL.AppBuilder.Portal.Frontend/src/data/models/organization-invite.ts
+++ b/source/SIL.AppBuilder.Portal.Frontend/src/data/models/organization-invite.ts
@@ -1,13 +1,15 @@
+import { AttributesObject } from "jsonapi-typescript";
+
 export const TYPE_NAME = 'organizationInvite';
 
-export interface OrganizationInviteAttributes {
+export interface OrganizationInviteAttributes extends AttributesObject {
   name?: string;
   ownerEmail?: string;
   url?: string;
   expiresAt?: Date;
 }
 
-export interface RequestAccessForOrganizationAttributes {
+export interface RequestAccessForOrganizationAttributes extends AttributesObject {
   name: string;
   orgAdminEmail: string;
   websiteUrl: string;

--- a/source/SIL.AppBuilder.Portal.Frontend/src/data/models/organization-membership.ts
+++ b/source/SIL.AppBuilder.Portal.Frontend/src/data/models/organization-membership.ts
@@ -1,5 +1,7 @@
+import { AttributesObject } from "jsonapi-typescript";
+
 export const TYPE_NAME = 'organization-membership';
 export const PLURAL_NAME = 'organization-memberships';
 
-export interface OrganizationMembershipAttributes {
+export interface OrganizationMembershipAttributes extends AttributesObject {
 }

--- a/source/SIL.AppBuilder.Portal.Frontend/src/data/models/organization.ts
+++ b/source/SIL.AppBuilder.Portal.Frontend/src/data/models/organization.ts
@@ -1,6 +1,8 @@
+import { AttributesObject } from "jsonapi-typescript";
+
 export const TYPE_NAME = 'organization';
 
-export interface OrganizationAttributes {
+export interface OrganizationAttributes extends AttributesObject {
   // from an invite
   token?: string;
 

--- a/source/SIL.AppBuilder.Portal.Frontend/src/data/models/product.ts
+++ b/source/SIL.AppBuilder.Portal.Frontend/src/data/models/product.ts
@@ -1,6 +1,11 @@
+import { AttributesObject } from "jsonapi-typescript";
+
 export const TYPE_NAME = 'product';
 export const PLURAL_NAME = 'products';
 
-export interface ProductAttributes {
+export interface ProductAttributes extends AttributesObject {
   name: string;
+  // type?
+  // TODO: figure out better mapping for this
+  //       we'll know for certain as we actually start to work with products
 }

--- a/source/SIL.AppBuilder.Portal.Frontend/src/data/models/project.ts
+++ b/source/SIL.AppBuilder.Portal.Frontend/src/data/models/project.ts
@@ -1,6 +1,9 @@
-export const TYPE_NAME = 'project';
+import { AttributesObject } from "jsonapi-typescript";
 
-export interface ProjectAttributes {
+export const TYPE_NAME = 'project';
+export const PLURAL_NAME = 'projects';
+
+export interface ProjectAttributes extends AttributesObject {
   name: string;
   status: string;
   dateCreated: Date;

--- a/source/SIL.AppBuilder.Portal.Frontend/src/data/models/role.ts
+++ b/source/SIL.AppBuilder.Portal.Frontend/src/data/models/role.ts
@@ -1,5 +1,7 @@
+import { AttributesObject } from "jsonapi-typescript";
+
 export const TYPE_NAME = 'role';
 
-export interface RoleAttributes {
+export interface RoleAttributes extends AttributesObject {
   name: string;
 }

--- a/source/SIL.AppBuilder.Portal.Frontend/src/data/models/task.ts
+++ b/source/SIL.AppBuilder.Portal.Frontend/src/data/models/task.ts
@@ -1,6 +1,8 @@
+import { AttributesObject } from "jsonapi-typescript";
+
 export const TYPE_NAME = 'task';
 
-export interface TaskAttributes {
+export interface TaskAttributes extends AttributesObject {
   status: string;
   waitTime: number;
 }

--- a/source/SIL.AppBuilder.Portal.Frontend/src/data/models/user.ts
+++ b/source/SIL.AppBuilder.Portal.Frontend/src/data/models/user.ts
@@ -1,7 +1,9 @@
+import { AttributesObject } from 'jsonapi-typescript';
+
 export const TYPE_NAME = 'user';
 export const PLURAL_NAME = 'users';
 
-export interface UserAttributes {
+export interface UserAttributes extends AttributesObject {
   givenName?: string;
   familyName?: string;
   name?: string;

--- a/source/SIL.AppBuilder.Portal.Frontend/src/ui/components/header/notifications/data.tsx
+++ b/source/SIL.AppBuilder.Portal.Frontend/src/ui/components/header/notifications/data.tsx
@@ -2,7 +2,7 @@ import * as React from 'react';
 import { compose } from 'recompose';
 import { withData as withOrbit, WithDataProps } from 'react-orbitjs';
 import { TYPE_NAME as NOTIFICATION, NotificationAttributes } from '@data/models/notification';
-import { query, defaultOptions } from '@data';
+import { query, defaultOptions, NOTIFICATIONS_TYPE } from '@data';
 import { withStubbedDevData } from '@data/with-stubbed-dev-data';
 import { ResourceObject } from 'jsonapi-typescript';
 
@@ -20,7 +20,7 @@ const mapRecordsToProps = (passedProps) => {
 };
 
 export interface DataProps {
-  notifications: Array<ResourceObject<'notifications', NotificationAttributes>>;
+  notifications: Array<ResourceObject<NOTIFICATIONS_TYPE, NotificationAttributes>>;
   haveAllNotificationsBeenSeen: boolean;
   isThereAtLeastOneNotificationToShow: boolean;
 }
@@ -29,7 +29,7 @@ export interface ActionProps {
   markNotificationsToSeen: () => void;
   clearAll: () => void;
   clearOne: (id: string) => void;
-  markNotificationToSeen: (notification: ResourceObject<'notifications', NotificationAttributes>) => void;
+  markNotificationToSeen: (notification: ResourceObject<NOTIFICATIONS_TYPE, NotificationAttributes>) => void;
 }
 
 export function withData(WrappedComponent) {

--- a/source/SIL.AppBuilder.Portal.Frontend/src/ui/components/header/notifications/data.tsx
+++ b/source/SIL.AppBuilder.Portal.Frontend/src/ui/components/header/notifications/data.tsx
@@ -4,6 +4,7 @@ import { withData as withOrbit, WithDataProps } from 'react-orbitjs';
 import { TYPE_NAME as NOTIFICATION, NotificationAttributes } from '@data/models/notification';
 import { query, defaultOptions } from '@data';
 import { withStubbedDevData } from '@data/with-stubbed-dev-data';
+import { ResourceObject } from 'jsonapi-typescript';
 
 // TODO: Use this map when API is ready
 // const mapNetworkToProps = (passedProps) => {
@@ -19,7 +20,7 @@ const mapRecordsToProps = (passedProps) => {
 };
 
 export interface DataProps {
-  notifications: Array<JSONAPI<NotificationAttributes>>;
+  notifications: Array<ResourceObject<'notifications', NotificationAttributes>>;
   haveAllNotificationsBeenSeen: boolean;
   isThereAtLeastOneNotificationToShow: boolean;
 }
@@ -28,7 +29,7 @@ export interface ActionProps {
   markNotificationsToSeen: () => void;
   clearAll: () => void;
   clearOne: (id: string) => void;
-  markNotificationToSeen: (notification: JSONAPI<NotificationAttributes>) => void;
+  markNotificationToSeen: (notification: ResourceObject<'notifications', NotificationAttributes>) => void;
 }
 
 export function withData(WrappedComponent) {

--- a/source/SIL.AppBuilder.Portal.Frontend/src/ui/components/header/user-dropdown.tsx
+++ b/source/SIL.AppBuilder.Portal.Frontend/src/ui/components/header/user-dropdown.tsx
@@ -12,10 +12,11 @@ import { withCurrentUser } from '@data/containers/with-current-user';
 import { deleteToken, getPictureUrl } from '@lib/auth0';
 import './header.scss';
 import { ResourceObject } from 'jsonapi-typescript';
+import { USERS_TYPE } from '@data';
 
 interface IOwnProps {
   toggleSidebar: () => void;
-  currentUser: ResourceObject<'users', UserAttributes>;
+  currentUser: ResourceObject<USERS_TYPE, UserAttributes>;
 }
 
 export type IProps =

--- a/source/SIL.AppBuilder.Portal.Frontend/src/ui/components/header/user-dropdown.tsx
+++ b/source/SIL.AppBuilder.Portal.Frontend/src/ui/components/header/user-dropdown.tsx
@@ -11,10 +11,11 @@ import { withCurrentUser } from '@data/containers/with-current-user';
 
 import { deleteToken, getPictureUrl } from '@lib/auth0';
 import './header.scss';
+import { ResourceObject } from 'jsonapi-typescript';
 
 interface IOwnProps {
   toggleSidebar: () => void;
-  currentUser: JSONAPI<UserAttributes>;
+  currentUser: ResourceObject<'users', UserAttributes>;
 }
 
 export type IProps =

--- a/source/SIL.AppBuilder.Portal.Frontend/src/ui/components/inputs/group-select/with-data.tsx
+++ b/source/SIL.AppBuilder.Portal.Frontend/src/ui/components/inputs/group-select/with-data.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { compose } from 'recompose';
-import { query, defaultOptions } from '@data';
+import { query, defaultOptions, GROUPS_TYPE, GROUP_MEMBERSHIPS_TYPE, USERS_TYPE } from '@data';
 import { withData as withOrbit, WithDataProps } from 'react-orbitjs';
 
 import { relationshipFor } from '@data';
@@ -12,16 +12,16 @@ import { PageLoader as Loader } from '@ui/components/loaders';
 import { ResourceObject } from 'jsonapi-typescript';
 
 export interface IProvidedProps {
-  groups: ResourceObject<'groups', GroupAttributes>[];
+  groups: ResourceObject<GROUPS_TYPE, GroupAttributes>[];
   disableSelection: true;
 }
 
 interface IOwnProps {
-  groups: ResourceObject<'groups', GroupAttributes>[];
-  groupMembershipsFromCache: ResourceObject<'group-memberships', GroupMembershipAttributes>[];
-  currentUserGroupMemberships: ResourceObject<'group-memberships', GroupMembershipAttributes>[];
+  groups: ResourceObject<GROUPS_TYPE, GroupAttributes>[];
+  groupMembershipsFromCache: ResourceObject<GROUP_MEMBERSHIPS_TYPE, GroupMembershipAttributes>[];
+  currentUserGroupMemberships: ResourceObject<GROUP_MEMBERSHIPS_TYPE, GroupMembershipAttributes>[];
   scopeToCurrentUser: boolean;
-  currentUser: ResourceObject<'users', UserAttributes>;
+  currentUser: ResourceObject<USERS_TYPE, UserAttributes>;
   selected: Id;
 }
 
@@ -61,7 +61,7 @@ export function withData(WrappedComponent) {
         return <Loader />;
       }
 
-      let availableGroups: ResourceObject<'groups', GroupAttributes>[];
+      let availableGroups: ResourceObject<GROUPS_TYPE, GroupAttributes>[];
 
       const groupIds = groupMembershipsFromCache
         .filter(gm => gm)

--- a/source/SIL.AppBuilder.Portal.Frontend/src/ui/components/inputs/group-select/with-data.tsx
+++ b/source/SIL.AppBuilder.Portal.Frontend/src/ui/components/inputs/group-select/with-data.tsx
@@ -3,25 +3,25 @@ import { compose } from 'recompose';
 import { query, defaultOptions } from '@data';
 import { withData as withOrbit, WithDataProps } from 'react-orbitjs';
 
-import { isRelatedTo, relationshipsFor, relationshipFor } from '@data';
-import { withRelationship } from '@data/containers/with-relationship';
+import { relationshipFor } from '@data';
 import { TYPE_NAME as GROUP, GroupAttributes } from '@data/models/group';
-import { TYPE_NAME as GROUP_MEMBERSHIP } from '@data/models/group-membership';
+import { GroupMembershipAttributes } from '@data/models/group-membership';
 import { UserAttributes } from '@data/models/user';
 
 import { PageLoader as Loader } from '@ui/components/loaders';
+import { ResourceObject } from 'jsonapi-typescript';
 
 export interface IProvidedProps {
-  groups: Array<JSONAPI<GroupAttributes>>;
+  groups: ResourceObject<'groups', GroupAttributes>[];
   disableSelection: true;
 }
 
 interface IOwnProps {
-  groups: Array<JSONAPI<GroupAttributes>>;
-  groupMembershipsFromCache: Array<JSONAPI<{}>>;
-  currentUserGroupMemberships: Array<JSONAPI<{}>>;
+  groups: ResourceObject<'groups', GroupAttributes>[];
+  groupMembershipsFromCache: ResourceObject<'group-memberships', GroupMembershipAttributes>[];
+  currentUserGroupMemberships: ResourceObject<'group-memberships', GroupMembershipAttributes>[];
   scopeToCurrentUser: boolean;
-  currentUser: JSONAPI<UserAttributes>;
+  currentUser: ResourceObject<'users', UserAttributes>;
   selected: Id;
 }
 
@@ -30,7 +30,7 @@ type IProps =
   & WithDataProps;
 
 export function withData(WrappedComponent) {
-  const mapNetworkToProps = (passedProps) => {
+  const mapNetworkToProps = () => {
     return {
       groups: [q => q.findRecords(GROUP), defaultOptions()]
     };
@@ -61,7 +61,7 @@ export function withData(WrappedComponent) {
         return <Loader />;
       }
 
-      let availableGroups: Array<JSONAPI<{}>>;
+      let availableGroups: ResourceObject<'groups', GroupAttributes>[];
 
       const groupIds = groupMembershipsFromCache
         .filter(gm => gm)

--- a/source/SIL.AppBuilder.Portal.Frontend/src/ui/components/inputs/group-select/with-data.tsx
+++ b/source/SIL.AppBuilder.Portal.Frontend/src/ui/components/inputs/group-select/with-data.tsx
@@ -12,14 +12,14 @@ import { PageLoader as Loader } from '@ui/components/loaders';
 import { ResourceObject } from 'jsonapi-typescript';
 
 export interface IProvidedProps {
-  groups: ResourceObject<GROUPS_TYPE, GroupAttributes>[];
+  groups: Array<ResourceObject<GROUPS_TYPE, GroupAttributes>>;
   disableSelection: true;
 }
 
 interface IOwnProps {
-  groups: ResourceObject<GROUPS_TYPE, GroupAttributes>[];
-  groupMembershipsFromCache: ResourceObject<GROUP_MEMBERSHIPS_TYPE, GroupMembershipAttributes>[];
-  currentUserGroupMemberships: ResourceObject<GROUP_MEMBERSHIPS_TYPE, GroupMembershipAttributes>[];
+  groups: Array<ResourceObject<GROUPS_TYPE, GroupAttributes>>;
+  groupMembershipsFromCache: Array<ResourceObject<GROUP_MEMBERSHIPS_TYPE, GroupMembershipAttributes>>;
+  currentUserGroupMemberships: Array<ResourceObject<GROUP_MEMBERSHIPS_TYPE, GroupMembershipAttributes>>;
   scopeToCurrentUser: boolean;
   currentUser: ResourceObject<USERS_TYPE, UserAttributes>;
   selected: Id;
@@ -61,7 +61,7 @@ export function withData(WrappedComponent) {
         return <Loader />;
       }
 
-      let availableGroups: ResourceObject<GROUPS_TYPE, GroupAttributes>[];
+      let availableGroups: Array<ResourceObject<GROUPS_TYPE, GroupAttributes>>;
 
       const groupIds = groupMembershipsFromCache
         .filter(gm => gm)

--- a/source/SIL.AppBuilder.Portal.Frontend/src/ui/components/inputs/locale-select/index.tsx
+++ b/source/SIL.AppBuilder.Portal.Frontend/src/ui/components/inputs/locale-select/index.tsx
@@ -9,9 +9,10 @@ import { UserAttributes } from "@data/models/user";
 import { TYPE_NAME as USER } from "@data/models/user";
 import { attributesFor } from "@data/helpers";
 import { ResourceObject } from "jsonapi-typescript";
+import { USERS_TYPE } from "@data";
 
 export interface IOwnProps {
-  currentUser: ResourceObject<'users', UserAttributes>;
+  currentUser: ResourceObject<USERS_TYPE, UserAttributes>;
   onChange: (locale: string) => void;
   className?: string;
 }

--- a/source/SIL.AppBuilder.Portal.Frontend/src/ui/components/inputs/locale-select/index.tsx
+++ b/source/SIL.AppBuilder.Portal.Frontend/src/ui/components/inputs/locale-select/index.tsx
@@ -8,9 +8,10 @@ import { withCurrentUser } from "@data/containers/with-current-user";
 import { UserAttributes } from "@data/models/user";
 import { TYPE_NAME as USER } from "@data/models/user";
 import { attributesFor } from "@data/helpers";
+import { ResourceObject } from "jsonapi-typescript";
 
 export interface IOwnProps {
-  currentUser: JSONAPI<UserAttributes>;
+  currentUser: ResourceObject<'users', UserAttributes>;
   onChange: (locale: string) => void;
   className?: string;
 }

--- a/source/SIL.AppBuilder.Portal.Frontend/src/ui/components/inputs/user-select/with-data.tsx
+++ b/source/SIL.AppBuilder.Portal.Frontend/src/ui/components/inputs/user-select/with-data.tsx
@@ -1,25 +1,26 @@
 import * as React from 'react';
 import { compose } from 'recompose';
 import { withData as withOrbit, WithDataProps } from 'react-orbitjs';
+import { ResourceObject } from 'jsonapi-typescript';
 
 import { query, defaultSourceOptions, relationshipFor } from '@data';
 import { TYPE_NAME as USER, UserAttributes } from '@data/models/user';
-import { TYPE_NAME as GROUP_MEMBERSHIPS } from '@data/models/group-membership';
+import { TYPE_NAME as GROUP_MEMBERSHIPS, GroupMembershipAttributes } from '@data/models/group-membership';
 import { withCurrentUser } from '@data/containers/with-current-user';
 
 import { PageLoader as Loader } from '@ui/components/loaders';
 
 export interface IProvidedProps {
-  users: Array<JSONAPI<UserAttributes>>;
+  users: ResourceObject<'users', UserAttributes>[];
   disableSelection: true;
 }
 
 interface IOwnProps {
-  users: Array<JSONAPI<UserAttributes>>;
-  groupMemberships: Array<JSONAPI<{}>>;
-  currentUsersGroupMemberships: Array<JSONAPI<{}>>;
-  usersFromCache: Array<JSONAPI<{}>>;
-  currentUser: JSONAPI<UserAttributes>;
+  users: ResourceObject<'users', UserAttributes>[];
+  groupMemberships: ResourceObject<'group-memberships', GroupMembershipAttributes>[];
+  currentUsersGroupMemberships: ResourceObject<'group-memberships', GroupMembershipAttributes>[];
+  usersFromCache: ResourceObject<'users', UserAttributes>[];
+  currentUser: ResourceObject<'users', UserAttributes>;
   selected: Id;
   groupId: Id;
   restrictToGroup: boolean;

--- a/source/SIL.AppBuilder.Portal.Frontend/src/ui/components/inputs/user-select/with-data.tsx
+++ b/source/SIL.AppBuilder.Portal.Frontend/src/ui/components/inputs/user-select/with-data.tsx
@@ -11,15 +11,15 @@ import { withCurrentUser } from '@data/containers/with-current-user';
 import { PageLoader as Loader } from '@ui/components/loaders';
 
 export interface IProvidedProps {
-  users: ResourceObject<USERS_TYPE, UserAttributes>[];
+  users: Array<ResourceObject<USERS_TYPE, UserAttributes>>;
   disableSelection: true;
 }
 
 interface IOwnProps {
-  users: ResourceObject<USERS_TYPE, UserAttributes>[];
-  groupMemberships: ResourceObject<GROUP_MEMBERSHIPS_TYPE, GroupMembershipAttributes>[];
-  currentUsersGroupMemberships: ResourceObject<GROUP_MEMBERSHIPS_TYPE, GroupMembershipAttributes>[];
-  usersFromCache: ResourceObject<USERS_TYPE, UserAttributes>[];
+  users: Array<ResourceObject<USERS_TYPE, UserAttributes>>;
+  groupMemberships: Array<ResourceObject<GROUP_MEMBERSHIPS_TYPE, GroupMembershipAttributes>>;
+  currentUsersGroupMemberships: Array<ResourceObject<GROUP_MEMBERSHIPS_TYPE, GroupMembershipAttributes>>;
+  usersFromCache: Array<ResourceObject<USERS_TYPE, UserAttributes>>;
   currentUser: ResourceObject<USERS_TYPE, UserAttributes>;
   selected: Id;
   groupId: Id;

--- a/source/SIL.AppBuilder.Portal.Frontend/src/ui/components/inputs/user-select/with-data.tsx
+++ b/source/SIL.AppBuilder.Portal.Frontend/src/ui/components/inputs/user-select/with-data.tsx
@@ -3,7 +3,7 @@ import { compose } from 'recompose';
 import { withData as withOrbit, WithDataProps } from 'react-orbitjs';
 import { ResourceObject } from 'jsonapi-typescript';
 
-import { query, defaultSourceOptions, relationshipFor } from '@data';
+import { query, defaultSourceOptions, relationshipFor, USERS_TYPE, GROUP_MEMBERSHIPS_TYPE } from '@data';
 import { TYPE_NAME as USER, UserAttributes } from '@data/models/user';
 import { TYPE_NAME as GROUP_MEMBERSHIPS, GroupMembershipAttributes } from '@data/models/group-membership';
 import { withCurrentUser } from '@data/containers/with-current-user';
@@ -11,16 +11,16 @@ import { withCurrentUser } from '@data/containers/with-current-user';
 import { PageLoader as Loader } from '@ui/components/loaders';
 
 export interface IProvidedProps {
-  users: ResourceObject<'users', UserAttributes>[];
+  users: ResourceObject<USERS_TYPE, UserAttributes>[];
   disableSelection: true;
 }
 
 interface IOwnProps {
-  users: ResourceObject<'users', UserAttributes>[];
-  groupMemberships: ResourceObject<'group-memberships', GroupMembershipAttributes>[];
-  currentUsersGroupMemberships: ResourceObject<'group-memberships', GroupMembershipAttributes>[];
-  usersFromCache: ResourceObject<'users', UserAttributes>[];
-  currentUser: ResourceObject<'users', UserAttributes>;
+  users: ResourceObject<USERS_TYPE, UserAttributes>[];
+  groupMemberships: ResourceObject<GROUP_MEMBERSHIPS_TYPE, GroupMembershipAttributes>[];
+  currentUsersGroupMemberships: ResourceObject<GROUP_MEMBERSHIPS_TYPE, GroupMembershipAttributes>[];
+  usersFromCache: ResourceObject<USERS_TYPE, UserAttributes>[];
+  currentUser: ResourceObject<USERS_TYPE, UserAttributes>;
   selected: Id;
   groupId: Id;
   restrictToGroup: boolean;

--- a/source/SIL.AppBuilder.Portal.Frontend/src/ui/components/product-icon/index.tsx
+++ b/source/SIL.AppBuilder.Portal.Frontend/src/ui/components/product-icon/index.tsx
@@ -1,5 +1,7 @@
 import * as React from 'react';
 import { Icon } from 'semantic-ui-react';
+import { ResourceObject } from 'jsonapi-typescript';
+import { ProductAttributes } from '@data/models/product';
 
 const iconMap = {
   android: 'android',
@@ -7,12 +9,7 @@ const iconMap = {
 };
 
 export interface IProps {
-  product: JSONAPI<{
-    name: string;
-    // type?
-    // TODO: figure out better mapping for this
-    //       we'll know for certain as we actually start to work with products
-  }>;
+  product: ResourceObject<'products', ProductAttributes>;
 }
 
 export default class ProductIcon extends React.Component<IProps> {

--- a/source/SIL.AppBuilder.Portal.Frontend/src/ui/components/product-icon/index.tsx
+++ b/source/SIL.AppBuilder.Portal.Frontend/src/ui/components/product-icon/index.tsx
@@ -2,6 +2,7 @@ import * as React from 'react';
 import { Icon } from 'semantic-ui-react';
 import { ResourceObject } from 'jsonapi-typescript';
 import { ProductAttributes } from '@data/models/product';
+import { PRODUCTS_TYPE } from '@data';
 
 const iconMap = {
   android: 'android',
@@ -9,7 +10,7 @@ const iconMap = {
 };
 
 export interface IProps {
-  product: ResourceObject<'products', ProductAttributes>;
+  product: ResourceObject<PRODUCTS_TYPE, ProductAttributes>;
 }
 
 export default class ProductIcon extends React.Component<IProps> {

--- a/source/SIL.AppBuilder.Portal.Frontend/src/ui/components/project-table/data.tsx
+++ b/source/SIL.AppBuilder.Portal.Frontend/src/ui/components/project-table/data.tsx
@@ -8,7 +8,7 @@ import { TYPE_NAME as PROJECT, ProjectAttributes } from '@data/models/project';
 import { TYPE_NAME as ORGANIZATION } from '@data/models/organization';
 import { TYPE_NAME as OWNER } from '@data/models/user';
 
-import { query, defaultSourceOptions } from '@data';
+import { query, defaultSourceOptions, PROJECTS_TYPE } from '@data';
 
 import { PageLoader as Loader } from '@ui/components/loaders';
 import { ResourceObject } from 'jsonapi-typescript';
@@ -34,7 +34,7 @@ function mapNetworkToProps(passedProps: IFilterProps) {
 }
 
 export interface IOwnProps {
-  projects: ResourceObject<'projects', ProjectAttributes>;
+  projects: ResourceObject<PROJECTS_TYPE, ProjectAttributes>;
   error?: any;
   applyFilter: (builder: FindRecordsTerm) => FindRecordsTerm;
 }

--- a/source/SIL.AppBuilder.Portal.Frontend/src/ui/components/project-table/data.tsx
+++ b/source/SIL.AppBuilder.Portal.Frontend/src/ui/components/project-table/data.tsx
@@ -11,6 +11,7 @@ import { TYPE_NAME as OWNER } from '@data/models/user';
 import { query, defaultSourceOptions } from '@data';
 
 import { PageLoader as Loader } from '@ui/components/loaders';
+import { ResourceObject } from 'jsonapi-typescript';
 
 function mapNetworkToProps(passedProps: IFilterProps) {
   const { applyFilter, filters } = passedProps;
@@ -33,7 +34,7 @@ function mapNetworkToProps(passedProps: IFilterProps) {
 }
 
 export interface IOwnProps {
-  projects: Array<JSONAPI<ProjectAttributes>>;
+  projects: ResourceObject<'projects', ProjectAttributes>;
   error?: any;
   applyFilter: (builder: FindRecordsTerm) => FindRecordsTerm;
 }

--- a/source/SIL.AppBuilder.Portal.Frontend/src/ui/components/project-table/data.tsx
+++ b/source/SIL.AppBuilder.Portal.Frontend/src/ui/components/project-table/data.tsx
@@ -34,7 +34,7 @@ function mapNetworkToProps(passedProps: IFilterProps) {
 }
 
 export interface IOwnProps {
-  projects: ResourceObject<PROJECTS_TYPE, ProjectAttributes>;
+  projects: Array<ResourceObject<PROJECTS_TYPE, ProjectAttributes>>;
   error?: any;
   applyFilter: (builder: FindRecordsTerm) => FindRecordsTerm;
 }

--- a/source/SIL.AppBuilder.Portal.Frontend/src/ui/components/project-table/row-actions.tsx
+++ b/source/SIL.AppBuilder.Portal.Frontend/src/ui/components/project-table/row-actions.tsx
@@ -8,10 +8,11 @@ import { attributesFor } from '@data';
 import { ProjectAttributes } from '@data/models/project';
 
 import { withProjectOperations } from '@ui/routes/project/with-project-operations';
+import { ResourceObject } from 'jsonapi-typescript';
 
 export interface IProps {
-  project: JSONAPI<ProjectAttributes>;
-  toggleArchiveProject: (project: JSONAPI<ProjectAttributes>) => void;
+  project: ResourceObject<'projects', ProjectAttributes>;
+  toggleArchiveProject: (project: ResourceObject<'projects', ProjectAttributes>) => void;
 }
 
 class RowActions extends React.Component<IProps & i18nProps> {

--- a/source/SIL.AppBuilder.Portal.Frontend/src/ui/components/project-table/row-actions.tsx
+++ b/source/SIL.AppBuilder.Portal.Frontend/src/ui/components/project-table/row-actions.tsx
@@ -4,15 +4,15 @@ import { compose } from 'recompose';
 import { Dropdown, Icon } from 'semantic-ui-react';
 import { withTranslations, i18nProps } from '@lib/i18n';
 
-import { attributesFor } from '@data';
+import { attributesFor, PROJECTS_TYPE } from '@data';
 import { ProjectAttributes } from '@data/models/project';
 
 import { withProjectOperations } from '@ui/routes/project/with-project-operations';
 import { ResourceObject } from 'jsonapi-typescript';
 
 export interface IProps {
-  project: ResourceObject<'projects', ProjectAttributes>;
-  toggleArchiveProject: (project: ResourceObject<'projects', ProjectAttributes>) => void;
+  project: ResourceObject<PROJECTS_TYPE, ProjectAttributes>;
+  toggleArchiveProject: (project: ResourceObject<PROJECTS_TYPE, ProjectAttributes>) => void;
 }
 
 class RowActions extends React.Component<IProps & i18nProps> {

--- a/source/SIL.AppBuilder.Portal.Frontend/src/ui/components/project-table/row.tsx
+++ b/source/SIL.AppBuilder.Portal.Frontend/src/ui/components/project-table/row.tsx
@@ -11,11 +11,12 @@ import { OrganizationAttributes } from '@data/models/organization';
 import { withRelationship } from './withRelationship';
 import ProductIcon from '@ui/components/product-icon';
 import RowActions from '@ui/components/project-table/row-actions';
+import { ResourceObject } from 'jsonapi-typescript';
 
 export interface IProps {
-  project: JSONAPI<ProjectAttributes>;
-  organization: JSONAPI<OrganizationAttributes>;
-  toggleArchiveProject: (project: JSONAPI<ProjectAttributes>) => void;
+  project: ResourceObject<'projects', ProjectAttributes>;
+  organization: ResourceObject<'organizations', OrganizationAttributes>;
+  toggleArchiveProject: (project: ResourceObject<'projects', ProjectAttributes>) => void;
 }
 
 // TODO: Remove this when we had products associated to projects

--- a/source/SIL.AppBuilder.Portal.Frontend/src/ui/components/project-table/row.tsx
+++ b/source/SIL.AppBuilder.Portal.Frontend/src/ui/components/project-table/row.tsx
@@ -4,7 +4,7 @@ import { Link } from 'react-router-dom';
 import { translate, InjectedTranslateProps as i18nProps } from 'react-i18next';
 import { compose } from 'recompose';
 
-import { attributesFor } from '@data';
+import { attributesFor, PROJECTS_TYPE, ORGANIZATIONS_TYPE } from '@data';
 import { ProjectAttributes } from '@data/models/project';
 import { OrganizationAttributes } from '@data/models/organization';
 
@@ -14,9 +14,9 @@ import RowActions from '@ui/components/project-table/row-actions';
 import { ResourceObject } from 'jsonapi-typescript';
 
 export interface IProps {
-  project: ResourceObject<'projects', ProjectAttributes>;
-  organization: ResourceObject<'organizations', OrganizationAttributes>;
-  toggleArchiveProject: (project: ResourceObject<'projects', ProjectAttributes>) => void;
+  project: ResourceObject<PROJECTS_TYPE, ProjectAttributes>;
+  organization: ResourceObject<ORGANIZATIONS_TYPE, OrganizationAttributes>;
+  toggleArchiveProject: (project: ResourceObject<PROJECTS_TYPE, ProjectAttributes>) => void;
 }
 
 // TODO: Remove this when we had products associated to projects

--- a/source/SIL.AppBuilder.Portal.Frontend/src/ui/components/project-table/table.tsx
+++ b/source/SIL.AppBuilder.Portal.Frontend/src/ui/components/project-table/table.tsx
@@ -4,9 +4,10 @@ import Header from './header';
 import Row from './row';
 import { ProjectAttributes } from '@data/models/project';
 import { ResourceObject } from 'jsonapi-typescript';
+import { PROJECTS_TYPE } from '@data';
 
 interface IOwnProps {
-  projects: ResourceObject<'projects', ProjectAttributes>[];
+  projects: ResourceObject<PROJECTS_TYPE, ProjectAttributes>[];
 }
 
 type IProps =

--- a/source/SIL.AppBuilder.Portal.Frontend/src/ui/components/project-table/table.tsx
+++ b/source/SIL.AppBuilder.Portal.Frontend/src/ui/components/project-table/table.tsx
@@ -7,7 +7,7 @@ import { ResourceObject } from 'jsonapi-typescript';
 import { PROJECTS_TYPE } from '@data';
 
 interface IOwnProps {
-  projects: ResourceObject<PROJECTS_TYPE, ProjectAttributes>[];
+  projects: Array<ResourceObject<PROJECTS_TYPE, ProjectAttributes>>;
 }
 
 type IProps =

--- a/source/SIL.AppBuilder.Portal.Frontend/src/ui/components/project-table/table.tsx
+++ b/source/SIL.AppBuilder.Portal.Frontend/src/ui/components/project-table/table.tsx
@@ -3,9 +3,10 @@ import * as React from 'react';
 import Header from './header';
 import Row from './row';
 import { ProjectAttributes } from '@data/models/project';
+import { ResourceObject } from 'jsonapi-typescript';
 
 interface IOwnProps {
-  projects: Array<JSONAPI<ProjectAttributes>>;
+  projects: ResourceObject<'projects', ProjectAttributes>[];
 }
 
 type IProps =

--- a/source/SIL.AppBuilder.Portal.Frontend/src/ui/components/sidebar/header.tsx
+++ b/source/SIL.AppBuilder.Portal.Frontend/src/ui/components/sidebar/header.tsx
@@ -8,14 +8,15 @@ import { translate, InjectedTranslateProps as i18nProps } from 'react-i18next';
 import { OrganizationAttributes } from '@data/models/organization';
 import { withCurrentOrganization } from '@data/containers/with-current-organization';
 import { ResourceObject } from 'jsonapi-typescript';
+import { ORGANIZATIONS_TYPE } from '@data';
 
 export interface IProps {
   closeSidebar: () => void;
   className?: string;
   isOrgSwitcherActive: boolean;
   toggleOrgSwitcher: () => void;
-  organization: ResourceObject<'organizations', OrganizationAttributes>;
-  currentOrganization: ResourceObject<'organizations', OrganizationAttributes>;
+  organization: ResourceObject<ORGANIZATIONS_TYPE, OrganizationAttributes>;
+  currentOrganization: ResourceObject<ORGANIZATIONS_TYPE, OrganizationAttributes>;
 }
 
 const mapStateToProps = ({ data }) => ({

--- a/source/SIL.AppBuilder.Portal.Frontend/src/ui/components/sidebar/header.tsx
+++ b/source/SIL.AppBuilder.Portal.Frontend/src/ui/components/sidebar/header.tsx
@@ -7,14 +7,15 @@ import { translate, InjectedTranslateProps as i18nProps } from 'react-i18next';
 
 import { OrganizationAttributes } from '@data/models/organization';
 import { withCurrentOrganization } from '@data/containers/with-current-organization';
+import { ResourceObject } from 'jsonapi-typescript';
 
 export interface IProps {
   closeSidebar: () => void;
   className?: string;
   isOrgSwitcherActive: boolean;
   toggleOrgSwitcher: () => void;
-  organization: JSONAPI<OrganizationAttributes>;
-  currentOrganization: JSONAPI<OrganizationAttributes>;
+  organization: ResourceObject<'organizations', OrganizationAttributes>;
+  currentOrganization: ResourceObject<'organizations', OrganizationAttributes>;
 }
 
 const mapStateToProps = ({ data }) => ({

--- a/source/SIL.AppBuilder.Portal.Frontend/src/ui/components/sidebar/org-switcher/display.tsx
+++ b/source/SIL.AppBuilder.Portal.Frontend/src/ui/components/sidebar/org-switcher/display.tsx
@@ -13,7 +13,7 @@ import { ResourceObject } from 'jsonapi-typescript';
 import { ORGANIZATIONS_TYPE } from '@data';
 
 export interface IOwnProps {
-  organizations: ResourceObject<ORGANIZATIONS_TYPE, OrganizationAttributes>[];
+  organizations: Array<ResourceObject<ORGANIZATIONS_TYPE, OrganizationAttributes>>;
   isLoading: boolean;
   searchByName: (name: string) => void;
   toggle: () => void;

--- a/source/SIL.AppBuilder.Portal.Frontend/src/ui/components/sidebar/org-switcher/display.tsx
+++ b/source/SIL.AppBuilder.Portal.Frontend/src/ui/components/sidebar/org-switcher/display.tsx
@@ -9,16 +9,17 @@ import { IProvidedProps as WithCurrentOrgProps } from '@data/containers/with-cur
 import Loader from '@ui/components/loaders/page';
 
 import Row from './row';
+import { ResourceObject } from 'jsonapi-typescript';
 
 export interface IOwnProps {
-  organizations: Array<JSONAPI<OrganizationAttributes>>;
+  organizations: ResourceObject<'organizations', OrganizationAttributes>[];
   isLoading: boolean;
   searchByName: (name: string) => void;
   toggle: () => void;
   searchTerm: string;
   allOrgsSelected: boolean;
   didTypeInSearch: (e: any) => void;
-  selectOrganization: (id: number | string) => (e: any) => void;
+  selectOrganization: (id: Id) => (e: any) => void;
 }
 
 export type IProps =

--- a/source/SIL.AppBuilder.Portal.Frontend/src/ui/components/sidebar/org-switcher/display.tsx
+++ b/source/SIL.AppBuilder.Portal.Frontend/src/ui/components/sidebar/org-switcher/display.tsx
@@ -10,9 +10,10 @@ import Loader from '@ui/components/loaders/page';
 
 import Row from './row';
 import { ResourceObject } from 'jsonapi-typescript';
+import { ORGANIZATIONS_TYPE } from '@data';
 
 export interface IOwnProps {
-  organizations: ResourceObject<'organizations', OrganizationAttributes>[];
+  organizations: ResourceObject<ORGANIZATIONS_TYPE, OrganizationAttributes>[];
   isLoading: boolean;
   searchByName: (name: string) => void;
   toggle: () => void;

--- a/source/SIL.AppBuilder.Portal.Frontend/src/ui/components/sidebar/org-switcher/index.tsx
+++ b/source/SIL.AppBuilder.Portal.Frontend/src/ui/components/sidebar/org-switcher/index.tsx
@@ -17,7 +17,7 @@ import { ResourceObject } from 'jsonapi-typescript';
 import { ORGANIZATIONS_TYPE } from '@data';
 
 export interface IOwnProps {
-  organizations: ResourceObject<ORGANIZATIONS_TYPE, OrganizationAttributes>[];
+  organizations: Array<ResourceObject<ORGANIZATIONS_TYPE, OrganizationAttributes>>;
   isLoading: boolean;
   searchByName: (name: string) => void;
   setCurrentOrganizationId: (id: Id) => void;

--- a/source/SIL.AppBuilder.Portal.Frontend/src/ui/components/sidebar/org-switcher/index.tsx
+++ b/source/SIL.AppBuilder.Portal.Frontend/src/ui/components/sidebar/org-switcher/index.tsx
@@ -14,9 +14,10 @@ import { withFiltering, IProvidedProps as IFilterProps } from '@data/containers/
 import { withData } from './with-data';
 import Display from './display';
 import { ResourceObject } from 'jsonapi-typescript';
+import { ORGANIZATIONS_TYPE } from '@data';
 
 export interface IOwnProps {
-  organizations: ResourceObject<'organizations', OrganizationAttributes>[];
+  organizations: ResourceObject<ORGANIZATIONS_TYPE, OrganizationAttributes>[];
   isLoading: boolean;
   searchByName: (name: string) => void;
   setCurrentOrganizationId: (id: Id) => void;

--- a/source/SIL.AppBuilder.Portal.Frontend/src/ui/components/sidebar/org-switcher/index.tsx
+++ b/source/SIL.AppBuilder.Portal.Frontend/src/ui/components/sidebar/org-switcher/index.tsx
@@ -13,12 +13,13 @@ import { withFiltering, IProvidedProps as IFilterProps } from '@data/containers/
 
 import { withData } from './with-data';
 import Display from './display';
+import { ResourceObject } from 'jsonapi-typescript';
 
 export interface IOwnProps {
-  organizations: Array<JSONAPI<OrganizationAttributes>>;
+  organizations: ResourceObject<'organizations', OrganizationAttributes>[];
   isLoading: boolean;
   searchByName: (name: string) => void;
-  setCurrentOrganizationId: (id: string | number) => void;
+  setCurrentOrganizationId: (id: Id) => void;
   toggle: () => void;
 }
 

--- a/source/SIL.AppBuilder.Portal.Frontend/src/ui/components/sidebar/org-switcher/row.tsx
+++ b/source/SIL.AppBuilder.Portal.Frontend/src/ui/components/sidebar/org-switcher/row.tsx
@@ -1,12 +1,12 @@
 import * as React from 'react';
 import { Menu } from 'semantic-ui-react';
 
-import { attributesFor } from '@data';
+import { attributesFor, ORGANIZATIONS_TYPE } from '@data';
 import { OrganizationAttributes } from '@data/models/organization';
 import { ResourceObject } from 'jsonapi-typescript';
 
 export interface IProps {
-  organization: ResourceObject<'organizations', OrganizationAttributes>;
+  organization: ResourceObject<ORGANIZATIONS_TYPE, OrganizationAttributes>;
   onClick: (e: any) => void;
   isActive: boolean;
 }

--- a/source/SIL.AppBuilder.Portal.Frontend/src/ui/components/sidebar/org-switcher/row.tsx
+++ b/source/SIL.AppBuilder.Portal.Frontend/src/ui/components/sidebar/org-switcher/row.tsx
@@ -3,9 +3,10 @@ import { Menu } from 'semantic-ui-react';
 
 import { attributesFor } from '@data';
 import { OrganizationAttributes } from '@data/models/organization';
+import { ResourceObject } from 'jsonapi-typescript';
 
 export interface IProps {
-  organization: JSONAPI<OrganizationAttributes>;
+  organization: ResourceObject<'organizations', OrganizationAttributes>;
   onClick: (e: any) => void;
   isActive: boolean;
 }

--- a/source/SIL.AppBuilder.Portal.Frontend/src/ui/components/sidebar/org-switcher/with-data.tsx
+++ b/source/SIL.AppBuilder.Portal.Frontend/src/ui/components/sidebar/org-switcher/with-data.tsx
@@ -2,7 +2,7 @@ import * as React from 'react';
 import { compose } from 'recompose';
 import { withData as withOrbit, WithDataProps } from 'react-orbitjs';
 
-import { query, defaultSourceOptions, defaultOptions } from '@data';
+import { query, defaultSourceOptions, defaultOptions, ORGANIZATIONS_TYPE } from '@data';
 import { IProvidedProps as IFilterProps } from '@data/containers/with-filtering';
 import { TYPE_NAME as ORGANIZATION, OrganizationAttributes } from '@data/models/organization';
 import { isEmpty } from '@lib/collection';
@@ -29,8 +29,8 @@ function mapNetworkToProps(passedProps) {
 }
 
 interface IOwnProps {
-  organizations: ResourceObject<'organizations', OrganizationAttributes>[];
-  fromCache: ResourceObject<'organizations', OrganizationAttributes>[];
+  organizations: ResourceObject<ORGANIZATIONS_TYPE, OrganizationAttributes>[];
+  fromCache: ResourceObject<ORGANIZATIONS_TYPE, OrganizationAttributes>[];
 }
 
 type IProps =

--- a/source/SIL.AppBuilder.Portal.Frontend/src/ui/components/sidebar/org-switcher/with-data.tsx
+++ b/source/SIL.AppBuilder.Portal.Frontend/src/ui/components/sidebar/org-switcher/with-data.tsx
@@ -29,8 +29,8 @@ function mapNetworkToProps(passedProps) {
 }
 
 interface IOwnProps {
-  organizations: ResourceObject<ORGANIZATIONS_TYPE, OrganizationAttributes>[];
-  fromCache: ResourceObject<ORGANIZATIONS_TYPE, OrganizationAttributes>[];
+  organizations: Array<ResourceObject<ORGANIZATIONS_TYPE, OrganizationAttributes>>;
+  fromCache: Array<ResourceObject<ORGANIZATIONS_TYPE, OrganizationAttributes>>;
 }
 
 type IProps =

--- a/source/SIL.AppBuilder.Portal.Frontend/src/ui/components/sidebar/org-switcher/with-data.tsx
+++ b/source/SIL.AppBuilder.Portal.Frontend/src/ui/components/sidebar/org-switcher/with-data.tsx
@@ -6,6 +6,7 @@ import { query, defaultSourceOptions, defaultOptions } from '@data';
 import { IProvidedProps as IFilterProps } from '@data/containers/with-filtering';
 import { TYPE_NAME as ORGANIZATION, OrganizationAttributes } from '@data/models/organization';
 import { isEmpty } from '@lib/collection';
+import { ResourceObject } from 'jsonapi-typescript';
 
 function mapRecordsToProps(passedProps) {
   const { filterOptions, applyFilter } = passedProps;
@@ -28,8 +29,8 @@ function mapNetworkToProps(passedProps) {
 }
 
 interface IOwnProps {
-  organizations: Array<JSONAPI<OrganizationAttributes>>;
-  fromCache: Array<JSONAPI<OrganizationAttributes>>;
+  organizations: ResourceObject<'organizations', OrganizationAttributes>[];
+  fromCache: ResourceObject<'organizations', OrganizationAttributes>[];
 }
 
 type IProps =

--- a/source/SIL.AppBuilder.Portal.Frontend/src/ui/components/user-table/data.tsx
+++ b/source/SIL.AppBuilder.Portal.Frontend/src/ui/components/user-table/data.tsx
@@ -46,11 +46,11 @@ function mapStateToProps({ data }) {
 }
 
 interface IOwnProps {
-  users: ResourceObject<USERS_TYPE, UserAttributes>[];
-  usersFromCache: ResourceObject<USERS_TYPE, UserAttributes>[];
-  groups: ResourceObject<GROUPS_TYPE, GroupAttributes>[];
+  users: Array<ResourceObject<USERS_TYPE, UserAttributes>>;
+  usersFromCache: Array<ResourceObject<USERS_TYPE, UserAttributes>>;
+  groups: Array<ResourceObject<GROUPS_TYPE, GroupAttributes>>;
   currentOrganizationId: string;
-  organizationMemberships: ResourceObject<ORGANIZATION_MEMBERSHIPS_TYPE, OrganizationMembershipAttributes>[];
+  organizationMemberships: Array<ResourceObject<ORGANIZATION_MEMBERSHIPS_TYPE, OrganizationMembershipAttributes>>;
 }
 
 type IProps =

--- a/source/SIL.AppBuilder.Portal.Frontend/src/ui/components/user-table/data.tsx
+++ b/source/SIL.AppBuilder.Portal.Frontend/src/ui/components/user-table/data.tsx
@@ -4,16 +4,16 @@ import { connect } from 'react-redux';
 import { withData as withOrbit, WithDataProps } from 'react-orbitjs';
 import * as toast from '@lib/toast';
 import { withTranslations, i18nProps } from '@lib/i18n';
+import { ResourceObject } from 'jsonapi-typescript';
 
-import { TYPE_NAME as USER, PLURAL_NAME as USERS, UserAttributes } from '@data/models/user';
+import { TYPE_NAME as USER, UserAttributes } from '@data/models/user';
 import { TYPE_NAME as GROUP, GroupAttributes } from '@data/models/group';
-import { TYPE_NAME as MEMBERSHIP, PLURAL_NAME as MEMBERSHIPS } from '@data/models/organization-membership';
+import { PLURAL_NAME as MEMBERSHIPS, OrganizationMembershipAttributes } from '@data/models/organization-membership';
 import { PageLoader as Loader } from '@ui/components/loaders';
-import { query, defaultSourceOptions, defaultOptions, isRelatedTo, relationshipFor } from '@data';
+import { query, defaultSourceOptions, defaultOptions, relationshipFor, ORGANIZATION_MEMBERSHIPS_TYPE, GROUPS_TYPE, USERS_TYPE } from '@data';
 import { withCurrentOrganization } from '@data/containers/with-current-organization';
-import { OrganizationMembershipAttributes } from '@data/models/organization-membership';
 
-function mapNetworkToProps(passedProps) {
+function mapNetworkToProps() {
 
   // TODO: combine into one query when
   //       https://github.com/json-api-dotnet/JsonApiDotNetCore/issues/39
@@ -32,7 +32,7 @@ function mapNetworkToProps(passedProps) {
   };
 }
 
-function mapRecordsToProps(passedProps) {
+function mapRecordsToProps() {
   return {
     usersFromCache: q => q.findRecords(USER),
     organizationMemberships: q => q.findRecords('organizationMembership')
@@ -46,11 +46,11 @@ function mapStateToProps({ data }) {
 }
 
 interface IOwnProps {
-  users: Array<JSONAPI<UserAttributes>>;
-  usersFromCache: Array<JSONAPI<UserAttributes>>;
-  groups: Array<JSONAPI<GroupAttributes>>;
+  users: ResourceObject<USERS_TYPE, UserAttributes>[];
+  usersFromCache: ResourceObject<USERS_TYPE, UserAttributes>[];
+  groups: ResourceObject<GROUPS_TYPE, GroupAttributes>[];
   currentOrganizationId: string;
-  organizationMemberships: Array<JSONAPI<{}>>;
+  organizationMemberships: ResourceObject<ORGANIZATION_MEMBERSHIPS_TYPE, OrganizationMembershipAttributes>[];
 }
 
 type IProps =

--- a/source/SIL.AppBuilder.Portal.Frontend/src/ui/components/user-table/row.tsx
+++ b/source/SIL.AppBuilder.Portal.Frontend/src/ui/components/user-table/row.tsx
@@ -7,11 +7,12 @@ import GroupDropdown from './dropdown';
 import { Link } from 'react-router-dom';
 import { Radio } from 'semantic-ui-react';
 import { ResourceObject } from 'jsonapi-typescript';
+import { USERS_TYPE, GROUPS_TYPE } from '@data';
 
 export interface IOwnProps {
-  user: ResourceObject<'users', UserAttributes>;
-  groups: ResourceObject<'groups', GroupAttributes>[];
-  toggleLock: (user: ResourceObject<'users', UserAttributes>) => void;
+  user: ResourceObject<USERS_TYPE, UserAttributes>;
+  groups: ResourceObject<GROUPS_TYPE, GroupAttributes>[];
+  toggleLock: (user: ResourceObject<USERS_TYPE, UserAttributes>) => void;
 }
 
 export type IProps =

--- a/source/SIL.AppBuilder.Portal.Frontend/src/ui/components/user-table/row.tsx
+++ b/source/SIL.AppBuilder.Portal.Frontend/src/ui/components/user-table/row.tsx
@@ -11,7 +11,7 @@ import { USERS_TYPE, GROUPS_TYPE } from '@data';
 
 export interface IOwnProps {
   user: ResourceObject<USERS_TYPE, UserAttributes>;
-  groups: ResourceObject<GROUPS_TYPE, GroupAttributes>[];
+  groups: Array<ResourceObject<GROUPS_TYPE, GroupAttributes>>;
   toggleLock: (user: ResourceObject<USERS_TYPE, UserAttributes>) => void;
 }
 

--- a/source/SIL.AppBuilder.Portal.Frontend/src/ui/components/user-table/row.tsx
+++ b/source/SIL.AppBuilder.Portal.Frontend/src/ui/components/user-table/row.tsx
@@ -6,11 +6,12 @@ import { GroupAttributes } from '@data/models/group';
 import GroupDropdown from './dropdown';
 import { Link } from 'react-router-dom';
 import { Radio } from 'semantic-ui-react';
+import { ResourceObject } from 'jsonapi-typescript';
 
 export interface IOwnProps {
-  user: JSONAPI<UserAttributes>;
-  groups: Array<JSONAPI<GroupAttributes>>;
-  toggleLock: (user: JSONAPI<UserAttributes>) => void;
+  user: ResourceObject<'users', UserAttributes>;
+  groups: ResourceObject<'groups', GroupAttributes>[];
+  toggleLock: (user: ResourceObject<'users', UserAttributes>) => void;
 }
 
 export type IProps =

--- a/source/SIL.AppBuilder.Portal.Frontend/src/ui/components/user-table/table.tsx
+++ b/source/SIL.AppBuilder.Portal.Frontend/src/ui/components/user-table/table.tsx
@@ -10,11 +10,12 @@ import Row from './row';
 
 import './user-table.scss';
 import { ResourceObject } from 'jsonapi-typescript';
+import { USERS_TYPE, GROUPS_TYPE } from '@data';
 
 interface IOwnProps {
-  users: ResourceObject<'users', UserAttributes>[];
-  groups: ResourceObject<'groups', GroupAttributes>[];
-  toggleLock: (user: ResourceObject<'users', UserAttributes>) => void;
+  users: ResourceObject<USERS_TYPE, UserAttributes>[];
+  groups: ResourceObject<GROUPS_TYPE, GroupAttributes>[];
+  toggleLock: (user: ResourceObject<USERS_TYPE, UserAttributes>) => void;
 }
 
 type IProps =

--- a/source/SIL.AppBuilder.Portal.Frontend/src/ui/components/user-table/table.tsx
+++ b/source/SIL.AppBuilder.Portal.Frontend/src/ui/components/user-table/table.tsx
@@ -9,11 +9,12 @@ import Header from './header';
 import Row from './row';
 
 import './user-table.scss';
+import { ResourceObject } from 'jsonapi-typescript';
 
 interface IOwnProps {
-  users: Array<JSONAPI<UserAttributes>>;
-  groups: Array<JSONAPI<GroupAttributes>>;
-  toggleLock: (user: JSONAPI<UserAttributes>) => void;
+  users: ResourceObject<'users', UserAttributes>[];
+  groups: ResourceObject<'groups', GroupAttributes>[];
+  toggleLock: (user: ResourceObject<'users', UserAttributes>) => void;
 }
 
 type IProps =

--- a/source/SIL.AppBuilder.Portal.Frontend/src/ui/components/user-table/table.tsx
+++ b/source/SIL.AppBuilder.Portal.Frontend/src/ui/components/user-table/table.tsx
@@ -13,8 +13,8 @@ import { ResourceObject } from 'jsonapi-typescript';
 import { USERS_TYPE, GROUPS_TYPE } from '@data';
 
 interface IOwnProps {
-  users: ResourceObject<USERS_TYPE, UserAttributes>[];
-  groups: ResourceObject<GROUPS_TYPE, GroupAttributes>[];
+  users: Array<ResourceObject<USERS_TYPE, UserAttributes>>;
+  groups: Array<ResourceObject<GROUPS_TYPE, GroupAttributes>>;
   toggleLock: (user: ResourceObject<USERS_TYPE, UserAttributes>) => void;
 }
 

--- a/source/SIL.AppBuilder.Portal.Frontend/src/ui/routes/organizations/settings/basic-info/index.tsx
+++ b/source/SIL.AppBuilder.Portal.Frontend/src/ui/routes/organizations/settings/basic-info/index.tsx
@@ -8,6 +8,7 @@ import { compose } from 'recompose';
 import { OrganizationAttributes } from '@data/models/organization';
 
 import SelectLogo from '../select-logo';
+import { ResourceObject } from 'jsonapi-typescript';
 
 export const pathName = '/organizations/:orgId/settings';
 
@@ -23,7 +24,7 @@ export interface Params {
 export interface IProps {
   match: Match<Params>;
   update: (payload: OrganizationAttributes) => void;
-  organization: JSONAPI<OrganizationAttributes>;
+  organization: ResourceObject<'organizations', OrganizationAttributes>;
 }
 
 @withTemplateHelpers

--- a/source/SIL.AppBuilder.Portal.Frontend/src/ui/routes/organizations/settings/basic-info/index.tsx
+++ b/source/SIL.AppBuilder.Portal.Frontend/src/ui/routes/organizations/settings/basic-info/index.tsx
@@ -9,6 +9,7 @@ import { OrganizationAttributes } from '@data/models/organization';
 
 import SelectLogo from '../select-logo';
 import { ResourceObject } from 'jsonapi-typescript';
+import { ORGANIZATIONS_TYPE } from '@data';
 
 export const pathName = '/organizations/:orgId/settings';
 
@@ -24,7 +25,7 @@ export interface Params {
 export interface IProps {
   match: Match<Params>;
   update: (payload: OrganizationAttributes) => void;
-  organization: ResourceObject<'organizations', OrganizationAttributes>;
+  organization: ResourceObject<ORGANIZATIONS_TYPE, OrganizationAttributes>;
 }
 
 @withTemplateHelpers

--- a/source/SIL.AppBuilder.Portal.Frontend/src/ui/routes/organizations/settings/index.tsx
+++ b/source/SIL.AppBuilder.Portal.Frontend/src/ui/routes/organizations/settings/index.tsx
@@ -8,7 +8,7 @@ import { translate, InjectedTranslateProps as i18nProps } from 'react-i18next';
 
 import * as toast from '@lib/toast';
 import NotFound from '@ui/routes/errors/not-found';
-import { defaultOptions } from '@data';
+import { defaultOptions, ORGANIZATIONS_TYPE } from '@data';
 import { OrganizationAttributes, TYPE_NAME } from '@data/models/organization';
 
 
@@ -32,7 +32,7 @@ interface PassedProps {
 }
 
 interface QueriedProps {
-  organization: ResourceObject<'organizations', OrganizationAttributes>;
+  organization: ResourceObject<ORGANIZATIONS_TYPE, OrganizationAttributes>;
 }
 
 export type IProps =

--- a/source/SIL.AppBuilder.Portal.Frontend/src/ui/routes/organizations/settings/index.tsx
+++ b/source/SIL.AppBuilder.Portal.Frontend/src/ui/routes/organizations/settings/index.tsx
@@ -18,6 +18,7 @@ import ProductsRoute, { pathName as productsPath } from './products';
 import GroupsRoute, { pathName as groupsPath } from './groups';
 import InfrastructureRoute, { pathName as infrastructurePath } from './infrastructure';
 import Navigation from './navigation';
+import { ResourceObject } from 'jsonapi-typescript';
 
 
 export const pathName = '/organizations/:orgId/settings';
@@ -31,7 +32,7 @@ interface PassedProps {
 }
 
 interface QueriedProps {
-  organization: JSONAPI<OrganizationAttributes>;
+  organization: ResourceObject<'organizations', OrganizationAttributes>;
 }
 
 export type IProps =

--- a/source/SIL.AppBuilder.Portal.Frontend/src/ui/routes/organizations/settings/infrastructure/display.tsx
+++ b/source/SIL.AppBuilder.Portal.Frontend/src/ui/routes/organizations/settings/infrastructure/display.tsx
@@ -5,13 +5,13 @@ import { withTemplateHelpers, Mut, Toggle } from 'react-action-decorators';
 import { translate, InjectedTranslateProps as i18nProps } from 'react-i18next';
 import { compose } from 'recompose';
 
-import { attributesFor } from '@data';
+import { attributesFor, ORGANIZATIONS_TYPE } from '@data';
 import { OrganizationAttributes } from '@data/models/organization';
 import { ResourceObject } from 'jsonapi-typescript';
 
 export interface IProps {
   onChange: (payload: OrganizationAttributes) => void;
-  organization: ResourceObject<'organizations', OrganizationAttributes>;
+  organization: ResourceObject<ORGANIZATIONS_TYPE, OrganizationAttributes>;
 }
 
 @withTemplateHelpers

--- a/source/SIL.AppBuilder.Portal.Frontend/src/ui/routes/organizations/settings/infrastructure/display.tsx
+++ b/source/SIL.AppBuilder.Portal.Frontend/src/ui/routes/organizations/settings/infrastructure/display.tsx
@@ -7,10 +7,11 @@ import { compose } from 'recompose';
 
 import { attributesFor } from '@data';
 import { OrganizationAttributes } from '@data/models/organization';
+import { ResourceObject } from 'jsonapi-typescript';
 
 export interface IProps {
   onChange: (payload: OrganizationAttributes) => void;
-  organization: JSONAPI<OrganizationAttributes>;
+  organization: ResourceObject<'organizations', OrganizationAttributes>;
 }
 
 @withTemplateHelpers

--- a/source/SIL.AppBuilder.Portal.Frontend/src/ui/routes/organizations/settings/infrastructure/index.tsx
+++ b/source/SIL.AppBuilder.Portal.Frontend/src/ui/routes/organizations/settings/infrastructure/index.tsx
@@ -4,6 +4,7 @@ import { OrganizationAttributes } from '@data/models/organization';
 
 import Display from './display';
 import { ResourceObject } from 'jsonapi-typescript';
+import { ORGANIZATIONS_TYPE } from '@data';
 
 export const pathName = '/organizations/:orgId/settings/infrastructure';
 
@@ -14,7 +15,7 @@ export interface Params {
 export interface IProps {
   match: Match<Params>;
   update: (payload: OrganizationAttributes) => void;
-  organization: ResourceObject<'organizations', OrganizationAttributes>;
+  organization: ResourceObject<ORGANIZATIONS_TYPE, OrganizationAttributes>;
 }
 
 

--- a/source/SIL.AppBuilder.Portal.Frontend/src/ui/routes/organizations/settings/infrastructure/index.tsx
+++ b/source/SIL.AppBuilder.Portal.Frontend/src/ui/routes/organizations/settings/infrastructure/index.tsx
@@ -3,6 +3,7 @@ import { match as Match } from 'react-router';
 import { OrganizationAttributes } from '@data/models/organization';
 
 import Display from './display';
+import { ResourceObject } from 'jsonapi-typescript';
 
 export const pathName = '/organizations/:orgId/settings/infrastructure';
 
@@ -13,7 +14,7 @@ export interface Params {
 export interface IProps {
   match: Match<Params>;
   update: (payload: OrganizationAttributes) => void;
-  organization: JSONAPI<OrganizationAttributes>;
+  organization: ResourceObject<'organizations', OrganizationAttributes>;
 }
 
 

--- a/source/SIL.AppBuilder.Portal.Frontend/src/ui/routes/organizations/settings/products/index.tsx
+++ b/source/SIL.AppBuilder.Portal.Frontend/src/ui/routes/organizations/settings/products/index.tsx
@@ -5,6 +5,8 @@ import { translate, InjectedTranslateProps as i18nProps } from 'react-i18next';
 import { compose } from 'recompose';
 
 import { TYPE_NAME, OrganizationAttributes } from '@data/models/organization';
+import { ORGANIZATIONS_TYPE } from '@data';
+import { ResourceObject } from 'jsonapi-typescript';
 
 export const pathName = '/organizations/:orgId/settings/products';
 
@@ -15,7 +17,7 @@ export interface Params {
 export interface IProps {
   match: Match<Params>;
   update: (payload: OrganizationAttributes) => void;
-  organization: JSONAPI<OrganizationAttributes>;
+  organization: ResourceObject<ORGANIZATIONS_TYPE, OrganizationAttributes>;
 }
 
 class ProductsRoute extends React.Component<IProps & i18nProps> {

--- a/source/SIL.AppBuilder.Portal.Frontend/src/ui/routes/project-directory/filters/index.tsx
+++ b/source/SIL.AppBuilder.Portal.Frontend/src/ui/routes/project-directory/filters/index.tsx
@@ -9,7 +9,7 @@ import MomentLocaleUtils, {
   parseDate,
 } from 'react-day-picker/moment';
 
-import { attributesFor } from '@data';
+import { attributesFor, ORGANIZATIONS_TYPE } from '@data';
 import { OrganizationAttributes } from '@data/models/organization';
 import { IFilter } from '@data/containers/with-filtering';
 import {
@@ -19,6 +19,7 @@ import {
 
 import 'react-day-picker/lib/style.css';
 import './filters.scss';
+import { ResourceObject } from 'jsonapi-typescript';
 
 interface IState {
   products: any[];
@@ -30,7 +31,7 @@ interface IState {
 
 interface IOwnProps {
   updateFilter: (filter: IFilter) => void;
-  organizations: Array<JSONAPI<OrganizationAttributes>>;
+  organizations: ResourceObject<ORGANIZATIONS_TYPE, OrganizationAttributes>[];
   onOrganizationChange: (id: string | number) => void;
 }
 

--- a/source/SIL.AppBuilder.Portal.Frontend/src/ui/routes/project-directory/filters/index.tsx
+++ b/source/SIL.AppBuilder.Portal.Frontend/src/ui/routes/project-directory/filters/index.tsx
@@ -31,7 +31,7 @@ interface IState {
 
 interface IOwnProps {
   updateFilter: (filter: IFilter) => void;
-  organizations: ResourceObject<ORGANIZATIONS_TYPE, OrganizationAttributes>[];
+  organizations: Array<ResourceObject<ORGANIZATIONS_TYPE, OrganizationAttributes>>;
   onOrganizationChange: (id: string | number) => void;
 }
 

--- a/source/SIL.AppBuilder.Portal.Frontend/src/ui/routes/project-directory/index.tsx
+++ b/source/SIL.AppBuilder.Portal.Frontend/src/ui/routes/project-directory/index.tsx
@@ -37,7 +37,7 @@ import { ResourceObject } from 'jsonapi-typescript';
 export const pathName = '/directory';
 
 export interface IOwnProps {
-  organizations: ResourceObject<ORGANIZATIONS_TYPE, OrganizationAttributes>;
+  organizations: Array<ResourceObject<ORGANIZATIONS_TYPE, OrganizationAttributes>>;
   setCurrentOrganizationId: (id: number | string) => void;
   groups: Array<ResourceObject<GROUPS_TYPE, GroupAttributes>>;
 }

--- a/source/SIL.AppBuilder.Portal.Frontend/src/ui/routes/project-directory/index.tsx
+++ b/source/SIL.AppBuilder.Portal.Frontend/src/ui/routes/project-directory/index.tsx
@@ -11,7 +11,7 @@ import { GroupAttributes } from '@data/models/group';
 import { withSorting } from '@data/containers/sorting';
 import { withPagination } from '@data/containers/pagination';
 
-import { query, defaultOptions } from '@data';
+import { query, defaultOptions, ORGANIZATIONS_TYPE, GROUPS_TYPE } from '@data';
 import { TYPE_NAME as ORGANIZATION } from '@data/models/organization';
 import { TYPE_NAME as GROUP } from '@data/models/group';
 
@@ -32,13 +32,14 @@ import ProjectSearch from '@ui/components/project-search';
 import '@ui/components/project-table/project-table.scss';
 
 import Filters from './filters';
+import { ResourceObject } from 'jsonapi-typescript';
 
 export const pathName = '/directory';
 
 export interface IOwnProps {
-  organizations: JSONAPI<OrganizationAttributes>;
+  organizations: ResourceObject<ORGANIZATIONS_TYPE, OrganizationAttributes>;
   setCurrentOrganizationId: (id: number | string) => void;
-  groups: JSONAPI<GroupAttributes>;
+  groups: ResourceObject<GROUPS_TYPE, GroupAttributes>[];
 }
 
 export type IProps =

--- a/source/SIL.AppBuilder.Portal.Frontend/src/ui/routes/project-directory/index.tsx
+++ b/source/SIL.AppBuilder.Portal.Frontend/src/ui/routes/project-directory/index.tsx
@@ -39,7 +39,7 @@ export const pathName = '/directory';
 export interface IOwnProps {
   organizations: ResourceObject<ORGANIZATIONS_TYPE, OrganizationAttributes>;
   setCurrentOrganizationId: (id: number | string) => void;
-  groups: ResourceObject<GROUPS_TYPE, GroupAttributes>[];
+  groups: Array<ResourceObject<GROUPS_TYPE, GroupAttributes>>;
 }
 
 export type IProps =

--- a/source/SIL.AppBuilder.Portal.Frontend/src/ui/routes/project/details/index.tsx
+++ b/source/SIL.AppBuilder.Portal.Frontend/src/ui/routes/project/details/index.tsx
@@ -3,9 +3,11 @@ import * as React from 'react';
 import { translate, InjectedTranslateProps as i18nProps } from 'react-i18next';
 import { compose } from 'recompose';
 import { ProjectAttributes } from '@data/models/project';
+import { ResourceObject } from 'jsonapi-typescript';
+import { PROJECTS_TYPE } from '@data';
 
 interface Params {
-  project: JSONAPI<ProjectAttributes>;
+  project: ResourceObject<PROJECTS_TYPE, ProjectAttributes>;
 }
 
 type IProps =

--- a/source/SIL.AppBuilder.Portal.Frontend/src/ui/routes/project/index.tsx
+++ b/source/SIL.AppBuilder.Portal.Frontend/src/ui/routes/project/index.tsx
@@ -23,6 +23,8 @@ import { withAccessRestriction } from './with-access-restriction';
 
 
 import './project.scss';
+import { ResourceObject } from 'jsonapi-typescript';
+import { PROJECTS_TYPE } from '@data';
 
 export const pathName = '/project/:id';
 
@@ -33,11 +35,11 @@ export interface Params {
 interface PassedProps {
   match: Match<Params>;
   timeAgo: any;
-  toggleArchiveProject: (project: JSONAPI<ProjectAttributes>) => void;
+  toggleArchiveProject: (project: ResourceObject<PROJECTS_TYPE, ProjectAttributes>) => void;
 }
 
 interface QueriedProps {
-  project: JSONAPI<ProjectAttributes>;
+  project: ResourceObject<PROJECTS_TYPE, ProjectAttributes>;
 }
 
 export type IProps =

--- a/source/SIL.AppBuilder.Portal.Frontend/src/ui/routes/project/location/index.tsx
+++ b/source/SIL.AppBuilder.Portal.Frontend/src/ui/routes/project/location/index.tsx
@@ -3,9 +3,11 @@ import * as React from 'react';
 import { translate, InjectedTranslateProps as i18nProps } from 'react-i18next';
 import { compose } from 'recompose';
 import { ProjectAttributes } from '@data/models/project';
+import { ResourceObject } from 'jsonapi-typescript';
+import { PROJECTS_TYPE } from '@data';
 
 interface Params {
-  project: JSONAPI<ProjectAttributes>;
+  project: ResourceObject<PROJECTS_TYPE, ProjectAttributes>;
 }
 
 type IProps =

--- a/source/SIL.AppBuilder.Portal.Frontend/src/ui/routes/project/owners/index.tsx
+++ b/source/SIL.AppBuilder.Portal.Frontend/src/ui/routes/project/owners/index.tsx
@@ -4,7 +4,7 @@ import { translate, InjectedTranslateProps as i18nProps } from 'react-i18next';
 import { compose } from 'recompose';
 import { withData as withOrbit } from 'react-orbitjs';
 
-import { attributesFor } from '@data';
+import { attributesFor, PROJECTS_TYPE } from '@data';
 import { ProjectAttributes } from '@data/models/project';
 import { withCurrentUser } from '@data/containers/with-current-user';
 import {
@@ -16,9 +16,10 @@ import * as toast from '@lib/toast';
 
 import GroupSelect from '@ui/components/inputs/group-select';
 import UserSelect from '@ui/components/inputs/user-select';
+import { ResourceObject } from 'jsonapi-typescript';
 
 interface Params {
-  project: JSONAPI<ProjectAttributes>;
+  project: ResourceObject<PROJECTS_TYPE, ProjectAttributes>;
 }
 
 type IProps =

--- a/source/SIL.AppBuilder.Portal.Frontend/src/ui/routes/project/products/index.tsx
+++ b/source/SIL.AppBuilder.Portal.Frontend/src/ui/routes/project/products/index.tsx
@@ -3,9 +3,11 @@ import * as React from 'react';
 import { translate, InjectedTranslateProps as i18nProps } from 'react-i18next';
 import { compose } from 'recompose';
 import { ProjectAttributes } from '@data/models/project';
+import { ResourceObject } from 'jsonapi-typescript';
+import { PROJECTS_TYPE } from '@data';
 
 interface Params {
-  project: JSONAPI<ProjectAttributes>;
+  project: ResourceObject<PROJECTS_TYPE, ProjectAttributes>;
 }
 
 type IProps =

--- a/source/SIL.AppBuilder.Portal.Frontend/src/ui/routes/project/reviewers/index.tsx
+++ b/source/SIL.AppBuilder.Portal.Frontend/src/ui/routes/project/reviewers/index.tsx
@@ -3,9 +3,11 @@ import * as React from 'react';
 import { translate, InjectedTranslateProps as i18nProps } from 'react-i18next';
 import { compose } from 'recompose';
 import { ProjectAttributes } from '@data/models/project';
+import { ResourceObject } from 'jsonapi-typescript';
+import { PROJECTS_TYPE } from '@data';
 
 interface Params {
-  project: JSONAPI<ProjectAttributes>;
+  project: ResourceObject<PROJECTS_TYPE, ProjectAttributes>;
 }
 
 type IProps =

--- a/source/SIL.AppBuilder.Portal.Frontend/src/ui/routes/project/settings/index.tsx
+++ b/source/SIL.AppBuilder.Portal.Frontend/src/ui/routes/project/settings/index.tsx
@@ -4,9 +4,11 @@ import { translate, InjectedTranslateProps as i18nProps } from 'react-i18next';
 import { compose } from 'recompose';
 import { ProjectAttributes } from '@data/models/project';
 import { Checkbox } from 'semantic-ui-react';
+import { ResourceObject } from 'jsonapi-typescript';
+import { PROJECTS_TYPE } from '@data';
 
 interface Params {
-  project: JSONAPI<ProjectAttributes>;
+  project: ResourceObject<PROJECTS_TYPE, ProjectAttributes>;
 }
 
 type IProps =

--- a/source/SIL.AppBuilder.Portal.Frontend/src/ui/routes/project/with-data.tsx
+++ b/source/SIL.AppBuilder.Portal.Frontend/src/ui/routes/project/with-data.tsx
@@ -2,7 +2,7 @@ import * as React from 'react';
 import { compose } from 'recompose';
 import { withData as withOrbit, WithDataProps } from 'react-orbitjs';
 
-import { query, defaultSourceOptions, defaultOptions } from '@data';
+import { query, defaultSourceOptions, defaultOptions, PROJECTS_TYPE } from '@data';
 
 import { TYPE_NAME as PROJECT, ProjectAttributes } from '@data/models/project';
 import { PLURAL_NAME as PRODUCTS } from '@data/models/product';
@@ -10,6 +10,7 @@ import { TYPE_NAME as ORGANIZATION } from '@data/models/organization';
 import { TYPE_NAME as GROUP } from '@data/models/group';
 
 import { PageLoader as Loader } from '@ui/components/loaders';
+import { ResourceObject } from 'jsonapi-typescript';
 
 const mapNetworkToProps = (passedProps) => {
   const { match } = passedProps;
@@ -39,8 +40,8 @@ const mapRecordsToProps = (passedProps) => {
 };
 
 interface IProps {
-  project: JSONAPI<ProjectAttributes>;
-  projectFromCache: JSONAPI<ProjectAttributes>;
+  project: ResourceObject<PROJECTS_TYPE, ProjectAttributes>;
+  projectFromCache: ResourceObject<PROJECTS_TYPE, ProjectAttributes>;
 }
 
 export function withData<T>(WrappedComponent) {

--- a/source/SIL.AppBuilder.Portal.Frontend/src/ui/routes/project/with-project-operations.tsx
+++ b/source/SIL.AppBuilder.Portal.Frontend/src/ui/routes/project/with-project-operations.tsx
@@ -4,15 +4,16 @@ import { compose } from 'recompose';
 import { withTranslations, i18nProps } from '@lib/i18n';
 import { withData, WithDataProps } from 'react-orbitjs';
 import { TYPE_NAME as PROJECT, ProjectAttributes} from '@data/models/project';
-import { attributesFor, defaultOptions } from '@data';
+import { attributesFor, defaultOptions, PROJECTS_TYPE } from '@data';
 
 import * as toast from '@lib/toast';
+import { ResourceObject } from 'jsonapi-typescript';
 
 export function withProjectOperations(WrappedComponent) {
 
   class DataWrapper extends React.Component<WithDataProps & i18nProps> {
 
-    toggleArchiveProject = async (project: JSONAPI<ProjectAttributes>) => {
+    toggleArchiveProject = async (project: ResourceObject<PROJECTS_TYPE, ProjectAttributes>) => {
 
       const { updateStore, t } = this.props;
       const { dateArchived } = attributesFor(project);

--- a/source/SIL.AppBuilder.Portal.Frontend/src/ui/routes/tasks/index.tsx
+++ b/source/SIL.AppBuilder.Portal.Frontend/src/ui/routes/tasks/index.tsx
@@ -21,7 +21,7 @@ import { ResourceObject } from 'jsonapi-typescript';
 export const pathName = '/tasks';
 
 export interface IOwnProps {
-  tasks: ResourceObject<TASKS_TYPE, TaskAttributes>[];
+  tasks: Array<ResourceObject<TASKS_TYPE, TaskAttributes>>;
 }
 
 export type IProps =

--- a/source/SIL.AppBuilder.Portal.Frontend/src/ui/routes/tasks/index.tsx
+++ b/source/SIL.AppBuilder.Portal.Frontend/src/ui/routes/tasks/index.tsx
@@ -6,7 +6,7 @@ import { Container, Icon, Button } from 'semantic-ui-react';
 import { uuid } from '@orbit/utils';
 import { withData, WithDataProps } from 'react-orbitjs';
 
-import { query } from '@data';
+import { query, TASKS_TYPE } from '@data';
 import { withStubbedDevData } from '@data/with-stubbed-dev-data';
 import { TaskAttributes, TYPE_NAME as TASKS } from '@data/models/task';
 import { withTranslations, i18nProps } from '@lib/i18n';
@@ -16,11 +16,12 @@ import { withLayout } from '@ui/components/layout';
 
 import './tasks.scss';
 import Row from './row';
+import { ResourceObject } from 'jsonapi-typescript';
 
 export const pathName = '/tasks';
 
 export interface IOwnProps {
-  tasks: Array<JSONAPI<TaskAttributes>>;
+  tasks: ResourceObject<TASKS_TYPE, TaskAttributes>[];
 }
 
 export type IProps =

--- a/source/SIL.AppBuilder.Portal.Frontend/src/ui/routes/tasks/row.tsx
+++ b/source/SIL.AppBuilder.Portal.Frontend/src/ui/routes/tasks/row.tsx
@@ -14,12 +14,14 @@ import { UserAttributes } from '@data/models/user';
 
 import ProductIcon from '@ui/components/product-icon';
 import { RectLoader as Loader } from '@ui/components/loaders';
+import { ResourceObject } from 'jsonapi-typescript';
+import { TASKS_TYPE, PRODUCTS_TYPE, PROJECTS_TYPE, USERS_TYPE } from '@data';
 
 export interface IOwnProps {
-  task: JSONAPI<TaskAttributes>;
-  product: JSONAPI<ProductAttributes>;
-  project: JSONAPI<ProjectAttributes>;
-  assignedTo: JSONAPI<UserAttributes>;
+  task: ResourceObject<TASKS_TYPE, TaskAttributes>;
+  product: ResourceObject<PRODUCTS_TYPE, ProductAttributes>;
+  project: ResourceObject<PROJECTS_TYPE, ProjectAttributes>;
+  assignedTo: ResourceObject<USERS_TYPE, UserAttributes>;
   cellClasses: string;
   cellSecondaryClasses: string;
 }

--- a/source/SIL.AppBuilder.Portal.Frontend/src/ui/routes/users/edit/form/index.tsx
+++ b/source/SIL.AppBuilder.Portal.Frontend/src/ui/routes/users/edit/form/index.tsx
@@ -6,11 +6,12 @@ import { translate, InjectedTranslateProps as i18nProps } from 'react-i18next';
 import TimezonePicker from 'react-timezone';
 
 import { UserAttributes } from '@data/models/user';
-import { idFor } from '@data';
+import { idFor, USERS_TYPE } from '@data';
+import { ResourceObject } from 'jsonapi-typescript';
 
 export interface IProps {
-  user: JSONAPI<UserAttributes>;
-  currentUser: JSONAPI<UserAttributes>;
+  user: ResourceObject<USERS_TYPE, UserAttributes>;
+  currentUser: ResourceObject<USERS_TYPE, UserAttributes>;
   onSubmit: (data: IState) => Promise<void>;
 }
 

--- a/source/SIL.AppBuilder.Portal.Frontend/src/ui/routes/users/edit/index.tsx
+++ b/source/SIL.AppBuilder.Portal.Frontend/src/ui/routes/users/edit/index.tsx
@@ -6,19 +6,20 @@ import { Container } from 'semantic-ui-react';
 import { withData as withOrbit, WithDataProps } from 'react-orbitjs';
 
 import * as toast from '@lib/toast';
-import { idFor, defaultOptions } from '@data';
+import { idFor, defaultOptions, USERS_TYPE } from '@data';
 import { UserAttributes, TYPE_NAME } from '@data/models/user';
 import { withCurrentUser } from '@data/containers/with-current-user';
 
 import EditProfileForm from './form';
 import { withData } from './with-data';
 import './profile.scss';
+import { ResourceObject } from 'jsonapi-typescript';
 
 export const pathName = '/users/:id/edit';
 
 export interface IOwnProps {
-  user: JSONAPI<UserAttributes>;
-  currentUser: JSONAPI<UserAttributes>;
+  user: ResourceObject<USERS_TYPE, UserAttributes>;
+  currentUser: ResourceObject<USERS_TYPE, UserAttributes>;
 }
 
 export type IProps =

--- a/source/SIL.AppBuilder.Portal.Frontend/src/ui/routes/users/edit/with-data.tsx
+++ b/source/SIL.AppBuilder.Portal.Frontend/src/ui/routes/users/edit/with-data.tsx
@@ -38,7 +38,7 @@ export function withData(WrappedComponent) {
   class DataWrapper extends React.Component<IProps> {
     render() {
       const { user } = this.props;
-      
+
       if (!user) {
         return <Loader />;
       }

--- a/source/SIL.AppBuilder.Portal.Frontend/src/ui/routes/users/edit/with-data.tsx
+++ b/source/SIL.AppBuilder.Portal.Frontend/src/ui/routes/users/edit/with-data.tsx
@@ -1,6 +1,7 @@
 import * as React from 'react';
 import { compose } from 'recompose';
 import { match as Match, Redirect } from 'react-router';
+import { Document, ResourceObject, SingleResourceDoc } from 'jsonapi-typescript';
 
 import { query, defaultOptions } from '@data';
 import { TYPE_NAME as USER, UserAttributes } from '@data/models/user';
@@ -16,7 +17,7 @@ interface PassedProps {
 }
 
 interface IOwnProps {
-  user: JSONAPIDocument<UserAttributes>;
+  user: SingleResourceDoc<'users', UserAttributes>;
 }
 
 type IProps =
@@ -37,7 +38,7 @@ export function withData(WrappedComponent) {
   class DataWrapper extends React.Component<IProps> {
     render() {
       const { user } = this.props;
-
+      
       if (!user) {
         return <Loader />;
       }

--- a/source/SIL.AppBuilder.Portal.Frontend/src/ui/routes/users/edit/with-data.tsx
+++ b/source/SIL.AppBuilder.Portal.Frontend/src/ui/routes/users/edit/with-data.tsx
@@ -3,7 +3,7 @@ import { compose } from 'recompose';
 import { match as Match, Redirect } from 'react-router';
 import { Document, ResourceObject, SingleResourceDoc } from 'jsonapi-typescript';
 
-import { query, defaultOptions } from '@data';
+import { query, defaultOptions, USERS_TYPE } from '@data';
 import { TYPE_NAME as USER, UserAttributes } from '@data/models/user';
 
 import { PageLoader as Loader } from '@ui/components/loaders';
@@ -17,7 +17,7 @@ interface PassedProps {
 }
 
 interface IOwnProps {
-  user: SingleResourceDoc<'users', UserAttributes>;
+  user: SingleResourceDoc<USERS_TYPE, UserAttributes>;
 }
 
 type IProps =

--- a/source/SIL.AppBuilder.Portal.Frontend/src/ui/routes/users/show/index.tsx
+++ b/source/SIL.AppBuilder.Portal.Frontend/src/ui/routes/users/show/index.tsx
@@ -5,15 +5,16 @@ import md5 from 'md5-hash';
 import { withTranslations, i18nProps } from '@lib/i18n';
 import { withData } from '../edit/with-data';
 import { UserAttributes } from '@data/models/user';
-import { attributesFor } from '@data';
+import { attributesFor, USERS_TYPE } from '@data';
 
 
 import './show.scss';
+import { ResourceObject } from 'jsonapi-typescript';
 
 export const pathName = '/users/:id';
 
 export interface IOwnProps {
-  user: JSONAPI<UserAttributes>;
+  user: ResourceObject<USERS_TYPE, UserAttributes>;
 }
 
 export type IProps =

--- a/source/SIL.AppBuilder.Portal.Frontend/tests/mocha.opts
+++ b/source/SIL.AppBuilder.Portal.Frontend/tests/mocha.opts
@@ -1,2 +1,2 @@
 {src,tests}/**/*-test.{ts,tsx}
---timeout 2000
+--timeout 10000

--- a/source/SIL.AppBuilder.Portal.Frontend/types/index.d.ts
+++ b/source/SIL.AppBuilder.Portal.Frontend/types/index.d.ts
@@ -24,18 +24,3 @@ interface Auth0JWT {
   gender: string;
   email: string;
 }
-
-
-// Resource
-declare interface JSONAPI<Attributes, Relationships = {}> {
-  id: string;
-  type: string;
-  attributes: Attributes;
-  relationships?: Relationships;
-};
-
-// Document
-declare interface JSONAPIDocument<Attributes, Relationships = {}> {
-  data: JSONAPI<Attributes, Relationships>;
-  included?: Array<JSONAPI<any, any>>;
-};

--- a/source/SIL.AppBuilder.Portal.Frontend/yarn.lock
+++ b/source/SIL.AppBuilder.Portal.Frontend/yarn.lock
@@ -3884,6 +3884,10 @@ json-stringify-safe@^5.0.1, json-stringify-safe@~5.0.1:
   version "5.0.1"
   resolved "https://registry.yarnpkg.com/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz#1296a2d58fd45f19a0f6ce01d65701e2c735b6eb"
 
+json-typescript@^1.0.0:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/json-typescript/-/json-typescript-1.0.1.tgz#9d71a17627a20a61dbbf504e33561030f4eefd7f"
+
 json3@^3.3.2:
   version "3.3.2"
   resolved "https://registry.yarnpkg.com/json3/-/json3-3.3.2.tgz#3c0434743df93e2f5c42aee7b19bcb483575f4e1"
@@ -3897,6 +3901,12 @@ json5@^1.0.1:
   resolved "https://registry.yarnpkg.com/json5/-/json5-1.0.1.tgz#779fb0018604fa854eacbf6252180d83543e3dbe"
   dependencies:
     minimist "^1.2.0"
+
+jsonapi-typescript@^0.0.9:
+  version "0.0.9"
+  resolved "https://registry.yarnpkg.com/jsonapi-typescript/-/jsonapi-typescript-0.0.9.tgz#3a1f78233e36935fcb19db80d2755a7f6454a4ad"
+  dependencies:
+    json-typescript "^1.0.0"
 
 jsonfile@^4.0.0:
   version "4.0.0"


### PR DESCRIPTION
Comparison of type errors:

master:
```
$ ./node_modules/.bin/tsc --noEmit | grep "/" | wc -l
94
```

this branch:
```
$ ./node_modules/.bin/tsc --noEmit | grep "/" | wc -l
86
```

Not much of a difference in type errors, but, we have the benefit of not having to maintain types for JSONAPI anymore. :)