### PR TITLE
Project Creation groups not restrictive enough

### DIFF
--- a/source/OptimaJet.DWKit.StarterApplication/BackendServicesExtension.cs
+++ b/source/OptimaJet.DWKit.StarterApplication/BackendServicesExtension.cs
@@ -39,6 +39,7 @@ namespace OptimaJet.DWKit.StarterApplication
             services.AddScoped<IEntityRepository<User>, UserRepository>();
             services.AddScoped<IEntityRepository<Group>, GroupRepository>();
             services.AddScoped<IEntityRepository<Project>, ProjectRepository>();
+            services.AddScoped<IEntityRepository<Organization>, OrganizationRepository>();
             services.AddScoped<IEntityRepository<OrganizationInviteRequest>, OrganizationInviteRequestRepository>();
             services.AddScoped<IResourceService<User>, UserService>();
             services.AddScoped<IResourceService<Organization>, OrganizationService>();
@@ -48,6 +49,8 @@ namespace OptimaJet.DWKit.StarterApplication
             services.AddScoped<UserRepository>();
             services.AddScoped<GroupRepository>();
             services.AddScoped<ProjectRepository>();
+            services.AddScoped<OrganizationRepository>();
+            services.AddScoped<CurrentUserRepository>();
 
             services.AddScoped<UserService>();
             services.AddScoped<OrganizationService>();

--- a/source/OptimaJet.DWKit.StarterApplication/Repositories/CurrentUserRepository.cs
+++ b/source/OptimaJet.DWKit.StarterApplication/Repositories/CurrentUserRepository.cs
@@ -4,8 +4,10 @@ using JsonApiDotNetCore.Data;
 using JsonApiDotNetCore.Services;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Logging;
+using Optimajet.DWKit.StarterApplication.Data;
 using Optimajet.DWKit.StarterApplication.Models;
 using OptimaJet.DWKit.StarterApplication.Services;
+using static Microsoft.AspNetCore.Hosting.Internal.HostingApplication;
 
 namespace OptimaJet.DWKit.StarterApplication.Repositories
 {
@@ -19,14 +21,27 @@ namespace OptimaJet.DWKit.StarterApplication.Repositories
             ICurrentUserContext currentUserContext
         ) : base(loggerFactory, jsonApiContext, contextResolver)
         {
+            this.DBContext = (AppDbContext)contextResolver.GetContext();
             this.CurrentUserContext = currentUserContext;
         }
 
+        public AppDbContext DBContext { get; }
         public ICurrentUserContext CurrentUserContext { get; }
 
+        // memoize once per local thread,
+        // since the current user can't change in a single request
+        // this should be ok.
         public async Task<User> GetCurrentUser()
         {
             var auth0Id = this.CurrentUserContext.Auth0Id;
+
+            var userFromResult = this.DBContext
+                .Users.Local
+                .FirstOrDefault(u => u.ExternalId.Equals(auth0Id));
+
+            if (userFromResult != null) {
+                return await Task.FromResult(userFromResult);
+            }
 
             var currentUser = await base.Get()
                 .Where(user => user.ExternalId.Equals(auth0Id))

--- a/source/OptimaJet.DWKit.StarterApplication/Repositories/CurrentUserRepository.cs
+++ b/source/OptimaJet.DWKit.StarterApplication/Repositories/CurrentUserRepository.cs
@@ -1,0 +1,38 @@
+using System.Linq;
+using System.Threading.Tasks;
+using JsonApiDotNetCore.Data;
+using JsonApiDotNetCore.Services;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging;
+using Optimajet.DWKit.StarterApplication.Models;
+using OptimaJet.DWKit.StarterApplication.Services;
+
+namespace OptimaJet.DWKit.StarterApplication.Repositories
+{
+    public class CurrentUserRepository : DefaultEntityRepository<User> 
+    {
+        // NOTE: this repository MUST not rely on any other repositories or services
+        public CurrentUserRepository(
+            ILoggerFactory loggerFactory,
+            IJsonApiContext jsonApiContext,
+            IDbContextResolver contextResolver,
+            ICurrentUserContext currentUserContext
+        ) : base(loggerFactory, jsonApiContext, contextResolver)
+        {
+            this.CurrentUserContext = currentUserContext;
+        }
+
+        public ICurrentUserContext CurrentUserContext { get; }
+
+        public async Task<User> GetCurrentUser()
+        {
+            var auth0Id = this.CurrentUserContext.Auth0Id;
+
+            var currentUser = await base.Get()
+                .Where(user => user.ExternalId.Equals(auth0Id))
+                .FirstOrDefaultAsync();
+
+            return currentUser;
+        }
+    }
+}

--- a/source/OptimaJet.DWKit.StarterApplication/Repositories/OrganizationRepository.cs
+++ b/source/OptimaJet.DWKit.StarterApplication/Repositories/OrganizationRepository.cs
@@ -1,0 +1,49 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using JsonApiDotNetCore.Data;
+using JsonApiDotNetCore.Internal.Query;
+using JsonApiDotNetCore.Services;
+using Microsoft.Extensions.Logging;
+using Optimajet.DWKit.StarterApplication.Models;
+using OptimaJet.DWKit.StarterApplication.Services;
+using static OptimaJet.DWKit.StarterApplication.Utility.IEnumerableExtensions;
+using static OptimaJet.DWKit.StarterApplication.Utility.RepositoryExtensions;
+
+namespace OptimaJet.DWKit.StarterApplication.Repositories
+{
+    public class OrganizationRepository : ControllerRepository<Organization>
+    {
+        public CurrentUserRepository CurrentUserRepository { get; }
+
+
+        public OrganizationRepository(
+            ILoggerFactory loggerFactory,
+            IJsonApiContext jsonApiContext,
+            CurrentUserRepository currentUserRepository,
+            IDbContextResolver contextResolver
+            ) : base(loggerFactory, jsonApiContext, contextResolver)
+        {
+            this.CurrentUserRepository = currentUserRepository;
+        }
+        public override IQueryable<Organization> Filter(IQueryable<Organization> query, FilterQuery filterQuery)
+        {
+            var attribute = filterQuery.Attribute;
+            var value = filterQuery.Value;
+            var isScopeToUser = attribute.Equals("scope-to-current-user", StringComparison.OrdinalIgnoreCase);
+
+            if (isScopeToUser) {
+                var currentUser = CurrentUserRepository.GetCurrentUser().Result;
+
+                var orgIds = currentUser.OrganizationIds.OrEmpty();
+
+                var scopedToUser = query.Where(organization => orgIds.Contains(organization.Id));
+
+                // return base.Filter(scopedToUser, filterQuery);
+                return scopedToUser;
+            }
+
+            return base.Filter(query, filterQuery);
+        }
+    }
+}

--- a/source/SIL.AppBuilder.Portal.Frontend/.editorconfig
+++ b/source/SIL.AppBuilder.Portal.Frontend/.editorconfig
@@ -1,0 +1,1 @@
+../../.editorconfig

--- a/source/SIL.AppBuilder.Portal.Frontend/src/data/containers/wait-for.tsx
+++ b/source/SIL.AppBuilder.Portal.Frontend/src/data/containers/wait-for.tsx
@@ -10,7 +10,7 @@ export function waitFor<TWrappedProps>(resultKey: string, asyncFn: (props) => Pr
       }
 
       componentDidMount() {
-        this.runAsync();    
+        this.runAsync();
       }
 
       runAsync = async () => {
@@ -25,5 +25,5 @@ export function waitFor<TWrappedProps>(resultKey: string, asyncFn: (props) => Pr
     }
 
     return WaitForWrapper;
-  }
+  };
 }

--- a/source/SIL.AppBuilder.Portal.Frontend/src/data/containers/wait-for.tsx
+++ b/source/SIL.AppBuilder.Portal.Frontend/src/data/containers/wait-for.tsx
@@ -1,0 +1,29 @@
+import * as React from 'react';
+
+export function waitFor<TWrappedProps>(resultKey: string, asyncFn: (props) => Promise<any>) {
+  return WrappedComponent => {
+    class WaitForWrapper extends React.Component<TWrappedProps> {
+      constructor(props) {
+        super(props);
+
+        this.state = {};
+      }
+
+      componentDidMount() {
+        this.runAsync();    
+      }
+
+      runAsync = async () => {
+        const result = await asyncFn(this.props);
+
+        this.setState({ [resultKey]: result });
+      }
+
+      render() {
+        return <WrappedComponent { ...this.state } { ...this.props } />;
+      }
+    }
+
+    return WaitForWrapper;
+  }
+}

--- a/source/SIL.AppBuilder.Portal.Frontend/src/data/containers/with-current-organization.tsx
+++ b/source/SIL.AppBuilder.Portal.Frontend/src/data/containers/with-current-organization.tsx
@@ -57,7 +57,10 @@ export function withCurrentOrganization(InnerComponent) {
 
   return compose(
     connect(mapStateToProps),
-    withData(mapRecordsToProps)
+    branch(
+      ({ currentOrganizationId: id }) => id && id.length > 0,
+      withData(mapRecordsToProps)
+    )
   )(WrapperClass);
 }
 

--- a/source/SIL.AppBuilder.Portal.Frontend/src/data/containers/with-current-organization.tsx
+++ b/source/SIL.AppBuilder.Portal.Frontend/src/data/containers/with-current-organization.tsx
@@ -64,8 +64,8 @@ export function requireOrganizationToBeSelected(InnerComponent) {
     (props: IProvidedProps) => props.currentOrganizationId === '',
     () => () => {
       toast.warning('An Organization must be selected to view this page');
-      
-      return <Redirect to={'/'} push={true} />
+
+      return <Redirect to={'/'} push={true} />;
     }
   )(InnerComponent);
 }

--- a/source/SIL.AppBuilder.Portal.Frontend/src/data/containers/with-current-organization.tsx
+++ b/source/SIL.AppBuilder.Portal.Frontend/src/data/containers/with-current-organization.tsx
@@ -10,6 +10,8 @@ import { ORGANIZATIONS_TYPE } from '@data';
 
 import { buildFindRecord } from '@data/store-helpers';
 import * as toast from '@lib/toast';
+import { withTranslations } from '@lib/i18n';
+import { i18nProps } from 'react-i18next/src/I18n';
 
 export interface IProvidedProps {
   currentOrganizationId: string | number;
@@ -60,12 +62,16 @@ export function withCurrentOrganization(InnerComponent) {
 }
 
 export function requireOrganizationToBeSelected(InnerComponent) {
-  return branch(
-    (props: IProvidedProps) => props.currentOrganizationId === '',
-    () => () => {
-      toast.warning('An Organization must be selected to view this page');
+  return compose(
+    withTranslations,
+    branch(
+      (props: IProvidedProps) => props.currentOrganizationId === '',
+      () => ({ t }: any) => {
 
-      return <Redirect to={'/'} push={true} />;
-    }
+        toast.warning(t('errors.orgMustBeSelected'));
+
+        return <Redirect to={'/'} push={true} />;
+      }
+    )
   )(InnerComponent);
 }

--- a/source/SIL.AppBuilder.Portal.Frontend/src/data/containers/with-current-organization.tsx
+++ b/source/SIL.AppBuilder.Portal.Frontend/src/data/containers/with-current-organization.tsx
@@ -1,13 +1,15 @@
 import * as React from 'react';
 import { withData } from 'react-orbitjs';
 import { connect } from 'react-redux';
-import { compose } from 'recompose';
+import { compose, branch } from 'recompose';
 import { ResourceObject } from 'jsonapi-typescript';
+import { Redirect } from 'react-router';
 
 import { OrganizationAttributes, TYPE_NAME } from '../models/organization';
 import { ORGANIZATIONS_TYPE } from '@data';
 
 import { buildFindRecord } from '@data/store-helpers';
+import * as toast from '@lib/toast';
 
 export interface IProvidedProps {
   currentOrganizationId: string | number;
@@ -55,4 +57,15 @@ export function withCurrentOrganization(InnerComponent) {
     connect(mapStateToProps),
     withData(mapRecordsToProps)
   )(WrapperClass);
+}
+
+export function requireOrganizationToBeSelected(InnerComponent) {
+  return branch(
+    (props: IProvidedProps) => props.currentOrganizationId === '',
+    () => () => {
+      toast.warning('An Organization must be selected to view this page');
+      
+      return <Redirect to={'/'} push={true} />
+    }
+  )(InnerComponent);
 }

--- a/source/SIL.AppBuilder.Portal.Frontend/src/data/containers/with-current-organization.tsx
+++ b/source/SIL.AppBuilder.Portal.Frontend/src/data/containers/with-current-organization.tsx
@@ -58,7 +58,7 @@ export function withCurrentOrganization(InnerComponent) {
   return compose(
     connect(mapStateToProps),
     branch(
-      ({ currentOrganizationId: id }) => id && id.length > 0,
+      ({ currentOrganizationId: id }) => id && `${id}`.length > 0,
       withData(mapRecordsToProps)
     )
   )(WrapperClass);

--- a/source/SIL.AppBuilder.Portal.Frontend/src/data/containers/with-current-user.tsx
+++ b/source/SIL.AppBuilder.Portal.Frontend/src/data/containers/with-current-user.tsx
@@ -20,6 +20,7 @@ import { withTranslations, i18nProps } from '@lib/i18n';
 
 import * as toast from '@lib/toast';
 import { attributesFor } from '@data/helpers';
+import { ServerError } from '@data/errors/server-error';
 
 type UserPayload = SingleResourceDoc<USERS_TYPE, UserAttributes>;
 
@@ -52,17 +53,6 @@ const defaultOptions = {
 };
 
 
-class ServerError extends Error {
-  status: number;
-  text: string;
-
-  constructor(status, text) {
-    super(text);
-
-    this.status = status;
-    this.text = text;
-  }
-}
 
 // TODO: store the attempted URL so that after login,
 //     we can navigate back.
@@ -132,11 +122,11 @@ export function withCurrentUser(opts = {}) {
 
           if (status === 403 || status === 401) {
             const errorJson = await tryParseJson(response);
-            const error = firstError(errorJson).title;
+            const errorTitle = firstError(errorJson).title;
             const defaultMessage = unauthorized ? t('errors.notAuthorized') : t('errors.userForbidden');
 
             deleteToken();
-            throw new Error(error || defaultMessage);
+            throw new Error(errorTitle || defaultMessage);
           }
 
           if (status >= 500) {

--- a/source/SIL.AppBuilder.Portal.Frontend/src/data/containers/with-filtering.tsx
+++ b/source/SIL.AppBuilder.Portal.Frontend/src/data/containers/with-filtering.tsx
@@ -121,6 +121,10 @@ export function withFiltering(opts: IFilterOptions = {}) {
         switch(filter.value) {
           case 'isnull:': return { ...filter, attribute, value: null };
           case 'isnotnull:': return { ...filter, attribute, value: '', op: 'gt' };
+          // TODO: write a mapping for like for locale query
+          // TODO: also consider a different scheme of mapping remote filtering
+          //       with local filtering
+          // case 'like:': return { ...filter, attribute, value:}
           default: return { ...filter, attribute };
         }
       }

--- a/source/SIL.AppBuilder.Portal.Frontend/src/data/containers/with-filtering.tsx
+++ b/source/SIL.AppBuilder.Portal.Frontend/src/data/containers/with-filtering.tsx
@@ -13,7 +13,7 @@ export interface IFilter {
 export interface IProvidedProps {
   filters: IFilter[];
   updateFilter: (filter: IFilter) => void;
-  applyFilter: (builder: FindRecordsTerm, onCache?: boolean) => FindRecordsTerm;
+  applyFilter: (builder: FindRecordsTerm, onCache?: boolean, ignoreRequired?: boolean) => FindRecordsTerm;
   removeFilter: (filter: IFilter | string) => void;
 }
 
@@ -97,14 +97,14 @@ export function withFiltering(opts: IFilterOptions = {}) {
       //       these are equivalent.
       //       this technical limitation also stems from the fact that all values
       //       are strings when sent across the network.
-      applyFilter = (builder: FindRecordsTerm, onCache = false): FindRecordsTerm => {
+      applyFilter = (builder: FindRecordsTerm, onCache = false, ignoreRequired = false): FindRecordsTerm => {
         const { filters, options } = this.state;
 
         if (isEmpty(filters) && isEmpty(options.requiredFilters)) {
           return builder;
         }
 
-        const allFilters = [ ...filters, ...options.requiredFilters ];
+        const allFilters = [ ...filters, ...(ignoreRequired ? [] : options.requiredFilters) ];
         const filtersToApply = onCache ? allFilters.map(this._filterOperationMap) : allFilters;
 
         return builder.filter(...filtersToApply);

--- a/source/SIL.AppBuilder.Portal.Frontend/src/data/containers/with-filtering.tsx
+++ b/source/SIL.AppBuilder.Portal.Frontend/src/data/containers/with-filtering.tsx
@@ -74,8 +74,8 @@ export function withFiltering(opts: IFilterOptions = {}) {
 
         const newFilters = filters.filter(currentFilter => {
           return currentFilter.attribute !== filter.attribute;
-        })
-        
+        });
+
         newFilters.push(filter);
 
         this.setState({ filters: newFilters });

--- a/source/SIL.AppBuilder.Portal.Frontend/src/data/containers/with-filtering.tsx
+++ b/source/SIL.AppBuilder.Portal.Frontend/src/data/containers/with-filtering.tsx
@@ -74,7 +74,9 @@ export function withFiltering(opts: IFilterOptions = {}) {
 
         const newFilters = filters.filter(currentFilter => {
           return currentFilter.attribute !== filter.attribute;
-        }).push(filter);
+        })
+        
+        newFilters.push(filter);
 
         this.setState({ filters: newFilters });
       }
@@ -86,6 +88,8 @@ export function withFiltering(opts: IFilterOptions = {}) {
         const newFiletrs = filters.filter(currentFilter => {
           return currentFilter.attribute !== attrToRemove;
         });
+
+        this.setState({ filters: newFiletrs });
       }
 
       // NOTE: onCache signifies that that the filtering will only happen on the cache store.
@@ -104,7 +108,8 @@ export function withFiltering(opts: IFilterOptions = {}) {
           return builder;
         }
 
-        const allFilters = [ ...filters, ...(ignoreRequired ? [] : options.requiredFilters) ];
+        const required = ignoreRequired ? [] : options.requiredFilters;
+        const allFilters = [ ...filters, ...required ];
         const filtersToApply = onCache ? allFilters.map(this._filterOperationMap) : allFilters;
 
         return builder.filter(...filtersToApply);

--- a/source/SIL.AppBuilder.Portal.Frontend/src/data/errors/server-error.ts
+++ b/source/SIL.AppBuilder.Portal.Frontend/src/data/errors/server-error.ts
@@ -1,0 +1,11 @@
+export class ServerError extends Error {
+  status: number;
+  text: string;
+
+  constructor(status, text) {
+    super(text);
+
+    this.status = status;
+    this.text = text;
+  }
+}

--- a/source/SIL.AppBuilder.Portal.Frontend/src/data/helpers.ts
+++ b/source/SIL.AppBuilder.Portal.Frontend/src/data/helpers.ts
@@ -6,7 +6,7 @@ import {
   ResourceLinkage
 } from "jsonapi-typescript";
 
-import { idFromRecordIdentity } from './store-helpers';
+import { idFromRecordIdentity, localIdFromRecordIdentity } from './store-helpers';
 
 type IJsonApiPayload<TType extends string, TAttrs extends AttributesObject> =
   | SingleResourceDoc<TType, TAttrs>
@@ -31,6 +31,22 @@ export function idFor(payload: any): string {
   if (payload.data) { return idFor(payload.data); }
 
   return payload.id;
+}
+
+export function idsForRelationship(collection, relationshipName) {
+  const localIds = collection.map(record => {
+    const relationData = relationshipFor(record, relationshipName).data;
+
+    if (!relationData) { return; }
+
+    return localIdFromRecordIdentity(relationData);
+  }).filter(id => id);
+
+  return localIds;
+}
+
+export function recordsWithIdIn(collection, ids) {
+  return collection.filter(record => ids.includes(record.id));
 }
 
 export function relationshipsFor<

--- a/source/SIL.AppBuilder.Portal.Frontend/src/data/helpers.ts
+++ b/source/SIL.AppBuilder.Portal.Frontend/src/data/helpers.ts
@@ -6,7 +6,13 @@ import {
   ResourceLinkage
 } from "jsonapi-typescript";
 
-import { idFromRecordIdentity, localIdFromRecordIdentity } from './store-helpers';
+import Store from '@orbit/store';
+import { QueryBuilder, QueryOrExpression } from '@orbit/data';
+
+import {
+  idFromRecordIdentity, localIdFromRecordIdentity, IIdentityFromKeys,
+  modelNameFromRelationship
+} from './store-helpers';
 
 type IJsonApiPayload<TType extends string, TAttrs extends AttributesObject> =
   | SingleResourceDoc<TType, TAttrs>
@@ -94,6 +100,69 @@ export function isRelatedRecord<TType extends string = ''>(payload: any, record:
 
   return isRelatedTo(payload, record.type, id) || isRelatedTo(payload, record.type, record.id);
 }
+
+
+
+// NOTE:
+//   this function is pretty much 'filter'
+//   but hides the relational logic behind the filter.
+//   since a lot of logic in the app has to do with
+//   many-to-many / many-through-something-has-many relationships
+//   this function should be used to ensure that no extra data in the cache
+//   bleeds through what is intended to be seen.
+//
+// through is camelCase, and represents a relationship
+//
+// NOTE: this is a work in progress
+// TODO: finish this
+export async function cachedWithRelationThrough(
+  store: Store,
+  query: QueryOrExpression,
+  throughRelationshipName: string,
+  to: IIdentityFromKeys) {
+
+    const cacheResultsFromQuery = await store.cache.query(query);
+    // if something doesn't have attributes, it hasn't been fetched from the remote
+    const cacheResults = cacheResultsFromQuery.filter(r => r.attributes);
+
+    if (cacheResults.length === 0) { return []; }
+
+    const throughModelName = modelNameFromRelationship(cacheResults[0], throughRelationshipName);
+    const modelname = cacheResults[0].type;
+    const targetModelName = to.type;
+    // const joiningRelationName = inverseRelationshipOf(throughModelName, joiningRelationName);
+
+    const results: any = [];
+
+    const filterPromise = cacheResults.map(async cacheResult => {
+      const relation = relationshipFor(cacheResult, throughRelationshipName);
+      const { data: relationData } = relation;
+
+      if (!relationData) { return false; }
+
+      const joinRecords = await store.cache.query(q => q.findRelatedRecords(cacheResult, throughModelName));
+
+      if (joinRecords.length === 0) { return []; }
+
+      // TODO: make this lookup the other side of the relationship in case the
+      //       relationship name does not match the model name / type
+      const joinPromises = joinRecords.map(joinRecord => {
+        const isRelated = isRelatedRecord(joinRecord, to as any);
+
+        if (isRelated) {
+          results.push(cacheResult);
+        }
+      });
+
+    });
+
+    await Promise.all(filterPromise);
+
+  return results;
+}
+
+
+
 
 export function firstError(json): ErrorObject {
   if (!json || !json.errors) { return {}; }

--- a/source/SIL.AppBuilder.Portal.Frontend/src/data/index.ts
+++ b/source/SIL.AppBuilder.Portal.Frontend/src/data/index.ts
@@ -11,14 +11,16 @@ export {
   buildOptions,
   buildFindRelatedRecords,
   buildFindRelatedRecord,
-  localIdFromRecordIdentity
+  localIdFromRecordIdentity,
 } from './store-helpers';
 
 export {
   attributesFor, idFor,
   relationshipsFor, hasRelationship, isRelatedTo,
   relationshipFor, firstError,
-  isRelatedRecord
+  isRelatedRecord,
+  idsForRelationship,
+  recordsWithIdIn
 } from './helpers';
 
 export { withLoader } from './containers/with-loader';

--- a/source/SIL.AppBuilder.Portal.Frontend/src/data/schema.ts
+++ b/source/SIL.AppBuilder.Portal.Frontend/src/data/schema.ts
@@ -34,6 +34,9 @@ const schemaDefinition: SchemaSettings = {
         // unpresisted, send-only attribute for when a user accepts an
         // invite to create an organization
         token: { type: 'string' },
+
+        // filter-keys - throw-away
+        scopeToCurrentUser: { type: 'string' },
       },
       relationships: {
         owner: { type: 'hasOne', model: 'user', inverse: 'ownedOrganizations' },

--- a/source/SIL.AppBuilder.Portal.Frontend/src/data/store-helpers.ts
+++ b/source/SIL.AppBuilder.Portal.Frontend/src/data/store-helpers.ts
@@ -1,5 +1,6 @@
 import Store from '@orbit/store';
-import { QueryBuilder } from '@orbit/data';
+import { QueryBuilder, QueryOrExpression } from '@orbit/data';
+import { camelize } from '@orbit/utils';
 
 import { ResourceObject, AttributesObject } from 'jsonapi-typescript';
 
@@ -28,6 +29,28 @@ export function buildFindRecord(q: QueryBuilder, type: string, id: string) {
   const recordIdentity = recordIdentityFrom(id, type);
 
   return q.findRecord(recordIdentity);
+}
+
+export function modelNameFromRelationship(record: any, relationshipName: string) {
+  const recordModelName = record.type;
+
+  const { models } = schema;
+  const modelSchemaInfo = models[recordModelName];
+
+  const relationship = modelSchemaInfo.relationships[relationshipName];
+
+  const modelName = camelize(relationship.model);
+
+  return modelName;
+}
+
+export function inverseRelationshipOf(modelName: string, relationshipName) {
+  const { models } = schema;
+  const modelSchemaInfo = models[modelName];
+
+  const relationship = modelSchemaInfo.relationships[relationshipName];
+
+  return relationship.inverse;
 }
 
 export function buildOptions(options: IQueryOptions = {}, label?: string) {
@@ -79,7 +102,6 @@ export async function create<TAttrs, TRelationships>(
 
   return record;
 }
-
 
 // Example:
 // buildNew('projects', {
@@ -150,7 +172,7 @@ export function recordIdentityFrom(id: string, type: string) {
   return recordIdentityFromKeys({ keys: { remoteId: id }, type });
 }
 
-interface IIdentityFromKeys {
+export interface IIdentityFromKeys {
   type?: string;
   id?: string;
   keys?: any;

--- a/source/SIL.AppBuilder.Portal.Frontend/src/translations/locales/en-us.ts
+++ b/source/SIL.AppBuilder.Portal.Frontend/src/translations/locales/en-us.ts
@@ -17,6 +17,7 @@ export default {
 
   common: {
     search: 'Search',
+    noResults: 'No Results...',
     change: 'Change',
     cancel: 'Cancel',
     save: 'Save',

--- a/source/SIL.AppBuilder.Portal.Frontend/src/translations/locales/en-us.ts
+++ b/source/SIL.AppBuilder.Portal.Frontend/src/translations/locales/en-us.ts
@@ -140,6 +140,7 @@ export default {
       Please contact your organization administrator to discuss receiving an invite to
       an organization on Scriptoria.
     `,
+    orgMustBeSelected: `An organization must be selected to view this page`,
   },
 
   tasks: {

--- a/source/SIL.AppBuilder.Portal.Frontend/src/ui/components/inputs/group-select/with-data.tsx
+++ b/source/SIL.AppBuilder.Portal.Frontend/src/ui/components/inputs/group-select/with-data.tsx
@@ -12,7 +12,9 @@ import {
   isRelatedRecord,
   withLoader,
   buildFindRecord,
-  localIdFromRecordIdentity
+  localIdFromRecordIdentity,
+  idsForRelationship,
+  recordsWithIdIn
 } from '@data';
 
 import { TYPE_NAME as GROUP, GroupAttributes } from '@data/models/group';
@@ -64,21 +66,10 @@ export function withData(WrappedComponent) {
 
       let availableGroups: Array<ResourceObject<GROUPS_TYPE, GroupAttributes>>;
 
-      const groupIds = groupMembershipsForCurrentUser
-        .map(gm => {
-          const relationData = relationshipFor(gm, 'group').data;
-
-          if (!relationData) { return; }
-
-          return localIdFromRecordIdentity(relationData);
-        })
-        .filter(id => id);
+      const groupIds = idsForRelationship(groupMembershipsForCurrentUser, 'group');
 
       if (scopeToCurrentUser) {
-        availableGroups = groups
-          .filter(g => {
-            return g.id === selected || groupIds.includes(g.id);
-          });
+        availableGroups = recordsWithIdIn(groups, [selected, ...groupIds]);
       } else {
         availableGroups = groups;
       }

--- a/source/SIL.AppBuilder.Portal.Frontend/src/ui/components/inputs/group-select/with-data.tsx
+++ b/source/SIL.AppBuilder.Portal.Frontend/src/ui/components/inputs/group-select/with-data.tsx
@@ -3,26 +3,25 @@ import { compose } from 'recompose';
 import { withData as withOrbit, WithDataProps } from 'react-orbitjs';
 
 import {
-  query, defaultOptions,
   GROUPS_TYPE, GROUP_MEMBERSHIPS_TYPE, USERS_TYPE,
   buildFindRelatedRecords,
-  relationshipFor,
-  idFromRecordIdentity,
-  isRelatedTo,
   isRelatedRecord,
   withLoader,
-  buildFindRecord,
-  localIdFromRecordIdentity,
   idsForRelationship,
-  recordsWithIdIn
+  recordsWithIdIn,
+  buildFindRelatedRecord,
+  PROJECTS_TYPE,
+  ORGANIZATIONS_TYPE,
+  isRelatedTo
 } from '@data';
 
 import { TYPE_NAME as GROUP, GroupAttributes } from '@data/models/group';
 import { GroupMembershipAttributes } from '@data/models/group-membership';
 import { UserAttributes } from '@data/models/user';
 
-import { PageLoader as Loader } from '@ui/components/loaders';
 import { ResourceObject } from 'jsonapi-typescript';
+import { ProjectAttributes } from '@data/models/project';
+import { OrganizationAttributes } from '@data/models/organization';
 
 export interface IProvidedProps {
   groups: Array<ResourceObject<GROUPS_TYPE, GroupAttributes>>;
@@ -32,7 +31,8 @@ export interface IProvidedProps {
 interface IOwnProps {
   groups: Array<ResourceObject<GROUPS_TYPE, GroupAttributes>>;
   groupMembershipsForCurrentUser: Array<ResourceObject<GROUP_MEMBERSHIPS_TYPE, GroupMembershipAttributes>>;
-  scopeToCurrentUser: boolean;
+  scopeToCurrentUser?: boolean;
+  scopeToOrganization?: ResourceObject<ORGANIZATIONS_TYPE, OrganizationAttributes>;
   currentUser: ResourceObject<USERS_TYPE, UserAttributes>;
   selected: Id;
 }
@@ -43,7 +43,7 @@ type IProps =
 
 export function withData(WrappedComponent) {
   const mapRecordsToProps = (passedProps) => {
-    const { currentUser } = passedProps;
+    const { currentUser, project } = passedProps;
 
     return {
       // all groups available to the current user should have been fetch with the
@@ -59,7 +59,7 @@ export function withData(WrappedComponent) {
         groupMembershipsForCurrentUser,
         groups,
         currentUser,
-        scopeToCurrentUser,
+        scopeToCurrentUser, scopeToOrganization,
         selected,
         ...otherProps
       } = this.props;
@@ -72,6 +72,14 @@ export function withData(WrappedComponent) {
         availableGroups = recordsWithIdIn(groups, [selected, ...groupIds]);
       } else {
         availableGroups = groups;
+      }
+
+      if (scopeToOrganization) {
+        availableGroups = availableGroups.filter(group => {
+          if (group.id === selected) { return true; }
+
+          return isRelatedTo(group, 'owner', scopeToOrganization.id);
+        });
       }
 
       const disableSelection = (

--- a/source/SIL.AppBuilder.Portal.Frontend/src/ui/components/sidebar/header.tsx
+++ b/source/SIL.AppBuilder.Portal.Frontend/src/ui/components/sidebar/header.tsx
@@ -9,6 +9,7 @@ import { OrganizationAttributes } from '@data/models/organization';
 import { withCurrentOrganization } from '@data/containers/with-current-organization';
 import { ResourceObject } from 'jsonapi-typescript';
 import { ORGANIZATIONS_TYPE } from '@data';
+import { withTranslations } from '@lib/i18n';
 
 export interface IProps {
   closeSidebar: () => void;
@@ -72,5 +73,5 @@ class SidebarHeader extends React.Component<IProps & i18nProps> {
 
 export default compose(
   withCurrentOrganization,
-  translate('translations')
+  withTranslations
 )(SidebarHeader);

--- a/source/SIL.AppBuilder.Portal.Frontend/src/ui/components/sidebar/navigation.tsx
+++ b/source/SIL.AppBuilder.Portal.Frontend/src/ui/components/sidebar/navigation.tsx
@@ -13,18 +13,19 @@ export interface IProps {
 interface MenuItem {
   name: string;
   to: string;
+  tag: any;
   onClick: (e) => void;
   exact?: boolean;
   className?: string;
 }
 
-const MenuItem = ({ name, to, onClick, exact, className }: MenuItem) => {
+const MenuItem = ({ name, to, onClick, exact, className, tag }: MenuItem) => {
 
   return (
     <>
       <Menu.Item
         name={name}
-        as={NavLink}
+        as={tag || NavLink}
         to={to}
         exact
         activeClassName='active'
@@ -32,7 +33,7 @@ const MenuItem = ({ name, to, onClick, exact, className }: MenuItem) => {
       />
       <Menu.Item
         name={name}
-        as={NavLink}
+        as={tag || NavLink}
         to={to}
         activeClassName='active'
         onClick={onClick}
@@ -49,6 +50,7 @@ class Navigation extends React.Component<IProps & i18nProps> {
 
     const currentOrganizationId = getCurrentOrganizationId();
     const hasSelectedOrg = currentOrganizationId && currentOrganizationId.length > 0;
+    const allOrgsSelected = '' === currentOrganizationId;
 
     const { t, closeSidebar } = this.props;
 
@@ -98,9 +100,12 @@ class Navigation extends React.Component<IProps & i18nProps> {
         <hr />
 
         <MenuItem
+          className={allOrgsSelected && 'disabled'}
+          tag={allOrgsSelected ? 'span' : NavLink}
           name={t('sidebar.addProject')}
           to='/projects/new'
           onClick={closeSidebar} />
+        
 
         <hr />
 

--- a/source/SIL.AppBuilder.Portal.Frontend/src/ui/components/sidebar/navigation.tsx
+++ b/source/SIL.AppBuilder.Portal.Frontend/src/ui/components/sidebar/navigation.tsx
@@ -111,7 +111,7 @@ class Navigation extends React.Component<IProps & i18nProps> {
 
         <MenuItem
           name={t('opensource')}
-          to='open-source'
+          to='/open-source'
           className='m-t-lg'
           onClick={closeSidebar} />
       </Menu>

--- a/source/SIL.AppBuilder.Portal.Frontend/src/ui/components/sidebar/navigation.tsx
+++ b/source/SIL.AppBuilder.Portal.Frontend/src/ui/components/sidebar/navigation.tsx
@@ -13,19 +13,18 @@ export interface IProps {
 interface MenuItem {
   name: string;
   to: string;
-  tag: any;
   onClick: (e) => void;
   exact?: boolean;
   className?: string;
 }
 
-const MenuItem = ({ name, to, onClick, exact, className, tag }: MenuItem) => {
+const MenuItem = ({ name, to, onClick, exact, className }: MenuItem) => {
 
   return (
     <>
       <Menu.Item
         name={name}
-        as={tag || NavLink}
+        as={NavLink}
         to={to}
         exact
         activeClassName='active'
@@ -33,7 +32,7 @@ const MenuItem = ({ name, to, onClick, exact, className, tag }: MenuItem) => {
       />
       <Menu.Item
         name={name}
-        as={tag || NavLink}
+        as={NavLink}
         to={to}
         activeClassName='active'
         onClick={onClick}
@@ -99,13 +98,20 @@ class Navigation extends React.Component<IProps & i18nProps> {
 
         <hr />
 
-        <MenuItem
-          className={allOrgsSelected && 'disabled'}
-          tag={allOrgsSelected ? 'span' : NavLink}
-          name={t('sidebar.addProject')}
-          to='/projects/new'
-          onClick={closeSidebar} />
+        { allOrgsSelected && (
+          <Menu.Item
+            className={'disabled'}
+            to='/projects/new'>
+            <span>{t('sidebar.addProject')}</span>
+          </Menu.Item>
+        )}
 
+        { !allOrgsSelected && (
+          <MenuItem
+            name={t('sidebar.addProject')}
+            to='/projects/new'
+            onClick={closeSidebar} />
+        )}
 
         <hr />
 

--- a/source/SIL.AppBuilder.Portal.Frontend/src/ui/components/sidebar/navigation.tsx
+++ b/source/SIL.AppBuilder.Portal.Frontend/src/ui/components/sidebar/navigation.tsx
@@ -105,7 +105,7 @@ class Navigation extends React.Component<IProps & i18nProps> {
           name={t('sidebar.addProject')}
           to='/projects/new'
           onClick={closeSidebar} />
-        
+
 
         <hr />
 

--- a/source/SIL.AppBuilder.Portal.Frontend/src/ui/components/sidebar/org-switcher/__tests__/acceptance-test.ts
+++ b/source/SIL.AppBuilder.Portal.Frontend/src/ui/components/sidebar/org-switcher/__tests__/acceptance-test.ts
@@ -238,6 +238,8 @@ describe('Acceptance | Organization Switcher', () => {
       });
 
       it('hides the org switcher', () => {
+        // expect(switcher.selectedOrg).to.equal("SIL International");
+
         expect(app.isOrgSwitcherVisible).to.be.false;
       });
     });

--- a/source/SIL.AppBuilder.Portal.Frontend/src/ui/components/sidebar/org-switcher/__tests__/acceptance-test.ts
+++ b/source/SIL.AppBuilder.Portal.Frontend/src/ui/components/sidebar/org-switcher/__tests__/acceptance-test.ts
@@ -1,15 +1,12 @@
-import * as React from 'react';
 import { describe, beforeEach, it } from '@bigtest/mocha';
 import { visit, location } from '@bigtest/react';
 import { expect } from 'chai';
 
 import {
   setupApplicationTest, useFakeAuthentication,
-  setupRequestInterceptor, wait
-} from 'tests/helpers/index';
+  setupRequestInterceptor} from 'tests/helpers/index';
 
 import app from 'tests/helpers/pages/app';
-import { fakeAuth0Id } from 'tests/helpers/jwt';
 import switcher from './page';
 
 async function makeOrgSwitcherVisible() {

--- a/source/SIL.AppBuilder.Portal.Frontend/src/ui/components/sidebar/org-switcher/__tests__/acceptance-test.ts
+++ b/source/SIL.AppBuilder.Portal.Frontend/src/ui/components/sidebar/org-switcher/__tests__/acceptance-test.ts
@@ -4,7 +4,8 @@ import { expect } from 'chai';
 
 import {
   setupApplicationTest, useFakeAuthentication,
-  setupRequestInterceptor} from 'tests/helpers/index';
+  setupRequestInterceptor, fakeAuth0Id
+} from 'tests/helpers/index';
 
 import app from 'tests/helpers/pages/app';
 import switcher from './page';
@@ -19,32 +20,198 @@ async function makeOrgSwitcherVisible() {
   await app.openOrgSwitcher();
   expect(app.isOrgSwitcherVisible).to.be.true;
 }
+const lotsOfOrgs = [
+  {
+    type: 'organizations', id: 1,
+    attributes: {
+      name: 'SIL International'
+    }
+  }, {
+    type: 'organizations', id: 2,
+    attributes: {
+      name: 'DeveloperTown'
+    }
+  }, {
+    type: 'organizations', id: 3,
+    attributes: {
+      name: 'Kalaam Media'
+    }
+  }, {
+    type: 'organizations', id: 4,
+    attributes: {
+      name: 'The Ember Learning Team'
+    }
+  }, {
+    type: 'organizations', id: 5,
+    attributes: {
+      name: 'Blizzard Entertainment'
+    }
+  }, {
+    type: 'organizations', id: 5,
+    attributes: {
+      name: 'Linkedin'
+    }
+  }
+];
+
+const threeOrgs = [
+  {
+    type: 'organizations', id: 1,
+    attributes: {
+      name: 'SIL International'
+    }
+  }, {
+    type: 'organizations', id: 2,
+    attributes: {
+      name: 'DeveloperTown'
+    }
+  }, {
+    type: 'organizations', id: 3,
+    attributes: {
+      name: 'Kalaam Media'
+    }
+  }
+];
+
+const scenarios = {
+  userIsInLotsOfOrganizations() {
+    useFakeAuthentication({
+      data: {
+        id: 1,
+        type: 'users',
+        attributes: { id: 1, auth0Id: fakeAuth0Id, familyName: 'fake', givenName: 'fake' },
+        relationships: {
+          ['organization-memberships']: {
+            data: [
+              { id: 1, type: 'organization-memberships' },
+            ]
+          }
+        }
+      },
+      included: [
+        {
+          id: 1,
+          type: 'organization-memberships',
+          attributes: {},
+          relationships: {
+            user: { data: { id: 1, type: 'users' } },
+            organization: { data: { id: 1, type: 'organizations' } }
+          }
+        },
+        {
+          id: 2,
+          type: 'organization-memberships',
+          attributes: {},
+          relationships: {
+            user: { data: { id: 1, type: 'users' } },
+            organization: { data: { id: 2, type: 'organizations' } }
+          }
+        },
+        {
+          id: 3,
+          type: 'organization-memberships',
+          attributes: {},
+          relationships: {
+            user: { data: { id: 1, type: 'users' } },
+            organization: { data: { id: 3, type: 'organizations' } }
+          }
+        },
+        {
+          id: 4,
+          type: 'organization-memberships',
+          attributes: {},
+          relationships: {
+            user: { data: { id: 1, type: 'users' } },
+            organization: { data: { id: 4, type: 'organizations' } }
+          }
+        },
+        {
+          id: 5,
+          type: 'organization-memberships',
+          attributes: {},
+          relationships: {
+            user: { data: { id: 1, type: 'users' } },
+            organization: { data: { id: 4, type: 'organizations' } }
+          }
+        },
+        {
+          id: 1,
+          type: 'groups' ,
+          attributes: { name: 'Some Group' },
+          relationships: {
+            organization: { data: { id: 1, type: 'organizations' } }
+          }
+        },
+        ...lotsOfOrgs
+      ]
+    });
+  },
+  userIsIn3Organizations() {
+    useFakeAuthentication({
+      data: {
+        id: 1,
+        type: 'users',
+        attributes: { id: 1, auth0Id: fakeAuth0Id, familyName: 'fake', givenName: 'fake' },
+        relationships: {
+          ['organization-memberships']: {
+            data: [
+              { id: 1, type: 'organization-memberships' },
+            ]
+          }
+        }
+      },
+      included: [
+        {
+          id: 1,
+          type: 'organization-memberships',
+          attributes: {},
+          relationships: {
+            user: { data: { id: 1, type: 'users' } },
+            organization: { data: { id: 1, type: 'organizations' } }
+          }
+        },
+        {
+          id: 2,
+          type: 'organization-memberships',
+          attributes: {},
+          relationships: {
+            user: { data: { id: 1, type: 'users' } },
+            organization: { data: { id: 2, type: 'organizations' } }
+          }
+        },
+        {
+          id: 3,
+          type: 'organization-memberships',
+          attributes: {},
+          relationships: {
+            user: { data: { id: 1, type: 'users' } },
+            organization: { data: { id: 3, type: 'organizations' } }
+          }
+        },
+        {
+          id: 1,
+          type: 'groups' ,
+          attributes: { name: 'Some Group' },
+          relationships: {
+            organization: { data: { id: 1, type: 'organizations' } }
+          }
+        },
+        ...threeOrgs
+      ]
+    });
+  }
+};
 
 describe('Acceptance | Organization Switcher', () => {
   setupApplicationTest();
   setupRequestInterceptor();
 
   describe('The Current User is a member of multiple organizations', () => {
-    useFakeAuthentication();
+    scenarios.userIsIn3Organizations();
 
     beforeEach(function() {
       this.mockGet(200, '/organizations', {
-        data: [{
-          type: 'organizations', id: 1,
-          attributes: {
-            name: 'SIL International'
-          }
-        }, {
-          type: 'organizations', id: 2,
-          attributes: {
-            name: 'DeveloperTown'
-          }
-        }, {
-          type: 'organizations', id: 3,
-          attributes: {
-            name: 'Kalaam Media'
-          }
-        }]
+        data: [...threeOrgs]
       });
     });
 
@@ -77,41 +244,11 @@ describe('Acceptance | Organization Switcher', () => {
   });
 
   describe('The current user is a member of lots of organizations', () => {
-    useFakeAuthentication();
+    scenarios.userIsInLotsOfOrganizations();
 
     beforeEach(function() {
       this.mockGet(200, '/organizations', {
-        data: [{
-          type: 'organizations', id: 1,
-          attributes: {
-            name: 'SIL International'
-          }
-        }, {
-          type: 'organizations', id: 2,
-          attributes: {
-            name: 'DeveloperTown'
-          }
-        }, {
-          type: 'organizations', id: 3,
-          attributes: {
-            name: 'Kalaam Media'
-          }
-        }, {
-          type: 'organizations', id: 4,
-          attributes: {
-            name: 'The Ember Learning Team'
-          }
-        }, {
-          type: 'organizations', id: 5,
-          attributes: {
-            name: 'Blizzard Entertainment'
-          }
-        }, {
-          type: 'organizations', id: 5,
-          attributes: {
-            name: 'Linkedin'
-          }
-        }]
+        data: [...lotsOfOrgs]
       });
     });
 

--- a/source/SIL.AppBuilder.Portal.Frontend/src/ui/components/sidebar/org-switcher/__tests__/page.ts
+++ b/source/SIL.AppBuilder.Portal.Frontend/src/ui/components/sidebar/org-switcher/__tests__/page.ts
@@ -1,21 +1,17 @@
 import {
+  Interactor,
   interactor,
-  text,
   clickable,
   findAll,
   isPresent,
 } from '@bigtest/interactor';
 
-@interactor
-export class OrgSwitcherInteractor {
-  constructor(selector?: string) {}
-
-
+class OrgSwitcher {
   orgNames = findAll('[data-test-org-select-item]');
   selectOrg = clickable('[data-test-org-select-item]');
 
-  chooseOrganization(orgText: string) {
-    return this.when(() => {
+  chooseOrganization(this: Interactor, orgText: string) {
+    return this.when<HTMLElement>(() => {
       const el = this
         .$$('.item')
         .find(item => item.innerText.includes(orgText));
@@ -30,7 +26,11 @@ export class OrgSwitcherInteractor {
 
   selectAllOrg = clickable('[data-test-select-item-all-org]');
   isSearchVisible = isPresent('[data-test-org-switcher-search]');
-
 }
 
-export default new OrgSwitcherInteractor('[data-test-org-switcher]');
+
+export const OrgSwitcherInteractor = interactor(OrgSwitcher);
+
+export type TOrgSwitcherInteractor = OrgSwitcher & Interactor;
+
+export default new (OrgSwitcherInteractor as any)('[data-test-org-switcher]') as TOrgSwitcherInteractor;

--- a/source/SIL.AppBuilder.Portal.Frontend/src/ui/components/sidebar/org-switcher/__tests__/page.ts
+++ b/source/SIL.AppBuilder.Portal.Frontend/src/ui/components/sidebar/org-switcher/__tests__/page.ts
@@ -4,16 +4,20 @@ import {
   clickable,
   findAll,
   isPresent,
+  text,
 } from '@bigtest/interactor';
 
 class OrgSwitcher {
   orgNames = findAll('[data-test-org-select-item]');
   selectOrg = clickable('[data-test-org-select-item]');
 
+  selectedOrg = text('[data-test-org-select-item].active');
+
+
   chooseOrganization(this: Interactor, orgText: string) {
     return this.when<HTMLElement>(() => {
       const el = this
-        .$$('.item')
+        .$$('[data-test-org-select-item]')
         .find(item => item.innerText.includes(orgText));
 
         if (!el) {
@@ -21,9 +25,9 @@ class OrgSwitcher {
         }
 
         return el;
-    }).do(el => el.click());
+    })
+    .do(el => el.click());
   }
-
   selectAllOrg = clickable('[data-test-select-item-all-org]');
   isSearchVisible = isPresent('[data-test-org-switcher-search]');
 }

--- a/source/SIL.AppBuilder.Portal.Frontend/src/ui/components/sidebar/org-switcher/display.tsx
+++ b/source/SIL.AppBuilder.Portal.Frontend/src/ui/components/sidebar/org-switcher/display.tsx
@@ -38,10 +38,13 @@ class OrgSwitcherDisplay extends React.Component<IProps> {
       allOrgsSelected,
       searchTerm,
       didTypeInSearch,
-      selectOrganization
+      selectOrganization,
+      searchResults
     } = this.props;
 
-    const showSearch = organizations.length > 4 || !!searchTerm;
+    const showSearch = organizations.length > 4;
+    const results = searchResults || organizations;
+    const noResults = (!results || results.length === 0);
 
     return (
       <Menu
@@ -63,7 +66,7 @@ class OrgSwitcherDisplay extends React.Component<IProps> {
           </Menu.Item>
         )}
 
-        { organizations.map(organization => {
+        { results.map(organization => {
           const id = idFromRecordIdentity(organization as any);
 
           return (
@@ -73,6 +76,12 @@ class OrgSwitcherDisplay extends React.Component<IProps> {
               isActive={currentOrganizationId === id} />
           );
         })}
+
+        { noResults && (
+          <Menu.Item>
+            {t('common.noResults')}
+          </Menu.Item>
+        ) }
 
         <hr />
 

--- a/source/SIL.AppBuilder.Portal.Frontend/src/ui/components/sidebar/org-switcher/display.tsx
+++ b/source/SIL.AppBuilder.Portal.Frontend/src/ui/components/sidebar/org-switcher/display.tsx
@@ -3,18 +3,15 @@ import { Menu, Icon } from 'semantic-ui-react';
 import { WithDataProps } from 'react-orbitjs';
 import { InjectedTranslateProps as i18nProps } from 'react-i18next';
 
-import { OrganizationAttributes } from '@data/models/organization';
+import { idFromRecordIdentity } from '@data';
 import { IProvidedProps as WithCurrentOrgProps } from '@data/containers/with-current-organization';
 
-import Loader from '@ui/components/loaders/page';
-
+import { IProvidedDataProps } from './with-data';
 import Row from './row';
-import { ResourceObject } from 'jsonapi-typescript';
-import { ORGANIZATIONS_TYPE, idFromRecordIdentity } from '@data';
+import { IProvidedProps as IReduxProps } from './with-redux';
+import { IGivenProps } from './types';
 
 export interface IOwnProps {
-  organizations: Array<ResourceObject<ORGANIZATIONS_TYPE, OrganizationAttributes>>;
-  isLoading: boolean;
   searchByName: (name: string) => void;
   toggle: () => void;
   searchTerm: string;
@@ -24,9 +21,12 @@ export interface IOwnProps {
 }
 
 export type IProps =
+  & IGivenProps
+  & IReduxProps
   & IOwnProps
   & WithCurrentOrgProps
   & WithDataProps
+  & IProvidedDataProps
   & i18nProps;
 
 class OrgSwitcherDisplay extends React.Component<IProps> {

--- a/source/SIL.AppBuilder.Portal.Frontend/src/ui/components/sidebar/org-switcher/index.tsx
+++ b/source/SIL.AppBuilder.Portal.Frontend/src/ui/components/sidebar/org-switcher/index.tsx
@@ -1,102 +1,21 @@
-import * as React from 'react';
-import { compose } from 'recompose';
-import { connect } from 'react-redux';
-import { WithDataProps } from 'react-orbitjs';
-import { InjectedTranslateProps as i18nProps } from 'react-i18next';
+import { compose, withProps } from 'recompose';
 
-import { OrganizationAttributes } from '@data/models/organization';
 import { withCurrentOrganization, IProvidedProps as WithCurrentOrgProps } from '@data/containers/with-current-organization';
-import { debounce } from '@lib/debounce';
-import { setCurrentOrganization } from '@store/data';
-
-import { withFiltering, IProvidedProps as IFilterProps } from '@data/containers/with-filtering';
-
-import { withData } from './with-data';
-import Display from './display';
-import { ResourceObject } from 'jsonapi-typescript';
-import { ORGANIZATIONS_TYPE } from '@data';
 import { withTranslations } from '@lib/i18n';
 
-export interface IOwnProps {
-  organizations: Array<ResourceObject<ORGANIZATIONS_TYPE, OrganizationAttributes>>;
-  isLoading: boolean;
-  searchByName: (name: string) => void;
-  setCurrentOrganizationId: (id: Id) => void;
-  toggle: () => void;
-}
+import { withRedux } from './with-redux';
+import { withData } from './with-data';
+import { IGivenProps } from './types';
+import Display from './display';
+import { withCurrentUser } from '@data/containers/with-current-user';
 
-export type IProps =
-  & IOwnProps
-  & IFilterProps
-  & WithCurrentOrgProps
-  & WithDataProps
-  & i18nProps;
-
-
-const mapDispatchToProps = (dispatch) => ({
-  setCurrentOrganizationId: (id) => dispatch(setCurrentOrganization(id))
-});
-
-class OrgSwitcher extends React.Component<IProps> {
-  state = { searchTerm: '' };
-
-  selectOrganization = (id) => () => {
-    const { setCurrentOrganizationId, toggle } = this.props;
-    setCurrentOrganizationId(id);
-    toggle();
-  }
-
-  search = debounce(() => {
-    const { updateFilter } = this.props;
-    const { searchTerm } = this.state;
-
-    updateFilter({ attribute: 'name', value: `${searchTerm}*` });
-  }, 250);
-
-  didTypeInSearch = (e) => {
-    const searchTerm = e.target.value;
-
-    this.setState({ searchTerm }, this.search);
-  }
-
-  render() {
-    const {
-      t,
-      organizations,
-      currentOrganizationId,
-      isLoading
-    } = this.props;
-
-    const { searchTerm } = this.state;
-
-    const allOrgsSelected = '' === currentOrganizationId;
-    const orgs = organizations || [];
-
-    const displayProps = {
-      t,
-      isLoading,
-      allOrgsSelected,
-      currentOrganizationId,
-      organizations: orgs,
-      searchTerm,
-      didTypeInSearch: this.didTypeInSearch,
-      selectOrganization: this.selectOrganization,
-    };
-
-    return (
-      <Display { ...displayProps } />
-    );
-  }
-}
-
-export default compose(
+export default compose<IGivenProps, {}>(
+  withCurrentUser(),
   withTranslations,
-  connect(null, mapDispatchToProps),
+  withRedux,
   withCurrentOrganization,
-  withFiltering({
-    requiredFilters: [
-      { attribute: 'scope-to-current-user', value: 'isnull:' }
-    ]
-  }),
+  withProps(({ currentOrganizationId }: WithCurrentOrgProps) => ({
+    allOrgsSelected: '' === currentOrganizationId
+  })),
   withData,
-)(OrgSwitcher);
+)(Display);

--- a/source/SIL.AppBuilder.Portal.Frontend/src/ui/components/sidebar/org-switcher/index.tsx
+++ b/source/SIL.AppBuilder.Portal.Frontend/src/ui/components/sidebar/org-switcher/index.tsx
@@ -93,6 +93,10 @@ export default compose(
   withTranslations,
   connect(null, mapDispatchToProps),
   withCurrentOrganization,
-  withFiltering(),
+  withFiltering({
+    requiredFilters: [
+      { attribute: 'scope-to-current-user', value: 'isnull:' }
+    ]
+  }),
   withData,
 )(OrgSwitcher);

--- a/source/SIL.AppBuilder.Portal.Frontend/src/ui/components/sidebar/org-switcher/types.ts
+++ b/source/SIL.AppBuilder.Portal.Frontend/src/ui/components/sidebar/org-switcher/types.ts
@@ -1,0 +1,3 @@
+export interface IGivenProps {
+  toggle: () => void;
+}

--- a/source/SIL.AppBuilder.Portal.Frontend/src/ui/components/sidebar/org-switcher/with-data.tsx
+++ b/source/SIL.AppBuilder.Portal.Frontend/src/ui/components/sidebar/org-switcher/with-data.tsx
@@ -73,8 +73,12 @@ export function withData(WrappedComponent) {
       this.setState({ searchTerm }, this.search);
     }
 
+    // TODO: clean this up once
+    //       https://github.com/orbitjs/orbit/pull/525
+    //       is merged, where we'll be able to retrieve the query result
+    //       without local filtering. (so we can skip the cache query step)
     performSearch = async (searchTerm: string) => {
-      const { dataStore, applyFilter } = this.props;
+      const { dataStore } = this.props;
 
       await dataStore.query(q =>
         q
@@ -87,6 +91,7 @@ export function withData(WrappedComponent) {
       );
 
       const records = await dataStore.cache.query(q => q.findRecords(ORGANIZATION));
+      // TODO: MAY need to do a local filter on organizations that the current user owns
       const filtered = records.filter(record => {
         const { name } = attributesFor(record);
         if (!name) { return false; }

--- a/source/SIL.AppBuilder.Portal.Frontend/src/ui/components/sidebar/org-switcher/with-data.tsx
+++ b/source/SIL.AppBuilder.Portal.Frontend/src/ui/components/sidebar/org-switcher/with-data.tsx
@@ -53,17 +53,17 @@ export function withData(WrappedComponent) {
       setCurrentOrganizationId(id);
       toggle();
     }
-  
+
     search = debounce(() => {
       const { updateFilter } = this.props;
       const { searchTerm } = this.state;
-  
+
       updateFilter({ attribute: 'name', value: `${searchTerm}*` });
     }, 250);
-  
+
     didTypeInSearch = (e) => {
       const searchTerm = e.target.value;
-  
+
       this.setState({ searchTerm }, this.search);
     }
 
@@ -91,10 +91,10 @@ export function withData(WrappedComponent) {
       organizations: q => applyFilter(q.findRecords(ORGANIZATION), true, true)
     })),
     // if something doesn't have attributes, it hasn't been fetched from the remote
-    mapProps((props: IProps) => ({ 
-      ...props, 
+    mapProps((props: IProps) => ({
+      ...props,
       organizations: props.organizations.filter(o => o.attributes)
     })),
-    withLoader(({ fromNetwork, organizations }) => !fromNetwork || !organizations),
+    withLoader(({ fromNetwork, organizations }) => !organizations),
   )(DataWrapper);
 }

--- a/source/SIL.AppBuilder.Portal.Frontend/src/ui/components/sidebar/org-switcher/with-data.tsx
+++ b/source/SIL.AppBuilder.Portal.Frontend/src/ui/components/sidebar/org-switcher/with-data.tsx
@@ -1,11 +1,17 @@
+import * as React from 'react';
 import { compose, mapProps } from 'recompose';
 import { withData as withOrbit, WithDataProps } from 'react-orbitjs';
+import { ResourceObject } from 'jsonapi-typescript';
 
 import { query, defaultOptions, ORGANIZATIONS_TYPE, withLoader } from '@data';
-import { IProvidedProps as IFilterProps } from '@data/containers/with-filtering';
+import { IProvidedProps as IFilterProps, withFiltering } from '@data/containers/with-filtering';
 import { TYPE_NAME as ORGANIZATION, OrganizationAttributes } from '@data/models/organization';
-import { ResourceObject } from 'jsonapi-typescript';
 import { withCurrentUser, IProvidedProps as ICurrentUserProps } from '@data/containers/with-current-user';
+import { debounce } from '@lib/debounce';
+
+import { IProvidedProps as IReduxProps } from './with-redux';
+import { IGivenProps } from './types';
+
 
 function mapNetworkToProps(passedProps) {
   const { applyFilter } = passedProps;
@@ -22,17 +28,65 @@ interface IOwnProps {
   organizations: Array<ResourceObject<ORGANIZATIONS_TYPE, OrganizationAttributes>>;
 }
 
+export interface IProvidedDataProps {
+  organizations: Array<ResourceObject<ORGANIZATIONS_TYPE, OrganizationAttributes>>;
+  searchByName: (name: string) => void;
+  selectOrganization: (id: string) => void;
+  didTypeInSearch: (e: Event) => void;
+  toggle: () => void;
+}
+
 type IProps =
 & IOwnProps
 & IFilterProps
 & ICurrentUserProps
+& IReduxProps
+& IGivenProps
 & WithDataProps;
 
 export function withData(WrappedComponent) {
+  class DataWrapper extends React.Component<IProps> {
+    state = { searchTerm: '' };
+
+    selectOrganization = (id) => () => {
+      const { setCurrentOrganizationId, toggle } = this.props;
+      setCurrentOrganizationId(id);
+      toggle();
+    }
+  
+    search = debounce(() => {
+      const { updateFilter } = this.props;
+      const { searchTerm } = this.state;
+  
+      updateFilter({ attribute: 'name', value: `${searchTerm}*` });
+    }, 250);
+  
+    didTypeInSearch = (e) => {
+      const searchTerm = e.target.value;
+  
+      this.setState({ searchTerm }, this.search);
+    }
+
+    render() {
+      const { searchTerm } = this.state;
+
+      const extraDataProps = {
+        searchTerm,
+        didTypeInSearch: this.didTypeInSearch,
+        selectOrganization: this.selectOrganization,
+      };
+
+      return <WrappedComponent { ...this.props } { ...extraDataProps } />;
+    }
+  }
+
   return compose(
-    withCurrentUser(),
+    withFiltering({
+      requiredFilters: [
+        { attribute: 'scope-to-current-user', value: 'isnull:' }
+      ]
+    }),
     query(mapNetworkToProps),
-    withLoader(({ fromNetwork }) => !fromNetwork),
     withOrbit(({ applyFilter }: IProps) => ({
       organizations: q => applyFilter(q.findRecords(ORGANIZATION), true, true)
     })),
@@ -41,6 +95,6 @@ export function withData(WrappedComponent) {
       ...props, 
       organizations: props.organizations.filter(o => o.attributes)
     })),
-    withLoader(({ organizations }) => !organizations),
-  )(WrappedComponent);
+    withLoader(({ fromNetwork, organizations }) => !fromNetwork || !organizations),
+  )(DataWrapper);
 }

--- a/source/SIL.AppBuilder.Portal.Frontend/src/ui/components/sidebar/org-switcher/with-redux.tsx
+++ b/source/SIL.AppBuilder.Portal.Frontend/src/ui/components/sidebar/org-switcher/with-redux.tsx
@@ -1,0 +1,13 @@
+import { connect } from "react-redux";
+
+import { setCurrentOrganization } from '@store/data';
+
+export interface IProvidedProps {
+  setCurrentOrganizationId: (id: Id) => void;
+}
+
+const mapDispatchToProps = (dispatch) => ({
+  setCurrentOrganizationId: (id) => dispatch(setCurrentOrganization(id))
+});
+
+export const withRedux = connect(null, mapDispatchToProps);

--- a/source/SIL.AppBuilder.Portal.Frontend/src/ui/routes/project/__tests__/group-and-access-acceptance-test.ts
+++ b/source/SIL.AppBuilder.Portal.Frontend/src/ui/routes/project/__tests__/group-and-access-acceptance-test.ts
@@ -11,7 +11,6 @@ import {
 import {
   userInDifferentOrganization,
   userInSameOrgDifferentGroup,
-  userInSameOrgAndGroup
 } from './user-scenarios';
 
 import page from './page';
@@ -35,7 +34,12 @@ describe('Acceptance | Project Edit | re-assigning the group', () => {
       },
       included: [
         { type: 'organizations', id: 1, },
-        { type: 'groups', id: 1, attributes: { name: 'Group 1' } },
+        { type: 'groups', id: 1,
+          attributes: { name: 'Group 1' },
+          relationships: {
+            organization: { data: { id: 1, type: 'organizations' } }
+          }
+        },
         { type: 'users' , id: 2, attributes: { familyName: 'last', givenName: 'first' } },
       ]
     });
@@ -122,21 +126,21 @@ describe('Acceptance | Project Edit | re-assigning the group', () => {
         { id: 1, type: 'groups' ,
           attributes: { name: 'Group 1' },
           relationships: {
-            organization: { data: { id: 1, type: 'organizations' } }
+            owner: { data: { id: 1, type: 'organizations' } }
           }
         },
         { id: 2, type: 'groups' ,
           attributes: { name: 'Group 2' },
           relationships: {
-            organization: { data: { id: 1, type: 'organizations' } }
+            owner: { data: { id: 1, type: 'organizations' } }
           }
         },
         { id: 3, type: 'groups' ,
           attributes: { name: 'Group 3' },
           relationships: {
-            organization: { data: { id: 1, type: 'organizations' } }
+            owner: { data: { id: 1, type: 'organizations' } }
           }
-        }
+        },
       ]
     });
 

--- a/source/SIL.AppBuilder.Portal.Frontend/src/ui/routes/project/__tests__/user-scenarios.ts
+++ b/source/SIL.AppBuilder.Portal.Frontend/src/ui/routes/project/__tests__/user-scenarios.ts
@@ -5,19 +5,19 @@ const groups = [
   { id: 1, type: 'groups' ,
     attributes: { name: 'Group 1' },
     relationships: {
-      organization: { data: { id: 1, type: 'organizations' } }
+      owner: { data: { id: 1, type: 'organizations' } }
     }
   },
   { id: 2, type: 'groups' ,
     attributes: { name: 'Group 2' },
     relationships: {
-      organization: { data: { id: 1, type: 'organizations' } }
+      owner: { data: { id: 1, type: 'organizations' } }
     }
   },
   { id: 3, type: 'groups' ,
     attributes: { name: 'Group 3' },
     relationships: {
-      organization: { data: { id: 1, type: 'organizations' } }
+      owner: { data: { id: 1, type: 'organizations' } }
     }
   }
 ];

--- a/source/SIL.AppBuilder.Portal.Frontend/src/ui/routes/project/owners/index.tsx
+++ b/source/SIL.AppBuilder.Portal.Frontend/src/ui/routes/project/owners/index.tsx
@@ -35,7 +35,6 @@ const mapRecordsToProps = (passedProps) => {
     group: q => q.findRelatedRecord({ type, id }, 'group'),
     organization: q => q.findRelatedRecord({ type, id }, 'organization'),
     owner: q => q.findRelatedRecord({ type, id }, 'owner'),
-
   };
 };
 
@@ -94,6 +93,7 @@ class Owners extends React.Component<IProps> {
           <GroupSelect
             data-test-group-select
             scopeToCurrentUser={true}
+            scopeToOrganization={organization}
             selected={groupId}
             onChange={this.updateGroup} />
         </div>

--- a/source/SIL.AppBuilder.Portal.Frontend/src/ui/routes/project/with-data.tsx
+++ b/source/SIL.AppBuilder.Portal.Frontend/src/ui/routes/project/with-data.tsx
@@ -29,7 +29,7 @@ const mapRecordsToProps = (passedProps) => {
   const { params: { id } } = match;
 
   return {
-    project: q => buildFindRecord(q, PROJECT, id )
+    project: q => buildFindRecord(q, PROJECT, id ),
   };
 };
 

--- a/source/SIL.AppBuilder.Portal.Frontend/src/ui/routes/projects/new/__tests__/acceptance-test.ts
+++ b/source/SIL.AppBuilder.Portal.Frontend/src/ui/routes/projects/new/__tests__/acceptance-test.ts
@@ -9,12 +9,12 @@ import {
 
 import page from './page';
 
-describe('Acceptance | New Project', () => {
-  setupApplicationTest();
-  setupRequestInterceptor();
-
-
-  describe('the user has no groups', () => {
+const scenarios = {
+  appWithSelectedOrg(orgId = '') {
+    setupApplicationTest({ data: { currentOrganizationId: orgId}});
+    setupRequestInterceptor();
+  },
+  userHasNoGroups() {
     useFakeAuthentication({
       data: {
         id: 1, type: 'users',
@@ -37,20 +37,8 @@ describe('Acceptance | New Project', () => {
         }
       ]
     });
-
-    describe('navigates to new project page', () => {
-      beforeEach(async function() {
-        await visit('/projects/new');
-      });
-
-      it('is redirected', () => {
-        expect(location().pathname).to.equal('/');
-      });
-    });
-  });
-
-
-  describe('the user has groups', () => {
+  },
+  userHasGroups() {
     useFakeAuthentication({
       data: {
         id: 1, type: 'users',
@@ -88,16 +76,47 @@ describe('Acceptance | New Project', () => {
         }
       ]
     });
+  }
+};
 
-    // beforeEach(function() {
-    //   this.mockGet(200, '/groups', {
-    //     data: [
-    //       { id: 1, type: 'groups', attributes: { name: 'Group 1' } }
-    //     ]
-    //   });
-    // });
+describe('Acceptance | New Project', () => {
+  describe('the user has no groups', () => {
+    scenarios.appWithSelectedOrg();
+    scenarios.userHasNoGroups();
+
+
+    describe('navigates to new project page', () => {
+      beforeEach(async function() {
+        await visit('/projects/new');
+      });
+
+      it('is redirected', () => {
+        expect(location().pathname).to.equal('/');
+      });
+    });
+  });
+
+
+  describe('the user has groups', () => {
+    describe('but has all organizations selected', () => {
+      scenarios.appWithSelectedOrg('');
+      scenarios.userHasNoGroups();
+
+      describe('navigates to the new project page', () => {
+        beforeEach(async function() {
+          await visit('/projects/new');
+        });
+
+        it('is redirected', () => {
+          expect(location().pathname).to.equal('/');
+        });
+      });
+    });
 
     describe('navigates to the new project page', () => {
+      scenarios.appWithSelectedOrg('1');
+      scenarios.userHasGroups();
+
       beforeEach(async function() {
         await visit('/projects/new');
 

--- a/source/SIL.AppBuilder.Portal.Frontend/src/ui/routes/projects/new/index.tsx
+++ b/source/SIL.AppBuilder.Portal.Frontend/src/ui/routes/projects/new/index.tsx
@@ -3,7 +3,7 @@ import { compose } from 'recompose';
 
 import { withTranslations } from '@lib/i18n' ;
 import { withCurrentUser } from '@data/containers/with-current-user';
-import { withCurrentOrganization } from '@data/containers/with-current-organization';
+import { withCurrentOrganization, requireOrganizationToBeSelected } from '@data/containers/with-current-organization';
 
 import { withData } from './with-data';
 import { withAccessRestriction } from './with-access-restriction';
@@ -16,6 +16,7 @@ export default compose(
   withTranslations,
   withCurrentUser(),
   withCurrentOrganization,
+  requireOrganizationToBeSelected,
   withData,
   withAccessRestriction
 )( Display );

--- a/source/SIL.AppBuilder.Portal.Frontend/src/ui/routes/users/list/__tests__/filter-by-organization-acceptance-test.tsx
+++ b/source/SIL.AppBuilder.Portal.Frontend/src/ui/routes/users/list/__tests__/filter-by-organization-acceptance-test.tsx
@@ -3,8 +3,8 @@ import { describe, it, beforeEach } from '@bigtest/mocha';
 import { visit } from '@bigtest/react';
 import { expect } from 'chai';
 
-import { 
-  setupApplicationTest, setupRequestInterceptor, useFakeAuthentication, fakeAuth0Id 
+import {
+  setupApplicationTest, setupRequestInterceptor, useFakeAuthentication, fakeAuth0Id, wait
 } from 'tests/helpers';
 
 import app from 'tests/helpers/pages/app';
@@ -12,74 +12,77 @@ import switcher from '@ui/components/sidebar/org-switcher/__tests__/page';
 import page from './page';
 
 describe('Acceptance | User list | Filtering users by organization', () => {
-  setupApplicationTest();
+  setupApplicationTest({
+    data: { currentOrganizationId: '1'}
+  });
   setupRequestInterceptor();
-
-  describe('User belongs multiple organizations', () => {
-
-    useFakeAuthentication({
-      data: {
+  useFakeAuthentication({
+    data: {
+      id: 1,
+      type: 'users',
+      attributes: { id: 1, auth0Id: fakeAuth0Id, familyName: 'fake', givenName: 'fake' },
+      relationships: {
+        ['organization-memberships']: {
+          data: [
+            { id: 1, type: 'organization-memberships' },
+          ]
+        }
+      }
+    },
+    included: [
+      {
         id: 1,
-        type: 'users',
-        attributes: { id: 1, auth0Id: fakeAuth0Id, familyName: 'fake', givenName: 'fake' },
+        type: 'organization-memberships',
+        attributes: {},
         relationships: {
-          ['organization-memberships']: {
-            data: [
-              { id: 1, type: 'organization-memberships' },
-            ]
-          }
+          user: { data: { id: 1, type: 'users' } },
+          organization: { data: { id: 1, type: 'organizations' } }
         }
       },
-      included: [
-        {
-          id: 1,
-          type: 'organization-memberships',
-          attributes: {},
-          relationships: {
-            user: { data: { id: 1, type: 'users' } },
-            organization: { data: { id: 1, type: 'organizations' } }
-          }
-        },
-        {
-          id: 4, type: 'organization-memberships',
-          attributes: {},
-          relationships: {
-            user: { data: { id: 1, type: 'users' } },
-            organization: { data: { id: 2, type: 'organizations' } }
-          }
-        },
-        {
-          type: 'organizations', id: 1,
-          attributes: {
-            name: 'SIL International'
-          }
-        }, {
-          type: 'organizations', id: 2,
-          attributes: {
-            name: 'DeveloperTown'
-          }
-        },
-        {
-          id: 1,
-          type: 'groups' ,
-          attributes: { name: 'Some Group' },
-          relationships: {
-            organization: { data: { id: 1, type: 'organizations' } }
-          }
+      {
+        id: 4, type: 'organization-memberships',
+        attributes: {},
+        relationships: {
+          user: { data: { id: 1, type: 'users' } },
+          organization: { data: { id: 2, type: 'organizations' } }
         }
-      ]
-    });
+      },
+      {
+        type: 'organizations', id: 1,
+        attributes: {
+          name: 'SIL International'
+        }
+      }, {
+        type: 'organizations', id: 2,
+        attributes: {
+          name: 'DeveloperTown'
+        }
+      },
+      {
+        id: 1,
+        type: 'groups' ,
+        attributes: { name: 'Some Group' },
+        relationships: {
+          organization: { data: { id: 1, type: 'organizations' } }
+        }
+      }
+    ]
+  });
 
+  describe('User belongs multiple organizations', () => {
     beforeEach(function () {
       const { server } = this.polly;
-      
+
       server.get('/api/users').intercept((req, res) => {
-        const orgHeader = req.getHeader('Organization');
+        const orgHeader = req.getHeader('organization');
 
         res.status(200);
         res.headers['Content-Type'] = 'application/vnd.api+json';
 
-        if (orgHeader === '') {
+        const allOrganizations = !orgHeader || orgHeader === 'null' || orgHeader === '';
+        const selectedOrganization = orgHeader === '1';
+
+        if (allOrganizations) {
           res.json({
             data: [{
               type: 'users',
@@ -128,7 +131,7 @@ describe('Acceptance | User list | Filtering users by organization', () => {
               }
             ]
           });
-        } else if (orgHeader === '1') {
+        } else if (selectedOrganization) {
           res.json({
             data: [{
               type: 'users',
@@ -157,24 +160,24 @@ describe('Acceptance | User list | Filtering users by organization', () => {
             ]
           });
         } else {
-          throw "Unexpected Header Value";
+          throw new Error(`Unexpected Header Value: ${orgHeader}. Available: ${Object.keys(req.headers).join()}`);
         }
       });
     });
 
     describe('Select all organizations',() => {
-
       beforeEach(async function () {
         await visit('/users');
+
         await app.openSidebar();
         await app.openOrgSwitcher();
         await switcher.selectAllOrg();
+
+        expect(app.selectedOrg).to.equal("All Organizations");
       });
 
       describe('Renders users page', () => {
-
         it('Should see all users', () => {
-
           expect(page.usernames().length).to.equal(3);
 
           const usernames = page.usernames();
@@ -187,13 +190,15 @@ describe('Acceptance | User list | Filtering users by organization', () => {
 
         describe('Select a specific organization', () => {
           beforeEach(async function () {
-            await app.openSidebar();
             await app.openOrgSwitcher();
+            expect(app.isOrgSwitcherVisible).to.be.true;
+
             await switcher.chooseOrganization("SIL International");
+
+            expect(app.selectedOrg).to.equal("SIL International");
           });
 
           it('Only display the users that belong to the selected organization', () => {
-            console.log(page.usernames());
             expect(page.usernames().length).to.equal(2);
 
             const usernames = page.usernames();
@@ -202,9 +207,7 @@ describe('Acceptance | User list | Filtering users by organization', () => {
             expect(text).to.include('fake fake');
             expect(text).to.include('One fake');
             expect(text).to.not.include('Two fake');
-
           });
-
         });
       });
     });

--- a/source/SIL.AppBuilder.Portal.Frontend/src/ui/routes/users/list/__tests__/filter-by-organization-acceptance-test.tsx
+++ b/source/SIL.AppBuilder.Portal.Frontend/src/ui/routes/users/list/__tests__/filter-by-organization-acceptance-test.tsx
@@ -1,26 +1,54 @@
 
 import { describe, it, beforeEach } from '@bigtest/mocha';
-import { visit, location } from '@bigtest/react';
+import { visit } from '@bigtest/react';
 import { expect } from 'chai';
 
-import { setupApplicationTest, setupRequestInterceptor, useFakeAuthentication } from 'tests/helpers';
+import { 
+  setupApplicationTest, setupRequestInterceptor, useFakeAuthentication, fakeAuth0Id 
+} from 'tests/helpers';
 
 import app from 'tests/helpers/pages/app';
 import switcher from '@ui/components/sidebar/org-switcher/__tests__/page';
 import page from './page';
 
 describe('Acceptance | User list | Filtering users by organization', () => {
-
   setupApplicationTest();
   setupRequestInterceptor();
 
   describe('User belongs multiple organizations', () => {
 
-    useFakeAuthentication();
-
-    beforeEach(function() {
-      this.mockGet(200, '/organizations', {
-        data: [{
+    useFakeAuthentication({
+      data: {
+        id: 1,
+        type: 'users',
+        attributes: { id: 1, auth0Id: fakeAuth0Id, familyName: 'fake', givenName: 'fake' },
+        relationships: {
+          ['organization-memberships']: {
+            data: [
+              { id: 1, type: 'organization-memberships' },
+            ]
+          }
+        }
+      },
+      included: [
+        {
+          id: 1,
+          type: 'organization-memberships',
+          attributes: {},
+          relationships: {
+            user: { data: { id: 1, type: 'users' } },
+            organization: { data: { id: 1, type: 'organizations' } }
+          }
+        },
+        {
+          id: 4, type: 'organization-memberships',
+          attributes: {},
+          relationships: {
+            user: { data: { id: 1, type: 'users' } },
+            organization: { data: { id: 2, type: 'organizations' } }
+          }
+        },
+        {
           type: 'organizations', id: 1,
           attributes: {
             name: 'SIL International'
@@ -30,63 +58,107 @@ describe('Acceptance | User list | Filtering users by organization', () => {
           attributes: {
             name: 'DeveloperTown'
           }
-        }, {
-          type: 'organizations', id: 3,
-          attributes: {
-            name: 'Kalaam Media'
+        },
+        {
+          id: 1,
+          type: 'groups' ,
+          attributes: { name: 'Some Group' },
+          relationships: {
+            organization: { data: { id: 1, type: 'organizations' } }
           }
-        }]
-      });
+        }
+      ]
     });
 
     beforeEach(function () {
-      this.mockGet(200, '/users', {
-        data: [{
-          type: 'users',
-          id: 2,
-          attributes: { id: 1, familyName: 'fake', givenName: 'One' },
-          relationships: {
-            ['organization-memberships']: { data: [ { id: 2, type: 'organization-memberships' }]},
-            "group-memberships": {}
-          }
-        }, {
-          type: 'users',
-          id: 3,
-          attributes: { id: 1, familyName: 'fake', givenName: 'Two' },
-          relationships: {
-            ['organization-memberships']: { data: [ { id: 3, type: 'organization-memberships' }]},
-            "group-memberships": {}
-          },
-        }],
-        included: [
-          {
-            id: 2, type: 'organization-memberships',
-            attributes: {},
-            relationships: {
-              user: { data: { id: 2, type: 'users' } },
-              organization: { data: { id: 1, type: 'organizations' } }
-            }
-          },
-          {
-            id: 3, type: 'organization-memberships',
-            attributes: {},
-            relationships: {
-              user: { data: { id: 3, type: 'users' } },
-              organization: { data: { id: 2, type: 'organizations' } }
-            }
-          },
-          {
-            type: 'organizations', id: 1,
-            attributes: {
-              name: 'SIL International'
-            }
-          }, {
-            type: 'organizations', id: 2,
-            attributes: {
-              name: 'DeveloperTown'
-            }
-          }
-        ]
+      const { server } = this.polly;
+      
+      server.get('/api/users').intercept((req, res) => {
+        const orgHeader = req.getHeader('Organization');
+
+        res.status(200);
+        res.headers['Content-Type'] = 'application/vnd.api+json';
+
+        if (orgHeader === '') {
+          res.json({
+            data: [{
+              type: 'users',
+              id: 2,
+              attributes: { familyName: 'fake', givenName: 'One' },
+              relationships: {
+                ['organization-memberships']: { data: [ { id: 2, type: 'organization-memberships' }]},
+                "group-memberships": {}
+              }
+            }, {
+              type: 'users',
+              id: 3,
+              attributes: { familyName: 'fake', givenName: 'Two' },
+              relationships: {
+                ['organization-memberships']: { data: [ { id: 3, type: 'organization-memberships' }]},
+                "group-memberships": {}
+              },
+            }],
+            included: [
+              {
+                id: 2, type: 'organization-memberships',
+                attributes: {},
+                relationships: {
+                  user: { data: { id: 2, type: 'users' } },
+                  organization: { data: { id: 1, type: 'organizations' } }
+                }
+              },
+              {
+                id: 3, type: 'organization-memberships',
+                attributes: {},
+                relationships: {
+                  user: { data: { id: 3, type: 'users' } },
+                  organization: { data: { id: 2, type: 'organizations' } }
+                }
+              },
+              {
+                type: 'organizations', id: 1,
+                attributes: {
+                  name: 'SIL International'
+                }
+              }, {
+                type: 'organizations', id: 2,
+                attributes: {
+                  name: 'DeveloperTown'
+                }
+              }
+            ]
+          });
+        } else if (orgHeader === '1') {
+          res.json({
+            data: [{
+              type: 'users',
+              id: 2,
+              attributes: { familyName: 'fake', givenName: 'One' },
+              relationships: {
+                ['organization-memberships']: { data: [ { id: 2, type: 'organization-memberships' }]},
+                "group-memberships": {}
+              }
+            }],
+            included: [
+              {
+                id: 2, type: 'organization-memberships',
+                attributes: {},
+                relationships: {
+                  user: { data: { id: 2, type: 'users' } },
+                  organization: { data: { id: 1, type: 'organizations' } }
+                }
+              },
+              {
+                type: 'organizations', id: 1,
+                attributes: {
+                  name: 'SIL International'
+                }
+              }
+            ]
+          });
+        } else {
+          throw "Unexpected Header Value";
+        }
       });
     });
 
@@ -114,7 +186,6 @@ describe('Acceptance | User list | Filtering users by organization', () => {
         });
 
         describe('Select a specific organization', () => {
-
           beforeEach(async function () {
             await app.openSidebar();
             await app.openOrgSwitcher();
@@ -122,7 +193,7 @@ describe('Acceptance | User list | Filtering users by organization', () => {
           });
 
           it('Only display the users that belong to the selected organization', () => {
-
+            console.log(page.usernames());
             expect(page.usernames().length).to.equal(2);
 
             const usernames = page.usernames();

--- a/source/SIL.AppBuilder.Portal.Frontend/src/ui/routes/users/show/index.tsx
+++ b/source/SIL.AppBuilder.Portal.Frontend/src/ui/routes/users/show/index.tsx
@@ -28,7 +28,7 @@ class User extends React.Component<IProps> {
     const { t, user: userData } = this.props;
     const user = userData.attributes;
 
-    const fullname = `${user.givenName} ${user.familyName}`;
+    const fullname = `${user.givenName || ''} ${user.familyName || ''}`;
     const phone = user.phone ? user.phone : t('profile.noPhone');
     const timezone = user.timezone ? `(${user.timezone})` : t('profile.noTimezone');
 

--- a/source/SIL.AppBuilder.Portal.Frontend/tests/helpers/pages/app.ts
+++ b/source/SIL.AppBuilder.Portal.Frontend/tests/helpers/pages/app.ts
@@ -3,13 +3,11 @@ import {
   clickable,
   text,
   selectable,
-  isPresent
+  isPresent,
+  Interactor
 } from '@bigtest/interactor';
 
-@interactor
-export class AppInteractor {
-  constructor(selector?: string) { }
-
+class App {
   headers = text('h1,h2,h3');
 
   clickNotificationsBell = clickable('[data-test-header-notification]');
@@ -23,6 +21,19 @@ export class AppInteractor {
   isSidebarVisible = isPresent('.is-sidebar-visible [data-test-sidebar]');
   openOrgSwitcher = clickable('[data-test-org-switcher-toggler]');
   isOrgSwitcherVisible = isPresent('[data-test-org-switcher]');
+
+  isLoaderVisible = isPresent('.spinner');
+
+  waitForDoneLoading = new Interactor('.spinner')
+    .when<boolean>(spinner => {
+      return !spinner;
+    })
+    .do(() => console.log('spinner gone'))
+    .timeout(200);
 }
 
-export default new AppInteractor('[data-test-app-container]');
+export const AppInteractor = interactor(App);
+
+export type TAppInteractor = App & Interactor;
+
+export default new (AppInteractor as any)('[data-test-app-container]') as TAppInteractor;

--- a/source/SIL.AppBuilder.Portal.Frontend/tests/helpers/pages/app.ts
+++ b/source/SIL.AppBuilder.Portal.Frontend/tests/helpers/pages/app.ts
@@ -20,6 +20,8 @@ class App {
   openSidebar = clickable('[data-test-header-sidebar-button]');
   isSidebarVisible = isPresent('.is-sidebar-visible [data-test-sidebar]');
   openOrgSwitcher = clickable('[data-test-org-switcher-toggler]');
+  selectedOrg = text('[data-test-org-switcher-toggler]');
+
   isOrgSwitcherVisible = isPresent('[data-test-org-switcher]');
 
   isLoaderVisible = isPresent('.spinner');

--- a/source/SIL.AppBuilder.Portal.Frontend/tests/helpers/request-intercepting/polly.ts
+++ b/source/SIL.AppBuilder.Portal.Frontend/tests/helpers/request-intercepting/polly.ts
@@ -27,7 +27,7 @@ export function setupRequestInterceptor(config: any = {}) {
           context: window
         }
       },
-      logging: true,
+      // logging: true,
       recordFailedRequests: false,
       recordIfMissing: false,
       matchRequestsBy: {

--- a/source/SIL.AppBuilder.Portal.Frontend/tests/helpers/request-intercepting/polly.ts
+++ b/source/SIL.AppBuilder.Portal.Frontend/tests/helpers/request-intercepting/polly.ts
@@ -27,7 +27,7 @@ export function setupRequestInterceptor(config: any = {}) {
           context: window
         }
       },
-      // logging: true,
+      logging: true,
       recordFailedRequests: false,
       recordIfMissing: false,
       matchRequestsBy: {

--- a/source/SIL.AppBuilder.Portal.Frontend/tests/helpers/request-intercepting/polly.ts
+++ b/source/SIL.AppBuilder.Portal.Frontend/tests/helpers/request-intercepting/polly.ts
@@ -32,11 +32,16 @@ export function setupRequestInterceptor(config: any = {}) {
       recordIfMissing: false,
       matchRequestsBy: {
         order: false,
-        headers: false,
+        headers: true,
         // url: {
-        //   protocol: false,
-        //   port: false,
-        //   hostname: false,
+        //   protocol: true,
+        //   username: true,
+        //   password: true,
+        //   hostname: true,
+        //   port: true,
+        //   pathname: true,
+        //   query: true,
+        //   hash: false
         // }
       },
       ...config

--- a/source/SIL.AppBuilder.Portal.Frontend/types/@bigtest/interactor.d.ts
+++ b/source/SIL.AppBuilder.Portal.Frontend/types/@bigtest/interactor.d.ts
@@ -1,0 +1,19 @@
+export function interactor<T>(WrappedClass: T) : Interactor & T;
+export function text(selector: string) : any;
+export function clickable(selector: string): () => Promise<void>;
+export function findAll(selector: string): Array<HTMLElement>;
+export function isPresent(selector: string): boolean;
+export function selectable(selector: string): (text: string) => Promise<void>;
+
+export class Interactor {
+  constructor(selector?: string);
+
+  $$(selector): this;
+  when<T>(condition: (element?: HTMLElement) => T): this;
+  
+  do<T>(doFn: (element: Interactor) => void);
+  
+  click(selector?: string): Promise<void>;
+  find(findFn: (element: HTMLElement) => boolean): HTMLElement;
+
+}

--- a/source/SIL.AppBuilder.Portal.Frontend/types/@bigtest/mocha.d.ts
+++ b/source/SIL.AppBuilder.Portal.Frontend/types/@bigtest/mocha.d.ts
@@ -1,0 +1,5 @@
+export function beforeEach(fn: () => void) : any;
+export function afterEach(fn: () => void) : any;
+export function describe(description: string, fn: () => void) : any;
+export function it(description: string, fn: () => void) : any;
+export function xit(fn: () => void) : any;

--- a/source/SIL.AppBuilder.Portal.Frontend/types/@bigtest/react.d.ts
+++ b/source/SIL.AppBuilder.Portal.Frontend/types/@bigtest/react.d.ts
@@ -1,0 +1,11 @@
+interface IOptions {
+  props: any;
+}
+
+export function setupAppForTesting(
+  component: React.Component<any, any>,
+  options: IOptions
+) : any;
+
+export function location(): {pathname: string};
+export function visit(path: string): Promise<void>;

--- a/source/SIL.AppBuilder.Portal.Frontend/types/index.d.ts
+++ b/source/SIL.AppBuilder.Portal.Frontend/types/index.d.ts
@@ -1,3 +1,7 @@
+declare module "@pollyjs/adapter-fetch";
+declare module "@pollyjs/adapter-xhr";
+declare module "@pollyjs/core";
+
 type Troolean =
 | boolean
 | undefined;


### PR DESCRIPTION
- [x] Don't show groups for organizations other than what the current-organization is.
- [x] Fix issue where 500 error from the backend would cause infinite redirect loop upon initial navigation to the app
- [x] Fix open source link navigation on the sidebar -- it did not start with a `/`
- [x] When a user's public profile is viewed, and the user does not have a name set, `null null` is shown as the name
- [x] Fix issue where sometimes the search bar on the org-switcher will hide when there are no found results from the query
- [x] Correctly show only the current user's organizations in the org-switcher
- [x] Don't add a project when "All Organizations" is selected
  - [x] If manually navigating to the the create project screen and "all organizations" is selected, redirect back and display a message.
  - [x] the add project button should be greyed / disabled in the sidebar when "All organizations" is selected

Issues found in this PR / existing code that will be addressed in another PR:
- [ ] can't update a project due to invalid backend validations
- [ ] move project editing from /project/:id to /projects/:id/edit -- this will allow a more RESTful implementation of the eventual public project page.
- [ ] upstream types for `@bigtest`
- [ ] extract orbitjs helpers to a separate package