### PR TITLE
Change models (date to string) and Add [Model]Resources

### DIFF
--- a/source/SIL.AppBuilder.Portal.Frontend/src/data/index.ts
+++ b/source/SIL.AppBuilder.Portal.Frontend/src/data/index.ts
@@ -1,5 +1,4 @@
 export { default as DataProvider } from './provider';
-import { USERS_TYPE, REVIEWERS_TYPE, PRODUCTS_TYPE, GROUP_MEMBERSHIPS_TYPE, ORGANIZATION_MEMBERSHIPS_TYPE } from '@data';
 
 export { defaultSourceOptions, defaultOptions } from './store';
 export {

--- a/source/SIL.AppBuilder.Portal.Frontend/src/data/index.ts
+++ b/source/SIL.AppBuilder.Portal.Frontend/src/data/index.ts
@@ -1,4 +1,5 @@
 export { default as DataProvider } from './provider';
+import { USERS_TYPE, REVIEWERS_TYPE, PRODUCTS_TYPE, GROUP_MEMBERSHIPS_TYPE, ORGANIZATION_MEMBERSHIPS_TYPE } from '@data';
 
 export { defaultSourceOptions, defaultOptions } from './store';
 export {
@@ -32,14 +33,11 @@ export { pushPayload } from './push-payload';
 
 export { TASKS_TYPE, TaskResource } from './models/task';
 export { NOTIFICATIONS_TYPE, NotificationResource } from './models/notification';
-
-// JSONAPI types
-export type ORGANIZATIONS_TYPE = 'organizations';
-export type GROUPS_TYPE = 'groups';
-export type PROJECTS_TYPE = 'projects';
-export type USERS_TYPE = 'users';
-export type PRODUCTS_TYPE = 'products';
-export type ORGANIZATION_MEMBERSHIPS_TYPE = 'organization-memberships';
-export type GROUP_MEMBERSHIPS_TYPE = 'group-memberships';
-
-export type REVIEWERS_TYPE = 'reviewers';
+export { ORGANIZATIONS_TYPE, OrganizationResource } from './models/organization';
+export { GROUPS_TYPE, GroupResource } from './models/group';
+export { PROJECTS_TYPE, ProjectResource } from './models/project';
+export { USERS_TYPE, UserResource } from './models/user';
+export { REVIEWERS_TYPE, ReviewerResource } from './models/reviewer';
+export { PRODUCTS_TYPE, ProductResource } from './models/product';
+export { GROUP_MEMBERSHIPS_TYPE, GroupMembershipResource } from './models/group-membership';
+export { ORGANIZATION_MEMBERSHIPS_TYPE, OrganizationMembershipResource } from './models/organization-membership';

--- a/source/SIL.AppBuilder.Portal.Frontend/src/data/models/group-membership.ts
+++ b/source/SIL.AppBuilder.Portal.Frontend/src/data/models/group-membership.ts
@@ -1,7 +1,11 @@
-import { AttributesObject } from "jsonapi-typescript";
+import { AttributesObject, ResourceObject } from "jsonapi-typescript";
+
+export type GROUP_MEMBERSHIPS_TYPE = 'group-memberships';
 
 export const TYPE_NAME = 'group-membership';
 export const PLURAL_NAME = 'group-memberships';
 
 export interface GroupMembershipAttributes extends AttributesObject {
 }
+
+export type GroupMembershipResource = ResourceObject<GROUP_MEMBERSHIPS_TYPE, GroupMembershipAttributes>;

--- a/source/SIL.AppBuilder.Portal.Frontend/src/data/models/group.ts
+++ b/source/SIL.AppBuilder.Portal.Frontend/src/data/models/group.ts
@@ -1,4 +1,6 @@
-import { AttributesObject } from "jsonapi-typescript";
+import { AttributesObject, ResourceObject } from "jsonapi-typescript";
+
+export type GROUPS_TYPE = 'groups';
 
 export const TYPE_NAME = 'group';
 export const PLURAL_NAME = 'groups';
@@ -7,3 +9,5 @@ export interface GroupAttributes extends AttributesObject {
   name: string;
   abbreviation: string;
 }
+
+export type GroupResource = ResourceObject<GROUPS_TYPE, GroupAttributes>;

--- a/source/SIL.AppBuilder.Portal.Frontend/src/data/models/notification.ts
+++ b/source/SIL.AppBuilder.Portal.Frontend/src/data/models/notification.ts
@@ -7,7 +7,7 @@ export const TYPE_NAME = 'notification';
 export interface NotificationAttributes extends AttributesObject {
   title: string;
   description: string;
-  time: Date;
+  time: string;
   link: string;
   isViewed: boolean;
   show: boolean;

--- a/source/SIL.AppBuilder.Portal.Frontend/src/data/models/organization-invite.ts
+++ b/source/SIL.AppBuilder.Portal.Frontend/src/data/models/organization-invite.ts
@@ -6,7 +6,7 @@ export interface OrganizationInviteAttributes extends AttributesObject {
   name?: string;
   ownerEmail?: string;
   url?: string;
-  expiresAt?: Date;
+  expiresAt?: string;
 }
 
 export interface RequestAccessForOrganizationAttributes extends AttributesObject {

--- a/source/SIL.AppBuilder.Portal.Frontend/src/data/models/organization-membership.ts
+++ b/source/SIL.AppBuilder.Portal.Frontend/src/data/models/organization-membership.ts
@@ -1,7 +1,11 @@
-import { AttributesObject } from "jsonapi-typescript";
+import { AttributesObject, ResourceObject } from "jsonapi-typescript";
+
+export type ORGANIZATION_MEMBERSHIPS_TYPE = 'organization-memberships';
 
 export const TYPE_NAME = 'organization-membership';
 export const PLURAL_NAME = 'organization-memberships';
 
 export interface OrganizationMembershipAttributes extends AttributesObject {
 }
+
+export type OrganizationMembershipResource = ResourceObject<ORGANIZATION_MEMBERSHIPS_TYPE, OrganizationMembershipAttributes>;

--- a/source/SIL.AppBuilder.Portal.Frontend/src/data/models/organization.ts
+++ b/source/SIL.AppBuilder.Portal.Frontend/src/data/models/organization.ts
@@ -1,4 +1,6 @@
-import { AttributesObject } from "jsonapi-typescript";
+import { AttributesObject, ResourceObject } from "jsonapi-typescript";
+
+export type ORGANIZATIONS_TYPE = 'organizations';
 
 export const TYPE_NAME = 'organization';
 
@@ -22,3 +24,5 @@ export interface OrganizationAttributes extends AttributesObject {
   // TODO: find out if we can define custom getters and setters on 'Models'
   logoUrl?: string;
 }
+
+export type OrganizationResource = ResourceObject<ORGANIZATIONS_TYPE, OrganizationAttributes>;

--- a/source/SIL.AppBuilder.Portal.Frontend/src/data/models/product.ts
+++ b/source/SIL.AppBuilder.Portal.Frontend/src/data/models/product.ts
@@ -1,4 +1,7 @@
-import { AttributesObject } from "jsonapi-typescript";
+import { AttributesObject, ResourceObject } from "jsonapi-typescript";
+
+export type PRODUCTS_TYPE = 'products';
+
 
 export const TYPE_NAME = 'product';
 export const PLURAL_NAME = 'products';
@@ -9,3 +12,5 @@ export interface ProductAttributes extends AttributesObject {
   // TODO: figure out better mapping for this
   //       we'll know for certain as we actually start to work with products
 }
+
+export type ProductResource = ResourceObject<PRODUCTS_TYPE, ProductAttributes>;

--- a/source/SIL.AppBuilder.Portal.Frontend/src/data/models/project.ts
+++ b/source/SIL.AppBuilder.Portal.Frontend/src/data/models/project.ts
@@ -1,4 +1,6 @@
-import { AttributesObject } from "jsonapi-typescript";
+import { AttributesObject, ResourceObject } from "jsonapi-typescript";
+
+export type PROJECTS_TYPE = 'projects';
 
 export const TYPE_NAME = 'project';
 export const PLURAL_NAME = 'projects';
@@ -6,15 +8,17 @@ export const PLURAL_NAME = 'projects';
 export interface ProjectAttributes extends AttributesObject {
   name: string;
   status: string;
-  dateCreated: Date;
-  dateArchived: Date;
+  dateCreated: string;
+  dateArchived: string;
   language: string;
   type: string;
   description: string;
   automaticBuilds: boolean;
   allowDownloads: boolean;
   location: string;
-  lastUpdatedAt: Date;
+  lastUpdatedAt: string;
   isPublic: boolean;
   organization: any; // TODO Remove this when API is ready
 }
+
+export type ProjectResource = ResourceObject<PROJECTS_TYPE, ProjectAttributes>;

--- a/source/SIL.AppBuilder.Portal.Frontend/src/data/models/reviewer.ts
+++ b/source/SIL.AppBuilder.Portal.Frontend/src/data/models/reviewer.ts
@@ -1,4 +1,6 @@
-import { AttributesObject } from "jsonapi-typescript";
+import { AttributesObject, ResourceObject } from "jsonapi-typescript";
+
+export type REVIEWERS_TYPE = 'reviewers';
 
 export const TYPE_NAME = 'reviewer';
 export const PLURAL_NAME = 'reviewers';
@@ -7,3 +9,5 @@ export interface ReviewerAttributes extends AttributesObject {
   name: string;
   email: string;
 }
+
+export type ReviewerResource = ResourceObject<REVIEWERS_TYPE, ReviewerAttributes>;

--- a/source/SIL.AppBuilder.Portal.Frontend/src/data/models/user.ts
+++ b/source/SIL.AppBuilder.Portal.Frontend/src/data/models/user.ts
@@ -1,4 +1,6 @@
-import { AttributesObject } from 'jsonapi-typescript';
+import { AttributesObject, ResourceObject } from 'jsonapi-typescript';
+
+export type USERS_TYPE = 'users';
 
 export const TYPE_NAME = 'user';
 export const PLURAL_NAME = 'users';
@@ -24,3 +26,5 @@ export interface UserAttributes extends AttributesObject {
 export function name(attrs: UserAttributes) {
   return `${attrs.givenName} ${attrs.familyName}`;
 }
+
+export type UserResource = ResourceObject<USERS_TYPE, UserAttributes>;


### PR DESCRIPTION
I changed all dates to string since they are not supported in ResourceObject and also added ModelResource for all models so we can start using them. I didn't refactor all the files where we could use this modelResource because I didn't want in getting in the way of your code.