### PR TITLE
Fix ApplicationType references

### DIFF
--- a/scripts/DB/application_types.sql
+++ b/scripts/DB/application_types.sql
@@ -1,5 +1,5 @@
-INSERT INTO "ApplicationTypes" ("Id", "Name") VALUES
-('scriptureappbuilder',	'Scripture App Builder'),
-('readingappbuilder',	'Reading App Builder'),
-('dictionaryappbuilder',	'Dictionary App Builder');
+INSERT INTO "ApplicationTypes" ("Id", "Name", "Description") VALUES
+(1, 'scriptureappbuilder',	'Scripture App Builder'),
+(2, 'readingappbuilder',	'Reading App Builder'),
+(3, 'dictionaryappbuilder',	'Dictionary App Builder');
 

--- a/source/OptimaJet.DWKit.StarterApplication/Controllers/ApplicationTypesController.cs
+++ b/source/OptimaJet.DWKit.StarterApplication/Controllers/ApplicationTypesController.cs
@@ -1,0 +1,22 @@
+﻿using JsonApiDotNetCore.Services;
+using Microsoft.AspNetCore.Authentication.JwtBearer;
+using Microsoft.AspNetCore.Authorization;
+using OptimaJet.DWKit.StarterApplication.Models;
+using OptimaJet.DWKit.StarterApplication.Services;
+
+namespace OptimaJet.DWKit.StarterApplication.Controllers
+{
+    [Authorize(AuthenticationSchemes = JwtBearerDefaults.AuthenticationScheme)]
+    public class ApplicationTypesController : BaseController<ApplicationType>
+    {
+        public ApplicationTypesController(
+            IJsonApiContext jsonApiContext,
+            IResourceService<ApplicationType> resourceService,
+            ICurrentUserContext currentUserContext,
+            OrganizationService organizationService,
+            UserService userService)
+            : base(jsonApiContext, resourceService, currentUserContext, organizationService, userService)
+        {
+        }
+    }
+}

--- a/source/OptimaJet.DWKit.StarterApplication/Migrations/20180802183431_AddBase.Designer.cs
+++ b/source/OptimaJet.DWKit.StarterApplication/Migrations/20180802183431_AddBase.Designer.cs
@@ -136,7 +136,7 @@ namespace OptimaJet.DWKit.StarterApplication.Migrations
 
                     b.Property<bool>("Private");
 
-                    b.Property<string>("Type");
+                    b.Property<int>("TypeId");
 
                     b.HasKey("Id");
 
@@ -145,6 +145,8 @@ namespace OptimaJet.DWKit.StarterApplication.Migrations
                     b.HasIndex("OrganizationId");
 
                     b.HasIndex("OwnerId");
+
+                    b.HasIndex("TypeId");
 
                     b.ToTable("Projects");
                 });
@@ -235,6 +237,10 @@ namespace OptimaJet.DWKit.StarterApplication.Migrations
                         .WithMany()
                         .HasForeignKey("OwnerId")
                         .OnDelete(DeleteBehavior.Cascade);
+
+                    b.HasOne("OptimaJet.DWKit.StarterApplication.Models.ApplicationType", "Type")
+                       .WithMany()
+                       .HasForeignKey("TypeId");
                 });
 #pragma warning restore 612, 618
         }

--- a/source/OptimaJet.DWKit.StarterApplication/Migrations/20180802183431_AddBase.cs
+++ b/source/OptimaJet.DWKit.StarterApplication/Migrations/20180802183431_AddBase.cs
@@ -147,7 +147,7 @@ namespace OptimaJet.DWKit.StarterApplication.Migrations
                     Id = table.Column<int>(nullable: false)
                         .Annotation("Npgsql:ValueGenerationStrategy", NpgsqlValueGenerationStrategy.SerialColumn),
                     Name = table.Column<string>(nullable: true),
-                    Type = table.Column<string>(nullable: true),
+                    TypeId = table.Column<int>(nullable: false),
                     Description = table.Column<string>(nullable: true),
                     OwnerId = table.Column<int>(nullable: false),
                     GroupId = table.Column<int>(nullable: false),

--- a/source/OptimaJet.DWKit.StarterApplication/Migrations/20180802213732_AddGroupMembership.Designer.cs
+++ b/source/OptimaJet.DWKit.StarterApplication/Migrations/20180802213732_AddGroupMembership.Designer.cs
@@ -136,7 +136,7 @@ namespace OptimaJet.DWKit.StarterApplication.Migrations
 
                     b.Property<bool>("Private");
 
-                    b.Property<string>("Type");
+                    b.Property<int>("TypeId");
 
                     b.HasKey("Id");
 
@@ -145,6 +145,8 @@ namespace OptimaJet.DWKit.StarterApplication.Migrations
                     b.HasIndex("OrganizationId");
 
                     b.HasIndex("OwnerId");
+
+                    b.HasIndex("TypeId");
 
                     b.ToTable("Projects");
                 });
@@ -235,6 +237,10 @@ namespace OptimaJet.DWKit.StarterApplication.Migrations
                         .WithMany()
                         .HasForeignKey("OwnerId")
                         .OnDelete(DeleteBehavior.Cascade);
+
+                    b.HasOne("OptimaJet.DWKit.StarterApplication.Models.ApplicationType", "Type")
+                       .WithMany()
+                       .HasForeignKey("TypeId");
                 });
 #pragma warning restore 612, 618
         }

--- a/source/OptimaJet.DWKit.StarterApplication/Migrations/20180803141430_AddEmail.Designer.cs
+++ b/source/OptimaJet.DWKit.StarterApplication/Migrations/20180803141430_AddEmail.Designer.cs
@@ -180,7 +180,7 @@ namespace OptimaJet.DWKit.StarterApplication.Migrations
 
                     b.Property<bool>("Private");
 
-                    b.Property<string>("Type");
+                    b.Property<int>("TypeId");
 
                     b.HasKey("Id");
 
@@ -189,6 +189,8 @@ namespace OptimaJet.DWKit.StarterApplication.Migrations
                     b.HasIndex("OrganizationId");
 
                     b.HasIndex("OwnerId");
+
+                    b.HasIndex("TypeId");
 
                     b.ToTable("Projects");
                 });
@@ -279,6 +281,10 @@ namespace OptimaJet.DWKit.StarterApplication.Migrations
                         .WithMany()
                         .HasForeignKey("OwnerId")
                         .OnDelete(DeleteBehavior.Cascade);
+
+                    b.HasOne("OptimaJet.DWKit.StarterApplication.Models.ApplicationType", "Type")
+                       .WithMany()
+                       .HasForeignKey("TypeId");
                 });
 #pragma warning restore 612, 618
         }

--- a/source/OptimaJet.DWKit.StarterApplication/Migrations/20180803221432_AddProductDefinition.cs
+++ b/source/OptimaJet.DWKit.StarterApplication/Migrations/20180803221432_AddProductDefinition.cs
@@ -11,8 +11,9 @@ namespace OptimaJet.DWKit.StarterApplication.Migrations
                 name: "ApplicationTypes",
                 columns: table => new
                 {
-                    Id = table.Column<string>(nullable: false),
-                    Name = table.Column<string>(nullable: true)
+                    Id = table.Column<int>(nullable: false),
+                    Name = table.Column<string>(nullable: true),
+                    Description = table.Column<string>(nullable:true)
                 },
                 constraints: table =>
                 {
@@ -42,7 +43,7 @@ namespace OptimaJet.DWKit.StarterApplication.Migrations
                     Id = table.Column<int>(nullable: false)
                         .Annotation("Npgsql:ValueGenerationStrategy", NpgsqlValueGenerationStrategy.SerialColumn),
                     Name = table.Column<string>(nullable: true),
-                    TypeId = table.Column<string>(nullable: true),
+                    TypeId = table.Column<int>(nullable: false),
                     Description = table.Column<string>(nullable: true),
                     WorkflowId = table.Column<int>(nullable: false)
                 },

--- a/source/OptimaJet.DWKit.StarterApplication/Migrations/20180809143521_DateTime_Visibility.Designer.cs
+++ b/source/OptimaJet.DWKit.StarterApplication/Migrations/20180809143521_DateTime_Visibility.Designer.cs
@@ -24,8 +24,10 @@ namespace OptimaJet.DWKit.StarterApplication.Migrations
 
             modelBuilder.Entity("OptimaJet.DWKit.StarterApplication.Models.ApplicationType", b =>
                 {
-                    b.Property<string>("Id")
+                    b.Property<int>("Id")
                         .ValueGeneratedOnAdd();
+
+                    b.Property<string>("Description");
 
                     b.Property<string>("Name");
 
@@ -180,7 +182,7 @@ namespace OptimaJet.DWKit.StarterApplication.Migrations
 
                     b.Property<string>("Name");
 
-                    b.Property<string>("TypeId");
+                    b.Property<int>("TypeId");
 
                     b.Property<int>("WorkflowId");
 
@@ -218,7 +220,7 @@ namespace OptimaJet.DWKit.StarterApplication.Migrations
 
                     b.Property<bool>("Private");
 
-                    b.Property<string>("Type");
+                    b.Property<int>("TypeId");
 
                     b.HasKey("Id");
 
@@ -227,6 +229,8 @@ namespace OptimaJet.DWKit.StarterApplication.Migrations
                     b.HasIndex("OrganizationId");
 
                     b.HasIndex("OwnerId");
+
+                    b.HasIndex("TypeId");
 
                     b.ToTable("Projects");
                 });
@@ -351,6 +355,10 @@ namespace OptimaJet.DWKit.StarterApplication.Migrations
                         .WithMany()
                         .HasForeignKey("OwnerId")
                         .OnDelete(DeleteBehavior.Cascade);
+
+                    b.HasOne("OptimaJet.DWKit.StarterApplication.Models.ApplicationType", "Type")
+                       .WithMany()
+                       .HasForeignKey("TypeId");
                 });
 #pragma warning restore 612, 618
         }

--- a/source/OptimaJet.DWKit.StarterApplication/Migrations/20180813133138_AddOrganizationProductDefinition.Designer.cs
+++ b/source/OptimaJet.DWKit.StarterApplication/Migrations/20180813133138_AddOrganizationProductDefinition.Designer.cs
@@ -24,8 +24,10 @@ namespace OptimaJet.DWKit.StarterApplication.Migrations
 
             modelBuilder.Entity("OptimaJet.DWKit.StarterApplication.Models.ApplicationType", b =>
                 {
-                    b.Property<string>("Id")
+                    b.Property<int>("Id")
                         .ValueGeneratedOnAdd();
+
+                    b.Property<string>("Description");
 
                     b.Property<string>("Name");
 
@@ -198,7 +200,7 @@ namespace OptimaJet.DWKit.StarterApplication.Migrations
 
                     b.Property<string>("Name");
 
-                    b.Property<string>("TypeId");
+                    b.Property<int>("TypeId");
 
                     b.Property<int>("WorkflowId");
 
@@ -236,7 +238,7 @@ namespace OptimaJet.DWKit.StarterApplication.Migrations
 
                     b.Property<bool>("Private");
 
-                    b.Property<string>("Type");
+                    b.Property<int>("TypeId");
 
                     b.HasKey("Id");
 
@@ -245,6 +247,8 @@ namespace OptimaJet.DWKit.StarterApplication.Migrations
                     b.HasIndex("OrganizationId");
 
                     b.HasIndex("OwnerId");
+
+                    b.HasIndex("TypeId");
 
                     b.ToTable("Projects");
                 });
@@ -382,6 +386,10 @@ namespace OptimaJet.DWKit.StarterApplication.Migrations
                         .WithMany()
                         .HasForeignKey("OwnerId")
                         .OnDelete(DeleteBehavior.Cascade);
+
+                    b.HasOne("OptimaJet.DWKit.StarterApplication.Models.ApplicationType", "Type")
+                       .WithMany()
+                       .HasForeignKey("TypeId");
                 });
 #pragma warning restore 612, 618
         }

--- a/source/OptimaJet.DWKit.StarterApplication/Migrations/20180815210429_AddUseSilBuildInfrastructureToOrganizations.Designer.cs
+++ b/source/OptimaJet.DWKit.StarterApplication/Migrations/20180815210429_AddUseSilBuildInfrastructureToOrganizations.Designer.cs
@@ -24,8 +24,10 @@ namespace OptimaJet.DWKit.StarterApplication.Migrations
 
             modelBuilder.Entity("OptimaJet.DWKit.StarterApplication.Models.ApplicationType", b =>
                 {
-                    b.Property<string>("Id")
+                    b.Property<int>("Id")
                         .ValueGeneratedOnAdd();
+
+                    b.Property<string>("Description");
 
                     b.Property<string>("Name");
 
@@ -198,7 +200,7 @@ namespace OptimaJet.DWKit.StarterApplication.Migrations
 
                     b.Property<string>("Name");
 
-                    b.Property<string>("TypeId");
+                    b.Property<int>("TypeId");
 
                     b.Property<int>("WorkflowId");
 
@@ -236,7 +238,7 @@ namespace OptimaJet.DWKit.StarterApplication.Migrations
 
                     b.Property<bool>("Private");
 
-                    b.Property<string>("Type");
+                    b.Property<int>("TypeId");
 
                     b.HasKey("Id");
 
@@ -245,6 +247,8 @@ namespace OptimaJet.DWKit.StarterApplication.Migrations
                     b.HasIndex("OrganizationId");
 
                     b.HasIndex("OwnerId");
+
+                    b.HasIndex("TypeId");
 
                     b.ToTable("Projects");
                 });
@@ -382,6 +386,10 @@ namespace OptimaJet.DWKit.StarterApplication.Migrations
                         .WithMany()
                         .HasForeignKey("OwnerId")
                         .OnDelete(DeleteBehavior.Cascade);
+
+                    b.HasOne("OptimaJet.DWKit.StarterApplication.Models.ApplicationType", "Type")
+                       .WithMany()
+                       .HasForeignKey("TypeId");
                 });
 #pragma warning restore 612, 618
         }

--- a/source/OptimaJet.DWKit.StarterApplication/Migrations/20180816123254_AddReviewers.Designer.cs
+++ b/source/OptimaJet.DWKit.StarterApplication/Migrations/20180816123254_AddReviewers.Designer.cs
@@ -24,8 +24,10 @@ namespace OptimaJet.DWKit.StarterApplication.Migrations
 
             modelBuilder.Entity("OptimaJet.DWKit.StarterApplication.Models.ApplicationType", b =>
                 {
-                    b.Property<string>("Id")
+                    b.Property<int>("Id")
                         .ValueGeneratedOnAdd();
+
+                    b.Property<string>("Description");
 
                     b.Property<string>("Name");
 
@@ -198,7 +200,7 @@ namespace OptimaJet.DWKit.StarterApplication.Migrations
 
                     b.Property<string>("Name");
 
-                    b.Property<string>("TypeId");
+                    b.Property<int>("TypeId");
 
                     b.Property<int>("WorkflowId");
 
@@ -236,7 +238,7 @@ namespace OptimaJet.DWKit.StarterApplication.Migrations
 
                     b.Property<bool>("Private");
 
-                    b.Property<string>("Type");
+                    b.Property<int>("TypeId");
 
                     b.HasKey("Id");
 
@@ -245,6 +247,8 @@ namespace OptimaJet.DWKit.StarterApplication.Migrations
                     b.HasIndex("OrganizationId");
 
                     b.HasIndex("OwnerId");
+
+                    b.HasIndex("TypeId");
 
                     b.ToTable("Projects");
                 });
@@ -400,6 +404,10 @@ namespace OptimaJet.DWKit.StarterApplication.Migrations
                         .WithMany()
                         .HasForeignKey("OwnerId")
                         .OnDelete(DeleteBehavior.Cascade);
+
+                    b.HasOne("OptimaJet.DWKit.StarterApplication.Models.ApplicationType", "Type")
+                       .WithMany()
+                       .HasForeignKey("TypeId");
                 });
 
             modelBuilder.Entity("OptimaJet.DWKit.StarterApplication.Models.Reviewer", b =>

--- a/source/OptimaJet.DWKit.StarterApplication/Migrations/20180823174619_AddUserEmailNotifications.Designer.cs
+++ b/source/OptimaJet.DWKit.StarterApplication/Migrations/20180823174619_AddUserEmailNotifications.Designer.cs
@@ -24,8 +24,10 @@ namespace OptimaJet.DWKit.StarterApplication.Migrations
 
             modelBuilder.Entity("OptimaJet.DWKit.StarterApplication.Models.ApplicationType", b =>
                 {
-                    b.Property<string>("Id")
+                    b.Property<int>("Id")
                         .ValueGeneratedOnAdd();
+
+                    b.Property<string>("Description");
 
                     b.Property<string>("Name");
 
@@ -200,7 +202,7 @@ namespace OptimaJet.DWKit.StarterApplication.Migrations
 
                     b.Property<string>("Name");
 
-                    b.Property<string>("TypeId");
+                    b.Property<int>("TypeId");
 
                     b.Property<int>("WorkflowId");
 
@@ -238,7 +240,7 @@ namespace OptimaJet.DWKit.StarterApplication.Migrations
 
                     b.Property<bool>("Private");
 
-                    b.Property<string>("Type");
+                    b.Property<int>("TypeId");
 
                     b.HasKey("Id");
 
@@ -247,6 +249,8 @@ namespace OptimaJet.DWKit.StarterApplication.Migrations
                     b.HasIndex("OrganizationId");
 
                     b.HasIndex("OwnerId");
+
+                    b.HasIndex("TypeId");
 
                     b.ToTable("Projects");
                 });
@@ -406,6 +410,10 @@ namespace OptimaJet.DWKit.StarterApplication.Migrations
                         .WithMany()
                         .HasForeignKey("OwnerId")
                         .OnDelete(DeleteBehavior.Cascade);
+
+                    b.HasOne("OptimaJet.DWKit.StarterApplication.Models.ApplicationType", "Type")
+                       .WithMany()
+                       .HasForeignKey("TypeId");
                 });
 
             modelBuilder.Entity("OptimaJet.DWKit.StarterApplication.Models.Reviewer", b =>

--- a/source/OptimaJet.DWKit.StarterApplication/Migrations/20180824204201_AddProducts.Designer.cs
+++ b/source/OptimaJet.DWKit.StarterApplication/Migrations/20180824204201_AddProducts.Designer.cs
@@ -24,8 +24,10 @@ namespace OptimaJet.DWKit.StarterApplication.Migrations
 
             modelBuilder.Entity("OptimaJet.DWKit.StarterApplication.Models.ApplicationType", b =>
                 {
-                    b.Property<string>("Id")
+                    b.Property<int>("Id")
                         .ValueGeneratedOnAdd();
+
+                    b.Property<string>("Description");
 
                     b.Property<string>("Name");
 
@@ -224,7 +226,7 @@ namespace OptimaJet.DWKit.StarterApplication.Migrations
 
                     b.Property<string>("Name");
 
-                    b.Property<string>("TypeId");
+                    b.Property<int>("TypeId");
 
                     b.Property<int>("WorkflowId");
 
@@ -262,7 +264,7 @@ namespace OptimaJet.DWKit.StarterApplication.Migrations
 
                     b.Property<bool>("Private");
 
-                    b.Property<string>("Type");
+                    b.Property<int>("TypeId");
 
                     b.HasKey("Id");
 
@@ -271,6 +273,8 @@ namespace OptimaJet.DWKit.StarterApplication.Migrations
                     b.HasIndex("OrganizationId");
 
                     b.HasIndex("OwnerId");
+
+                    b.HasIndex("TypeId");
 
                     b.ToTable("Projects");
                 });
@@ -443,6 +447,10 @@ namespace OptimaJet.DWKit.StarterApplication.Migrations
                         .WithMany()
                         .HasForeignKey("OwnerId")
                         .OnDelete(DeleteBehavior.Cascade);
+
+                    b.HasOne("OptimaJet.DWKit.StarterApplication.Models.ApplicationType", "Type")
+                       .WithMany()
+                       .HasForeignKey("TypeId");
                 });
 
             modelBuilder.Entity("OptimaJet.DWKit.StarterApplication.Models.Reviewer", b =>

--- a/source/OptimaJet.DWKit.StarterApplication/Migrations/20180907152517_AddProjectProperties.Designer.cs
+++ b/source/OptimaJet.DWKit.StarterApplication/Migrations/20180907152517_AddProjectProperties.Designer.cs
@@ -24,8 +24,10 @@ namespace OptimaJet.DWKit.StarterApplication.Migrations
 
             modelBuilder.Entity("OptimaJet.DWKit.StarterApplication.Models.ApplicationType", b =>
                 {
-                    b.Property<string>("Id")
+                    b.Property<int>("Id")
                         .ValueGeneratedOnAdd();
+
+                    b.Property<string>("Description");
 
                     b.Property<string>("Name");
 
@@ -200,7 +202,7 @@ namespace OptimaJet.DWKit.StarterApplication.Migrations
 
                     b.Property<string>("Name");
 
-                    b.Property<string>("TypeId");
+                    b.Property<int>("TypeId");
 
                     b.Property<int>("WorkflowId");
 
@@ -246,7 +248,7 @@ namespace OptimaJet.DWKit.StarterApplication.Migrations
 
                     b.Property<bool>("Private");
 
-                    b.Property<string>("Type");
+                    b.Property<int>("TypeId");
 
                     b.HasKey("Id");
 
@@ -255,6 +257,8 @@ namespace OptimaJet.DWKit.StarterApplication.Migrations
                     b.HasIndex("OrganizationId");
 
                     b.HasIndex("OwnerId");
+
+                    b.HasIndex("TypeId");
 
                     b.ToTable("Projects");
                 });
@@ -414,6 +418,10 @@ namespace OptimaJet.DWKit.StarterApplication.Migrations
                         .WithMany()
                         .HasForeignKey("OwnerId")
                         .OnDelete(DeleteBehavior.Cascade);
+
+                    b.HasOne("OptimaJet.DWKit.StarterApplication.Models.ApplicationType", "Type")
+                       .WithMany()
+                       .HasForeignKey("TypeId");
                 });
 
             modelBuilder.Entity("OptimaJet.DWKit.StarterApplication.Models.Reviewer", b =>

--- a/source/OptimaJet.DWKit.StarterApplication/Migrations/20180911122209_AddPublicByDefaultToOrganization.Designer.cs
+++ b/source/OptimaJet.DWKit.StarterApplication/Migrations/20180911122209_AddPublicByDefaultToOrganization.Designer.cs
@@ -24,8 +24,10 @@ namespace OptimaJet.DWKit.StarterApplication.Migrations
 
             modelBuilder.Entity("OptimaJet.DWKit.StarterApplication.Models.ApplicationType", b =>
                 {
-                    b.Property<string>("Id")
+                    b.Property<int>("Id")
                         .ValueGeneratedOnAdd();
+
+                    b.Property<string>("Description");
 
                     b.Property<string>("Name");
 
@@ -206,7 +208,7 @@ namespace OptimaJet.DWKit.StarterApplication.Migrations
 
                     b.Property<string>("Name");
 
-                    b.Property<string>("TypeId");
+                    b.Property<int>("TypeId");
 
                     b.Property<int>("WorkflowId");
 
@@ -252,7 +254,7 @@ namespace OptimaJet.DWKit.StarterApplication.Migrations
 
                     b.Property<bool>("Private");
 
-                    b.Property<string>("Type");
+                    b.Property<int>("TypeId");
 
                     b.HasKey("Id");
 
@@ -261,6 +263,8 @@ namespace OptimaJet.DWKit.StarterApplication.Migrations
                     b.HasIndex("OrganizationId");
 
                     b.HasIndex("OwnerId");
+
+                    b.HasIndex("TypeId");
 
                     b.ToTable("Projects");
                 });
@@ -420,6 +424,10 @@ namespace OptimaJet.DWKit.StarterApplication.Migrations
                         .WithMany()
                         .HasForeignKey("OwnerId")
                         .OnDelete(DeleteBehavior.Cascade);
+
+                    b.HasOne("OptimaJet.DWKit.StarterApplication.Models.ApplicationType", "Type")
+                       .WithMany()
+                       .HasForeignKey("TypeId");
                 });
 
             modelBuilder.Entity("OptimaJet.DWKit.StarterApplication.Models.Reviewer", b =>

--- a/source/OptimaJet.DWKit.StarterApplication/Migrations/20180912174013_AddBuildEngineProperties.Designer.cs
+++ b/source/OptimaJet.DWKit.StarterApplication/Migrations/20180912174013_AddBuildEngineProperties.Designer.cs
@@ -24,8 +24,10 @@ namespace OptimaJet.DWKit.StarterApplication.Migrations
 
             modelBuilder.Entity("OptimaJet.DWKit.StarterApplication.Models.ApplicationType", b =>
                 {
-                    b.Property<string>("Id")
+                    b.Property<int>("Id")
                         .ValueGeneratedOnAdd();
+
+                    b.Property<string>("Description");
 
                     b.Property<string>("Name");
 
@@ -238,7 +240,7 @@ namespace OptimaJet.DWKit.StarterApplication.Migrations
 
                     b.Property<string>("Name");
 
-                    b.Property<string>("TypeId");
+                    b.Property<int>("TypeId");
 
                     b.Property<int>("WorkflowId");
 
@@ -284,7 +286,7 @@ namespace OptimaJet.DWKit.StarterApplication.Migrations
 
                     b.Property<bool>("Private");
 
-                    b.Property<string>("Type");
+                    b.Property<int>("TypeId");
 
                     b.Property<int>("WorkflowProjectId");
 
@@ -295,6 +297,8 @@ namespace OptimaJet.DWKit.StarterApplication.Migrations
                     b.HasIndex("OrganizationId");
 
                     b.HasIndex("OwnerId");
+
+                    b.HasIndex("TypeId");
 
                     b.ToTable("Projects");
                 });
@@ -469,6 +473,10 @@ namespace OptimaJet.DWKit.StarterApplication.Migrations
                         .WithMany()
                         .HasForeignKey("OwnerId")
                         .OnDelete(DeleteBehavior.Cascade);
+
+                    b.HasOne("OptimaJet.DWKit.StarterApplication.Models.ApplicationType", "Type")
+                       .WithMany()
+                       .HasForeignKey("TypeId");
                 });
 
             modelBuilder.Entity("OptimaJet.DWKit.StarterApplication.Models.Reviewer", b =>

--- a/source/OptimaJet.DWKit.StarterApplication/Migrations/20180924195512_ProjectRenameProperty.Designer.cs
+++ b/source/OptimaJet.DWKit.StarterApplication/Migrations/20180924195512_ProjectRenameProperty.Designer.cs
@@ -6,12 +6,13 @@ using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using OptimaJet.DWKit.StarterApplication.Data;
+using OptimaJet.DWKit.StarterApplication.Models;
 
 namespace OptimaJet.DWKit.StarterApplication.Migrations
 {
     [DbContext(typeof(AppDbContext))]
-    [Migration("20180803221432_AddProductDefinition")]
-    partial class AddProductDefinition
+    [Migration("20180924195512_ProjectRenameProperty")]
+    partial class ProjectRenameProperty
     {
         protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
@@ -109,6 +110,14 @@ namespace OptimaJet.DWKit.StarterApplication.Migrations
 
                     b.Property<int>("OwnerId");
 
+                    b.Property<bool>("PublicByDefault")
+                        .ValueGeneratedOnAdd()
+                        .HasDefaultValue(true);
+
+                    b.Property<bool>("UseSilBuildInfrastructure")
+                        .ValueGeneratedOnAdd()
+                        .HasDefaultValue(true);
+
                     b.Property<string>("WebsiteUrl");
 
                     b.HasKey("Id");
@@ -139,8 +148,9 @@ namespace OptimaJet.DWKit.StarterApplication.Migrations
                     b.Property<int>("Id")
                         .ValueGeneratedOnAdd();
 
-                    b.Property<DateTime>("Created")
-                        .ValueGeneratedOnAdd();
+                    b.Property<DateTime?>("DateCreated");
+
+                    b.Property<DateTime?>("DateUpdated");
 
                     b.Property<string>("Name");
 
@@ -171,6 +181,56 @@ namespace OptimaJet.DWKit.StarterApplication.Migrations
                     b.ToTable("OrganizationMemberships");
                 });
 
+            modelBuilder.Entity("OptimaJet.DWKit.StarterApplication.Models.OrganizationProductDefinition", b =>
+                {
+                    b.Property<int>("Id")
+                        .ValueGeneratedOnAdd();
+
+                    b.Property<int>("OrganizationId");
+
+                    b.Property<int>("ProductDefinitionId");
+
+                    b.HasKey("Id");
+
+                    b.HasIndex("OrganizationId");
+
+                    b.HasIndex("ProductDefinitionId");
+
+                    b.ToTable("OrganizationProductDefinitions");
+                });
+
+            modelBuilder.Entity("OptimaJet.DWKit.StarterApplication.Models.Product", b =>
+                {
+                    b.Property<int>("Id")
+                        .ValueGeneratedOnAdd();
+
+                    b.Property<DateTime?>("DateBuilt");
+
+                    b.Property<DateTime?>("DateCreated");
+
+                    b.Property<DateTime?>("DatePublished");
+
+                    b.Property<DateTime?>("DateUpdated");
+
+                    b.Property<int>("ProductDefinitionId");
+
+                    b.Property<int>("ProjectId");
+
+                    b.Property<int>("WorkflowBuildId");
+
+                    b.Property<int>("WorkflowJobId");
+
+                    b.Property<int>("WorkflowPublishId");
+
+                    b.HasKey("Id");
+
+                    b.HasIndex("ProductDefinitionId");
+
+                    b.HasIndex("ProjectId");
+
+                    b.ToTable("Products");
+                });
+
             modelBuilder.Entity("OptimaJet.DWKit.StarterApplication.Models.ProductDefinition", b =>
                 {
                     b.Property<int>("Id")
@@ -198,9 +258,19 @@ namespace OptimaJet.DWKit.StarterApplication.Migrations
                     b.Property<int>("Id")
                         .ValueGeneratedOnAdd();
 
-                    b.Property<DateTime>("DateCreated");
+                    b.Property<bool>("AllowDownloads")
+                        .ValueGeneratedOnAdd()
+                        .HasDefaultValue(true);
 
-                    b.Property<DateTime>("DateUpdated");
+                    b.Property<bool>("AutomaticBuilds")
+                        .ValueGeneratedOnAdd()
+                        .HasDefaultValue(true);
+
+                    b.Property<DateTime?>("DateArchived");
+
+                    b.Property<DateTime?>("DateCreated");
+
+                    b.Property<DateTime?>("DateUpdated");
 
                     b.Property<string>("Description");
 
@@ -218,6 +288,8 @@ namespace OptimaJet.DWKit.StarterApplication.Migrations
 
                     b.Property<int>("TypeId");
 
+                    b.Property<int>("WorkflowProjectId");
+
                     b.HasKey("Id");
 
                     b.HasIndex("GroupId");
@@ -231,12 +303,34 @@ namespace OptimaJet.DWKit.StarterApplication.Migrations
                     b.ToTable("Projects");
                 });
 
+            modelBuilder.Entity("OptimaJet.DWKit.StarterApplication.Models.Reviewer", b =>
+                {
+                    b.Property<int>("Id")
+                        .ValueGeneratedOnAdd();
+
+                    b.Property<string>("Email");
+
+                    b.Property<string>("Name");
+
+                    b.Property<int>("ProjectId");
+
+                    b.HasKey("Id");
+
+                    b.HasIndex("ProjectId");
+
+                    b.ToTable("Reviewers");
+                });
+
             modelBuilder.Entity("OptimaJet.DWKit.StarterApplication.Models.User", b =>
                 {
                     b.Property<int>("Id")
                         .ValueGeneratedOnAdd();
 
                     b.Property<string>("Email");
+
+                    b.Property<bool>("EmailNotification")
+                        .ValueGeneratedOnAdd()
+                        .HasDefaultValue(true);
 
                     b.Property<string>("ExternalId");
 
@@ -251,6 +345,12 @@ namespace OptimaJet.DWKit.StarterApplication.Migrations
                     b.Property<string>("Name");
 
                     b.Property<string>("Phone");
+
+                    b.Property<int>("ProfileVisibility")
+                        .ValueGeneratedOnAdd()
+                        .HasDefaultValue(1);
+
+                    b.Property<string>("PublishingKey");
 
                     b.Property<string>("Timezone");
 
@@ -280,7 +380,7 @@ namespace OptimaJet.DWKit.StarterApplication.Migrations
             modelBuilder.Entity("OptimaJet.DWKit.StarterApplication.Models.Group", b =>
                 {
                     b.HasOne("OptimaJet.DWKit.StarterApplication.Models.Organization", "Owner")
-                        .WithMany()
+                        .WithMany("Groups")
                         .HasForeignKey("OwnerId")
                         .OnDelete(DeleteBehavior.Cascade);
                 });
@@ -319,11 +419,38 @@ namespace OptimaJet.DWKit.StarterApplication.Migrations
                         .OnDelete(DeleteBehavior.Cascade);
                 });
 
+            modelBuilder.Entity("OptimaJet.DWKit.StarterApplication.Models.OrganizationProductDefinition", b =>
+                {
+                    b.HasOne("OptimaJet.DWKit.StarterApplication.Models.Organization", "Organization")
+                        .WithMany("OrganizationProductDefinitions")
+                        .HasForeignKey("OrganizationId")
+                        .OnDelete(DeleteBehavior.Cascade);
+
+                    b.HasOne("OptimaJet.DWKit.StarterApplication.Models.ProductDefinition", "ProductDefinition")
+                        .WithMany()
+                        .HasForeignKey("ProductDefinitionId")
+                        .OnDelete(DeleteBehavior.Cascade);
+                });
+
+            modelBuilder.Entity("OptimaJet.DWKit.StarterApplication.Models.Product", b =>
+                {
+                    b.HasOne("OptimaJet.DWKit.StarterApplication.Models.ProductDefinition", "ProductDefinition")
+                        .WithMany()
+                        .HasForeignKey("ProductDefinitionId")
+                        .OnDelete(DeleteBehavior.Cascade);
+
+                    b.HasOne("OptimaJet.DWKit.StarterApplication.Models.Project", "Project")
+                        .WithMany()
+                        .HasForeignKey("ProjectId")
+                        .OnDelete(DeleteBehavior.Cascade);
+                });
+
             modelBuilder.Entity("OptimaJet.DWKit.StarterApplication.Models.ProductDefinition", b =>
                 {
                     b.HasOne("OptimaJet.DWKit.StarterApplication.Models.ApplicationType", "Type")
                         .WithMany()
-                        .HasForeignKey("TypeId");
+                        .HasForeignKey("TypeId")
+                        .OnDelete(DeleteBehavior.Cascade);
 
                     b.HasOne("OptimaJet.DWKit.StarterApplication.Models.WorkflowDefinition", "Workflow")
                         .WithMany()
@@ -349,8 +476,17 @@ namespace OptimaJet.DWKit.StarterApplication.Migrations
                         .OnDelete(DeleteBehavior.Cascade);
 
                     b.HasOne("OptimaJet.DWKit.StarterApplication.Models.ApplicationType", "Type")
-                       .WithMany()
-                       .HasForeignKey("TypeId");
+                        .WithMany()
+                        .HasForeignKey("TypeId")
+                        .OnDelete(DeleteBehavior.Cascade);
+                });
+
+            modelBuilder.Entity("OptimaJet.DWKit.StarterApplication.Models.Reviewer", b =>
+                {
+                    b.HasOne("OptimaJet.DWKit.StarterApplication.Models.Project", "Project")
+                        .WithMany("Reviewers")
+                        .HasForeignKey("ProjectId")
+                        .OnDelete(DeleteBehavior.Cascade);
                 });
 #pragma warning restore 612, 618
         }

--- a/source/OptimaJet.DWKit.StarterApplication/Migrations/20180924195512_ProjectRenameProperty.cs
+++ b/source/OptimaJet.DWKit.StarterApplication/Migrations/20180924195512_ProjectRenameProperty.cs
@@ -1,0 +1,23 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+namespace OptimaJet.DWKit.StarterApplication.Migrations
+{
+    public partial class ProjectRenameProperty : Migration
+    {
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.RenameColumn(
+                name: "DataArchived",
+                table: "Projects",
+                newName: "DateArchived");
+        }
+
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.RenameColumn(
+                name: "DateArchived",
+                table: "Projects",
+                newName: "DataArchived");
+        }
+    }
+}

--- a/source/OptimaJet.DWKit.StarterApplication/Migrations/AppDbContextModelSnapshot.cs
+++ b/source/OptimaJet.DWKit.StarterApplication/Migrations/AppDbContextModelSnapshot.cs
@@ -5,6 +5,7 @@ using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using OptimaJet.DWKit.StarterApplication.Data;
+using OptimaJet.DWKit.StarterApplication.Models;
 
 namespace OptimaJet.DWKit.StarterApplication.Migrations
 {
@@ -21,8 +22,10 @@ namespace OptimaJet.DWKit.StarterApplication.Migrations
 
             modelBuilder.Entity("OptimaJet.DWKit.StarterApplication.Models.ApplicationType", b =>
                 {
-                    b.Property<string>("Id")
+                    b.Property<int>("Id")
                         .ValueGeneratedOnAdd();
+
+                    b.Property<string>("Description");
 
                     b.Property<string>("Name");
 
@@ -235,7 +238,7 @@ namespace OptimaJet.DWKit.StarterApplication.Migrations
 
                     b.Property<string>("Name");
 
-                    b.Property<string>("TypeId");
+                    b.Property<int>("TypeId");
 
                     b.Property<int>("WorkflowId");
 
@@ -261,7 +264,7 @@ namespace OptimaJet.DWKit.StarterApplication.Migrations
                         .ValueGeneratedOnAdd()
                         .HasDefaultValue(true);
 
-                    b.Property<DateTime?>("DataArchived");
+                    b.Property<DateTime?>("DateArchived");
 
                     b.Property<DateTime?>("DateCreated");
 
@@ -281,7 +284,7 @@ namespace OptimaJet.DWKit.StarterApplication.Migrations
 
                     b.Property<bool>("Private");
 
-                    b.Property<string>("Type");
+                    b.Property<int>("TypeId");
 
                     b.Property<int>("WorkflowProjectId");
 
@@ -292,6 +295,8 @@ namespace OptimaJet.DWKit.StarterApplication.Migrations
                     b.HasIndex("OrganizationId");
 
                     b.HasIndex("OwnerId");
+
+                    b.HasIndex("TypeId");
 
                     b.ToTable("Projects");
                 });
@@ -442,7 +447,8 @@ namespace OptimaJet.DWKit.StarterApplication.Migrations
                 {
                     b.HasOne("OptimaJet.DWKit.StarterApplication.Models.ApplicationType", "Type")
                         .WithMany()
-                        .HasForeignKey("TypeId");
+                        .HasForeignKey("TypeId")
+                        .OnDelete(DeleteBehavior.Cascade);
 
                     b.HasOne("OptimaJet.DWKit.StarterApplication.Models.WorkflowDefinition", "Workflow")
                         .WithMany()
@@ -465,6 +471,11 @@ namespace OptimaJet.DWKit.StarterApplication.Migrations
                     b.HasOne("OptimaJet.DWKit.StarterApplication.Models.User", "Owner")
                         .WithMany()
                         .HasForeignKey("OwnerId")
+                        .OnDelete(DeleteBehavior.Cascade);
+
+                    b.HasOne("OptimaJet.DWKit.StarterApplication.Models.ApplicationType", "Type")
+                        .WithMany()
+                        .HasForeignKey("TypeId")
                         .OnDelete(DeleteBehavior.Cascade);
                 });
 

--- a/source/OptimaJet.DWKit.StarterApplication/Models/ApplicationType.cs
+++ b/source/OptimaJet.DWKit.StarterApplication/Models/ApplicationType.cs
@@ -3,9 +3,12 @@ using JsonApiDotNetCore.Models;
 
 namespace OptimaJet.DWKit.StarterApplication.Models
 {
-    public class ApplicationType : Identifiable<string> 
+    public class ApplicationType : Identifiable 
     {
         [Attr("name")]
         public string Name { get; set; }
+
+        [Attr("description")]
+        public string Description { get; set; }
     }
 }

--- a/source/OptimaJet.DWKit.StarterApplication/Models/ProductDefinition.cs
+++ b/source/OptimaJet.DWKit.StarterApplication/Models/ProductDefinition.cs
@@ -9,7 +9,7 @@ namespace OptimaJet.DWKit.StarterApplication.Models
 
         [HasOne("type")]
         public virtual ApplicationType Type { get; set; }
-        public string TypeId { get; set; }
+        public int TypeId { get; set; }
 
         [Attr("description")]
         public string Description { get; set; }

--- a/source/OptimaJet.DWKit.StarterApplication/Models/Project.cs
+++ b/source/OptimaJet.DWKit.StarterApplication/Models/Project.cs
@@ -10,8 +10,11 @@ namespace OptimaJet.DWKit.StarterApplication.Models
         [Attr("name")]
         public string Name { get; set; }
 
-        [Attr("type")]
-        public string Type { get; set; }
+        [HasOne("type")]
+        public virtual ApplicationType Type { get; set; }
+
+        [Attr("type-id")]
+        public int TypeId { get; set; }
 
         [Attr("description")]
         public string Description { get; set; }
@@ -42,7 +45,7 @@ namespace OptimaJet.DWKit.StarterApplication.Models
         public DateTime? DateUpdated { get; set; }
 
         [Attr("date-archived")]
-        public DateTime? DataArchived { get; set; }
+        public DateTime? DateArchived { get; set; }
 
         [HasMany("reviewers", Link.None)]
         public virtual List<Reviewer> Reviewers { get; set; }

--- a/source/SIL.AppBuilder.Portal.Backend.Tests/Acceptance/APIControllers/Organizations/BaseOrganizationTest.cs
+++ b/source/SIL.AppBuilder.Portal.Backend.Tests/Acceptance/APIControllers/Organizations/BaseOrganizationTest.cs
@@ -66,7 +66,8 @@ namespace SIL.AppBuilder.Portal.Backend.Tests.Acceptance.APIControllers.Organiza
             });
             appType1 = AddEntity<AppDbContext, ApplicationType>(new ApplicationType
             {
-                Name = "TestApp1"
+                Name = "TestApp1",
+                Description = "Test Application"
             });
             workflow1 = AddEntity<AppDbContext, WorkflowDefinition>(new WorkflowDefinition
             {

--- a/source/SIL.AppBuilder.Portal.Backend.Tests/Acceptance/APIControllers/Products/BaseProductTest.cs
+++ b/source/SIL.AppBuilder.Portal.Backend.Tests/Acceptance/APIControllers/Products/BaseProductTest.cs
@@ -26,11 +26,11 @@ namespace SIL.AppBuilder.Portal.Backend.Tests.Acceptance.APIControllers.Products
         public Group group3 { get; set; }
         public Group group4 { get; set; }
         public GroupMembership groupMembership1 { get; set; }
+        public ApplicationType type1 { get; set; }
         public Project project1 { get; set; }
         public Project project2 { get; set; }
         public Project project3 { get; set; }
         public Project project4 { get; set; }
-        public ApplicationType appType1 { get; set; }
         public WorkflowDefinition workflow1 { get; set; }
         public ProductDefinition productDefinition1 { get; set; }
         public ProductDefinition productDefinition2 { get; set; }
@@ -124,10 +124,15 @@ namespace SIL.AppBuilder.Portal.Backend.Tests.Acceptance.APIControllers.Products
                 UserId = CurrentUser.Id,
                 GroupId = group1.Id
             });
+            type1 = AddEntity<AppDbContext, ApplicationType>(new ApplicationType
+            {
+                Name = "scriptureappbuilder",
+                Description = "Scripture App Builder"
+            });
             project1 = AddEntity<AppDbContext, Project>(new Project
             {
                 Name = "Test Project1",
-                Type = "scriptureappbuilder",
+                TypeId = type1.Id,
                 Description = "Test Description",
                 OwnerId = CurrentUser.Id,
                 GroupId = group1.Id,
@@ -138,7 +143,7 @@ namespace SIL.AppBuilder.Portal.Backend.Tests.Acceptance.APIControllers.Products
             project2 = AddEntity<AppDbContext, Project>(new Project
             {
                 Name = "Test Project2",
-                Type = "scriptureappbuilder",
+                TypeId = type1.Id,
                 Description = "Test Description",
                 OwnerId = CurrentUser.Id,
                 GroupId = group1.Id,
@@ -149,7 +154,7 @@ namespace SIL.AppBuilder.Portal.Backend.Tests.Acceptance.APIControllers.Products
             project3 = AddEntity<AppDbContext, Project>(new Project
             {
                 Name = "Test Project3",
-                Type = "scriptureappbuilder",
+                TypeId = type1.Id,
                 Description = "Test Description",
                 OwnerId = CurrentUser.Id,
                 GroupId = group3.Id,
@@ -160,17 +165,13 @@ namespace SIL.AppBuilder.Portal.Backend.Tests.Acceptance.APIControllers.Products
             project4 = AddEntity<AppDbContext, Project>(new Project
             {
                 Name = "Test Project4",
-                Type = "scriptureappbuilder",
+                TypeId = type1.Id,
                 Description = "Test Description",
                 OwnerId = user1.Id,
                 GroupId = group4.Id,
                 OrganizationId = org3.Id,
                 Language = "eng-US",
                 Private = false
-            });
-            appType1 = AddEntity<AppDbContext, ApplicationType>(new ApplicationType
-            {
-                Name = "TestApp1"
             });
             workflow1 = AddEntity<AppDbContext, WorkflowDefinition>(new WorkflowDefinition
             {
@@ -182,14 +183,14 @@ namespace SIL.AppBuilder.Portal.Backend.Tests.Acceptance.APIControllers.Products
             productDefinition1 = AddEntity<AppDbContext, ProductDefinition>(new ProductDefinition
             {
                 Name = "TestProd1",
-                TypeId = appType1.Id,
+                TypeId = type1.Id,
                 Description = "This is a test product",
                 WorkflowId = workflow1.Id
             });
             productDefinition2 = AddEntity<AppDbContext, ProductDefinition>(new ProductDefinition
             {
                 Name = "TestProd2",
-                TypeId = appType1.Id,
+                TypeId = type1.Id,
                 Description = "This is test product 2",
                 WorkflowId = workflow1.Id
 
@@ -197,7 +198,7 @@ namespace SIL.AppBuilder.Portal.Backend.Tests.Acceptance.APIControllers.Products
             productDefinition3 = AddEntity<AppDbContext, ProductDefinition>(new ProductDefinition
             {
                 Name = "TestProd3",
-                TypeId = appType1.Id,
+                TypeId = type1.Id,
                 Description = "This is test product 3",
                 WorkflowId = workflow1.Id
 

--- a/source/SIL.AppBuilder.Portal.Backend.Tests/Acceptance/APIControllers/Projects/CreateProjectTest.cs
+++ b/source/SIL.AppBuilder.Portal.Backend.Tests/Acceptance/APIControllers/Projects/CreateProjectTest.cs
@@ -31,6 +31,7 @@ namespace SIL.AppBuilder.Portal.Backend.Tests.Acceptance.APIControllers.Projects
         public Group group3 { get; set; }
         public Group group4 { get; set; }
         public GroupMembership groupMembership1 { get; set; }
+        public ApplicationType type1 { get; set; }
         public Project project1 { get; set; }
         public Project project2 { get; set; }
         public Project project3 { get; set; }
@@ -118,10 +119,15 @@ namespace SIL.AppBuilder.Portal.Backend.Tests.Acceptance.APIControllers.Projects
                 UserId = CurrentUser.Id,
                 GroupId = group1.Id
             });
+            type1 = AddEntity<AppDbContext, ApplicationType>(new ApplicationType
+            {
+                Name = "scriptureappbuilder",
+                Description = "Scripture App Builder"
+            });
             project1 = AddEntity<AppDbContext, Project>(new Project
             {
                 Name = "Test Project1",
-                Type = "scriptureappbuilder",
+                TypeId = type1.Id,
                 Description = "Test Description",
                 OwnerId = CurrentUser.Id,
                 GroupId = group1.Id,
@@ -132,7 +138,7 @@ namespace SIL.AppBuilder.Portal.Backend.Tests.Acceptance.APIControllers.Projects
             project2 = AddEntity<AppDbContext, Project>(new Project
             {
                 Name = "Test Project2",
-                Type = "scriptureappbuilder",
+                TypeId = type1.Id,
                 Description = "Test Description",
                 OwnerId = CurrentUser.Id,
                 GroupId = group1.Id,
@@ -143,7 +149,7 @@ namespace SIL.AppBuilder.Portal.Backend.Tests.Acceptance.APIControllers.Projects
             project3 = AddEntity<AppDbContext, Project>(new Project
             {
                 Name = "Test Project3",
-                Type = "scriptureappbuilder",
+                TypeId = type1.Id,
                 Description = "Test Description",
                 OwnerId = CurrentUser.Id,
                 GroupId = group3.Id,
@@ -154,7 +160,7 @@ namespace SIL.AppBuilder.Portal.Backend.Tests.Acceptance.APIControllers.Projects
             project4 = AddEntity<AppDbContext, Project>(new Project
             {
                 Name = "Test Project4",
-                Type = "scriptureappbuilder",
+                TypeId = type1.Id,
                 Description = "Test Description",
                 OwnerId = CurrentUser.Id,
                 GroupId = group4.Id,

--- a/source/SIL.AppBuilder.Portal.Backend.Tests/Acceptance/APIControllers/Projects/GetProjectTest.cs
+++ b/source/SIL.AppBuilder.Portal.Backend.Tests/Acceptance/APIControllers/Projects/GetProjectTest.cs
@@ -30,6 +30,7 @@ namespace SIL.AppBuilder.Portal.Backend.Tests.Acceptance.APIControllers.Projects
         public Group group3 { get; set; }
         public Group group4 { get; set; }
         public GroupMembership groupMembership1 { get; set; }
+        public ApplicationType type1 { get; set; }
         public Project project1 { get; set; }
         public Project project2 { get; set; }
         public Project project3 { get; set; }
@@ -104,10 +105,15 @@ namespace SIL.AppBuilder.Portal.Backend.Tests.Acceptance.APIControllers.Projects
                 UserId = CurrentUser.Id,
                 GroupId = group1.Id
             });
+            type1 = AddEntity<AppDbContext, ApplicationType>(new ApplicationType
+            {
+                Name = "scriptureappbuilder",
+                Description = "Scripture App Builder"
+            });
             project1 = AddEntity<AppDbContext, Project>(new Project
             {
                 Name = "Test Project1",
-                Type = "scriptureappbuilder",
+                TypeId = type1.Id,
                 Description = "Test Description",
                 OwnerId = CurrentUser.Id,
                 GroupId = group1.Id,
@@ -118,7 +124,7 @@ namespace SIL.AppBuilder.Portal.Backend.Tests.Acceptance.APIControllers.Projects
             project2 = AddEntity<AppDbContext, Project>(new Project
             {
                 Name = "Test Project2",
-                Type = "scriptureappbuilder",
+                TypeId = type1.Id,
                 Description = "Test Description",
                 OwnerId = CurrentUser.Id,
                 GroupId = group1.Id,
@@ -129,7 +135,7 @@ namespace SIL.AppBuilder.Portal.Backend.Tests.Acceptance.APIControllers.Projects
             project3 = AddEntity<AppDbContext, Project>(new Project
             {
                 Name = "Test Project3",
-                Type = "scriptureappbuilder",
+                TypeId = type1.Id,
                 Description = "Test Description",
                 OwnerId = CurrentUser.Id,
                 GroupId = group3.Id,
@@ -140,7 +146,7 @@ namespace SIL.AppBuilder.Portal.Backend.Tests.Acceptance.APIControllers.Projects
             project4 = AddEntity<AppDbContext, Project>(new Project
             {
                 Name = "Test Project4",
-                Type = "scriptureappbuilder",
+                TypeId = type1.Id,
                 Description = "Test Description",
                 OwnerId = CurrentUser.Id,
                 GroupId = group4.Id,

--- a/source/SIL.AppBuilder.Portal.Backend.Tests/Acceptance/APIControllers/Projects/GetProjectsTest.cs
+++ b/source/SIL.AppBuilder.Portal.Backend.Tests/Acceptance/APIControllers/Projects/GetProjectsTest.cs
@@ -30,6 +30,7 @@ namespace SIL.AppBuilder.Portal.Backend.Tests.Acceptance.APIControllers.Projects
         public Group group3 { get; set; }
         public Group group4 { get; set; }
         public GroupMembership groupMembership1 { get; set; }
+        public ApplicationType type1 { get; set; }
         public Project project1 { get; set; }
         public Project project2 { get; set; }
         public Project project3 { get; set; }
@@ -107,10 +108,15 @@ namespace SIL.AppBuilder.Portal.Backend.Tests.Acceptance.APIControllers.Projects
                 UserId = CurrentUser.Id,
                 GroupId = group1.Id
             });
+            type1 = AddEntity<AppDbContext, ApplicationType>(new ApplicationType
+            {
+                Name = "scriptureappbuilder",
+                Description = "Scripture App Builder"
+            });
             project1 = AddEntity<AppDbContext, Project>(new Project
             {
                 Name = "Test Project1",
-                Type = "scriptureappbuilder",
+                TypeId = type1.Id,
                 Description = "Test Description",
                 OwnerId = CurrentUser.Id,
                 GroupId = group1.Id,
@@ -121,7 +127,7 @@ namespace SIL.AppBuilder.Portal.Backend.Tests.Acceptance.APIControllers.Projects
             project2 = AddEntity<AppDbContext, Project>(new Project
             {
                 Name = "Test Project2",
-                Type = "scriptureappbuilder",
+                TypeId = type1.Id,
                 Description = "Test Description",
                 OwnerId = CurrentUser.Id,
                 GroupId = group1.Id,
@@ -132,7 +138,7 @@ namespace SIL.AppBuilder.Portal.Backend.Tests.Acceptance.APIControllers.Projects
             project3 = AddEntity<AppDbContext, Project>(new Project
             {
                 Name = "Test Project3",
-                Type = "scriptureappbuilder",
+                TypeId = type1.Id,
                 Description = "Test Description",
                 OwnerId = CurrentUser.Id,
                 GroupId = group3.Id,
@@ -143,7 +149,7 @@ namespace SIL.AppBuilder.Portal.Backend.Tests.Acceptance.APIControllers.Projects
             project4 = AddEntity<AppDbContext, Project>(new Project
             {
                 Name = "Test Project4",
-                Type = "scriptureappbuilder",
+                TypeId = type1.Id,
                 Description = "Test Description",
                 OwnerId = CurrentUser.Id,
                 GroupId = group4.Id,

--- a/source/SIL.AppBuilder.Portal.Backend.Tests/Acceptance/APIControllers/Projects/UpdateProjectTest.cs
+++ b/source/SIL.AppBuilder.Portal.Backend.Tests/Acceptance/APIControllers/Projects/UpdateProjectTest.cs
@@ -31,6 +31,7 @@ namespace SIL.AppBuilder.Portal.Backend.Tests.Acceptance.APIControllers.Projects
         public Group group3 { get; set; }
         public Group group4 { get; set; }
         public GroupMembership groupMembership1 { get; set; }
+        public ApplicationType type1 { get; set; }
         public Project project1 { get; set; }
         public Project project2 { get; set; }
         public Project project3 { get; set; }
@@ -118,10 +119,15 @@ namespace SIL.AppBuilder.Portal.Backend.Tests.Acceptance.APIControllers.Projects
                 UserId = CurrentUser.Id,
                 GroupId = group1.Id
             });
+            type1 = AddEntity<AppDbContext, ApplicationType>(new ApplicationType
+            {
+                Name = "scriptureappbuilder",
+                Description = "Scripture App Builder"
+            });
             project1 = AddEntity<AppDbContext, Project>(new Project
             {
                 Name = "Test Project1",
-                Type = "scriptureappbuilder",
+                TypeId = type1.Id,
                 Description = "Test Description",
                 OwnerId = CurrentUser.Id,
                 GroupId = group1.Id,
@@ -132,7 +138,7 @@ namespace SIL.AppBuilder.Portal.Backend.Tests.Acceptance.APIControllers.Projects
             project2 = AddEntity<AppDbContext, Project>(new Project
             {
                 Name = "Test Project2",
-                Type = "scriptureappbuilder",
+                TypeId = type1.Id,
                 Description = "Test Description",
                 OwnerId = CurrentUser.Id,
                 GroupId = group1.Id,
@@ -143,7 +149,7 @@ namespace SIL.AppBuilder.Portal.Backend.Tests.Acceptance.APIControllers.Projects
             project3 = AddEntity<AppDbContext, Project>(new Project
             {
                 Name = "Test Project3",
-                Type = "scriptureappbuilder",
+                TypeId = type1.Id,
                 Description = "Test Description",
                 OwnerId = CurrentUser.Id,
                 GroupId = group3.Id,
@@ -154,7 +160,7 @@ namespace SIL.AppBuilder.Portal.Backend.Tests.Acceptance.APIControllers.Projects
             project4 = AddEntity<AppDbContext, Project>(new Project
             {
                 Name = "Test Project4",
-                Type = "scriptureappbuilder",
+                TypeId = type1.Id,
                 Description = "Test Description",
                 OwnerId = CurrentUser.Id,
                 GroupId = group4.Id,


### PR DESCRIPTION
Here is an overview of my changes:
• Changed `ApplicationType` to have: `int Id`, `string Name`, `string Description` (instead of `string Id`, `string Name`).  What was `Name` is now `Description` and what was `Id` is now `Name`.
• Changed `ProductionDefinition` to use `int TypeId` instead of `string TypeId`
• Changed `Project` to have `ApplicationType Type` and `int TypeId`
• Changed `Project.DataArchived` to `Project.DateArchived`