### PR TITLE
Actual work on Filtering on the Project Directory -- finally

### DIFF
--- a/source/OptimaJet.DWKit.StarterApplication/OptimaJet.DWKit.StarterApplication.csproj
+++ b/source/OptimaJet.DWKit.StarterApplication/OptimaJet.DWKit.StarterApplication.csproj
@@ -31,6 +31,7 @@
     <PackageReference Include="DWKit-Core" Version="2.2.3" />
     <PackageReference Include="Microsoft.ApplicationInsights.AspNetCore" Version="2.1.1" />
     <PackageReference Include="Microsoft.AspNetCore" Version="2.1.1" />
+    <PackageReference Include="Microsoft.NETCore.App" Version="2.1.1" />
     <PackageReference Include="Microsoft.AspNetCore.Authentication.Cookies" Version="2.1.1" />
     <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="2.1.1" />
     <PackageReference Include="Microsoft.AspNetCore.Http.Abstractions" Version="2.1.1" />

--- a/source/SIL.AppBuilder.Portal.Frontend/src/data/containers/resources/project/list.tsx
+++ b/source/SIL.AppBuilder.Portal.Frontend/src/data/containers/resources/project/list.tsx
@@ -16,7 +16,7 @@ export interface IOwnProps {
 }
 
 interface IOptions {
-  organizationHeader?: string;
+  all?: boolean;
 }
 
 type IProps =
@@ -25,13 +25,9 @@ type IProps =
 & ISortProps;
 
 export function withNetwork<TWrappedProps>(options: IOptions = {}) {
-  const { organizationHeader } = options;
+  const { all } = options;
 
-  const isUsingSpecifiedOrgHeader = (
-    organizationHeader !== null &&
-    organizationHeader !== undefined
-  );
-
+  const isWantingAllProjects = all === true;
 
   return WrappedComponent => {
     function mapNetworkToProps(passedProps: TWrappedProps & IProps) {
@@ -45,8 +41,8 @@ export function withNetwork<TWrappedProps>(options: IOptions = {}) {
         include: ['organization,group,owner']
       });
 
-      if (isUsingSpecifiedOrgHeader) {
-        requestOptions.sources.remote.settings.headers.Organization = organizationHeader;
+      if (isWantingAllProjects) {
+        delete requestOptions.sources.remote.settings.headers.Organization;
       }
 
       return {

--- a/source/SIL.AppBuilder.Portal.Frontend/src/data/store.ts
+++ b/source/SIL.AppBuilder.Portal.Frontend/src/data/store.ts
@@ -80,7 +80,8 @@ export async function createStore() {
         Accept: 'application/vnd.api+json',
         // these should be overwritten at runtime
         Authorization: 'Bearer not set',
-        Organization: 'Org Id not set'
+        // Do not have a default Organization header here.
+        // The Project directory needs this header to not be present
       }
     }
   });

--- a/source/SIL.AppBuilder.Portal.Frontend/src/ui/components/inputs/organization-select/__tests__/page.ts
+++ b/source/SIL.AppBuilder.Portal.Frontend/src/ui/components/inputs/organization-select/__tests__/page.ts
@@ -1,0 +1,36 @@
+import {
+  interactor,
+  Interactor,
+  text,
+  is,
+  collection
+} from '@bigtest/interactor';
+
+class OrgSelect {
+
+  isDisabled = is('.disabled');
+  selected = text('.text[role="alert"]');
+
+  options = collection('.item');
+
+  choose(this: Interactor, optionText: string) {
+    return this
+      .when(() => {
+        const el = this
+          .$$('.item')
+          .find(item => item.innerText.includes(optionText));
+
+        if (!el) {
+          throw new Error(`cannot find ".item" with text "${optionText}"`);
+        }
+
+        return el;
+      }).do(el => el.click());
+  }
+}
+
+export const OrgSelectInteractor = interactor(OrgSelect);
+
+export type TOrgSelectInteractor = OrgSelect & Interactor;
+
+export default new (OrgSelectInteractor as any)('[data-test-organization-select]') as TOrgSelectInteractor;

--- a/source/SIL.AppBuilder.Portal.Frontend/src/ui/components/inputs/organization-select/display.tsx
+++ b/source/SIL.AppBuilder.Portal.Frontend/src/ui/components/inputs/organization-select/display.tsx
@@ -1,0 +1,47 @@
+import * as React from 'react';
+import { Dropdown } from 'semantic-ui-react';
+
+import { OrganizationResource } from '@data';
+import { attributesFor, ORGANIZATIONS_TYPE, idFromRecordIdentity } from '@data';
+import { withTranslations, i18nProps } from '@lib/i18n';
+
+interface IOwnProps {
+  className?: string;
+  organizations: OrganizationResource[];
+  onChange: (value: string) => void;
+}
+
+export type IProps =
+  & IOwnProps
+  & i18nProps;
+
+class Display extends React.Component<IProps> {
+  onChange = (e, dropdownEvent) => {
+    e.preventDefault();
+
+    this.props.onChange(dropdownEvent.value);
+  }
+
+  render() {
+    const { t, organizations, ...otherProps } = this.props;
+    const organizationOptions = [{ text: t('org.allOrganizations'), value: 'all'}].concat(
+      organizations.map(o => ({
+        text: attributesFor(o).name || '',
+        value: o.id
+      }))
+    );
+
+    const dropdownProps = {
+      options: organizationOptions,
+      ...otherProps,
+      onChange: this.onChange
+    };
+
+    return (
+      <Dropdown data-test-organization-select { ...dropdownProps } />
+    );
+  }
+}
+
+export default withTranslations(Display);
+

--- a/source/SIL.AppBuilder.Portal.Frontend/src/ui/components/inputs/organization-select/index.ts
+++ b/source/SIL.AppBuilder.Portal.Frontend/src/ui/components/inputs/organization-select/index.ts
@@ -1,0 +1,1 @@
+export { Display } from './display';

--- a/source/SIL.AppBuilder.Portal.Frontend/src/ui/components/project-table/__tests__/page.ts
+++ b/source/SIL.AppBuilder.Portal.Frontend/src/ui/components/project-table/__tests__/page.ts
@@ -18,6 +18,8 @@ export class ProjectTableInteractor {
   columns = collection('[data-test-project-table-column]');
   isEmptyTextPresent = isPresent('[data-test-project-list-empty]');
   emptyText = text('[data-test-project-list-empty]');
+
+  rows = collection('[data-test-project-row]');
 }
 
 export default new ProjectTableInteractor('[data-test-project-table]');

--- a/source/SIL.AppBuilder.Portal.Frontend/src/ui/components/project-table/table/row/index.tsx
+++ b/source/SIL.AppBuilder.Portal.Frontend/src/ui/components/project-table/table/row/index.tsx
@@ -68,7 +68,7 @@ class Row extends React.Component<IProps & IProvidedProps> {
     const { name: projectName } = attributesFor(project);
 
     return (
-      <div>
+      <div data-test-project-row>
         <div className='flex row-header grid'>
           <div className='col flex-grow-xs flex-100'>
             <Link to={`/project/${projectId}`}>{projectName}</Link>

--- a/source/SIL.AppBuilder.Portal.Frontend/src/ui/routes/project-directory/__tests__/filtering-by-organization-acceptance-test.ts
+++ b/source/SIL.AppBuilder.Portal.Frontend/src/ui/routes/project-directory/__tests__/filtering-by-organization-acceptance-test.ts
@@ -14,17 +14,7 @@ import { threeProjects, DTProjects } from './scenarios';
 
 describe('Acceptance | Project Directory | Filtering | By Organization', () => {
   setupApplicationTest();
-  setupRequestInterceptor({
-    matchRequestsBy: {
-      order: false,
-      headers: true,
-      url: {
-        pathname: true,
-        query: true,
-        hash: false
-      }
-    }
-  });
+  setupRequestInterceptor();
   useFakeAuthentication();
 
   beforeEach(function () {
@@ -37,9 +27,12 @@ describe('Acceptance | Project Directory | Filtering | By Organization', () => {
 
         if (!req.query['filter[organization-header]']) {
           res.json(threeProjects);
+
         } else {
           res.json(DTProjects);
         }
+
+        expect(req.headers.Organization).to.equal(undefined);
       });
     });
   });

--- a/source/SIL.AppBuilder.Portal.Frontend/src/ui/routes/project-directory/__tests__/filtering-by-organization-acceptance-test.ts
+++ b/source/SIL.AppBuilder.Portal.Frontend/src/ui/routes/project-directory/__tests__/filtering-by-organization-acceptance-test.ts
@@ -1,0 +1,103 @@
+import { describe, it, beforeEach } from '@bigtest/mocha';
+import { visit, location } from '@bigtest/react';
+import { expect } from 'chai';
+
+import {
+  setupApplicationTest,
+  setupRequestInterceptor,
+  useFakeAuthentication,
+  wait
+} from 'tests/helpers/index';
+
+import page from './page';
+import { threeProjects, DTProjects } from './scenarios';
+
+describe('Acceptance | Project Directory | Filtering | By Organization', () => {
+  setupApplicationTest();
+  setupRequestInterceptor({
+    matchRequestsBy: {
+      order: false,
+      headers: true,
+      url: {
+        pathname: true,
+        query: true,
+        hash: false
+      }
+    }
+  });
+  useFakeAuthentication();
+
+  beforeEach(function () {
+    const { server } = this.polly;
+
+    server.namespace('/api', () => {
+      server.get('/projects').intercept((req, res) => {
+        res.status(200);
+        res.headers['Content-Type'] = 'application/vnd.api+json';
+
+        if (!req.query['filter[organization-header]']) {
+          res.json(threeProjects);
+        } else {
+          res.json(DTProjects);
+        }
+      });
+    });
+  });
+
+
+  describe('navigating to the project directory page', () => {
+    beforeEach(async function() {
+      await visit('/directory');
+    });
+
+    it('is on the directory page', () => {
+      expect(location().pathname).to.equal('/directory');
+    });
+
+    it('shows all the possible projects', () => {
+      const rows = page.table.rows();
+
+      expect(rows.length).to.equal(3);
+    });
+
+    it('defaults to all organizations', () => {
+      expect(page.orgSelect.selected).to.include('All Organizations');
+    });
+
+    it('the header displays the total number of projects', () => {
+      expect(page.header).to.include('(3)');
+    });
+
+    describe('selecting your own organization', () => {
+      let rows;
+
+      beforeEach(async function() {
+        await page.orgSelect.choose('DeveloperTown');
+        await wait(500);
+        rows = await page.table.rows();
+      });
+
+      it('The selected organization is changed', () => {
+        expect(page.orgSelect.selected).to.include('DeveloperTown');
+      });
+
+      it('shows the relevant projects', () => {
+        const text = rows.map(r => r.text).join();
+
+        expect(rows.length).to.equal(2);
+        expect(text).to.include('Dummy project');
+        expect(text).to.include('project 3');
+      });
+
+      it('does not show projects from another organization', () => {
+        const text = rows.map(r => r.text).join();
+
+        expect(text).to.not.include('project 2');
+      });
+
+      it('the count in the header is updated', () => {
+        expect(page.header).to.include('(2)');
+      });
+    });
+  });
+});

--- a/source/SIL.AppBuilder.Portal.Frontend/src/ui/routes/project-directory/__tests__/filtering-by-organization-acceptance-test.ts
+++ b/source/SIL.AppBuilder.Portal.Frontend/src/ui/routes/project-directory/__tests__/filtering-by-organization-acceptance-test.ts
@@ -61,13 +61,22 @@ describe('Acceptance | Project Directory | Filtering | By Organization', () => {
       expect(page.header).to.include('(3)');
     });
 
+    it('shows all the projects', () => {
+      const rows = page.table.rows();
+      const text = rows.map(r => r.text).join();
+
+      expect(text).to.include('Dummy project');
+      expect(text).to.include('project 3');
+      expect(text).to.include('project 2');
+    });
+
     describe('selecting your own organization', () => {
       let rows;
 
       beforeEach(async function() {
         await page.orgSelect.choose('DeveloperTown');
         await wait(500);
-        rows = await page.table.rows();
+        rows = page.table.rows();
       });
 
       it('The selected organization is changed', () => {

--- a/source/SIL.AppBuilder.Portal.Frontend/src/ui/routes/project-directory/__tests__/page.ts
+++ b/source/SIL.AppBuilder.Portal.Frontend/src/ui/routes/project-directory/__tests__/page.ts
@@ -1,0 +1,20 @@
+import {
+  interactor,
+  Interactor,
+  text
+} from '@bigtest/interactor';
+
+import orgSelectInteractor from '@ui/components/inputs/organization-select/__tests__/page';
+import tableInteractor from '@ui/components/project-table/__tests__/page';
+
+class Directory {
+  header = text('[data-test-directory-header]');
+
+  orgSelect = orgSelectInteractor;
+  table = tableInteractor;
+}
+
+export const DirectoryInteractor = interactor(Directory);
+export type TDirectoryInteractor = Directory & Interactor;
+
+export default new (DirectoryInteractor as any)('[data-test-project-directory]') as TDirectoryInteractor;

--- a/source/SIL.AppBuilder.Portal.Frontend/src/ui/routes/project-directory/__tests__/scenarios.ts
+++ b/source/SIL.AppBuilder.Portal.Frontend/src/ui/routes/project-directory/__tests__/scenarios.ts
@@ -1,0 +1,93 @@
+export const threeProjects = {
+  data: [{
+    type: 'projects',
+    id: '1',
+    attributes: {
+      'name': 'Dummy project',
+      'date-archived': null,
+      'language': 'English',
+      'is-public': false
+    },
+    relationships: {
+      organization: { data: { id: 1, type: 'organizations' } },
+      group: { data: { id: 1, type: 'groups' } },
+      owner: { data: { id: 1, type: 'users' } }
+    }
+  }, {
+    type: 'projects',
+    id: 2,
+    attributes: {
+      'name': 'project 2',
+      'date-archived': null,
+      'language': 'English',
+      'is-public': true
+    },
+    relationships: {
+      organization: { data: { id: 2, type: 'organizations' } },
+      group: { data: { id: 2, type: 'groups' } },
+      owner: { data: { id: 2, type: 'users' } }
+    }
+  }, {
+    type: 'projects',
+    id: 3,
+    attributes: {
+      'name': 'project 3',
+      'date-archived': null,
+      'language': 'English',
+      'is-public': true
+    },
+    relationships: {
+      organization: { data: { id: 1, type: 'organizations' } },
+      group: { data: { id: 1, type: 'groups' } },
+      owner: { data: { id: 3, type: 'users' } }
+    }
+  }],
+  included: [
+    { type: 'organizations', id: 1, attributes: { name: 'DeveloperTown'} },
+    { type: 'organizations', id: 2, attributes: { name: 'SIL'} },
+    { type: 'groups', id: 1, attributes: { name: 'Group' } },
+    { type: 'groups', id: 2, attributes: { name: 'Group' } },
+    { type: 'groups', id: 3, attributes: { name: 'Group' } },
+    { type: 'users', id: 2 },
+    { type: 'users', id: 3 },
+  ]
+};
+
+export const DTProjects = {
+  data: [{
+    type: 'projects',
+    id: '1',
+    attributes: {
+      'name': 'Dummy project',
+      'date-archived': null,
+      'language': 'English',
+      'is-public': false
+    },
+    relationships: {
+      organization: { data: { id: 1, type: 'organizations' } },
+      group: { data: { id: 1, type: 'groups' } },
+      owner: { data: { id: 1, type: 'users' } }
+    }
+  }, {
+    type: 'projects',
+    id: 3,
+    attributes: {
+      'name': 'project 3',
+      'date-archived': null,
+      'language': 'English',
+      'is-public': true
+    },
+    relationships: {
+      organization: { data: { id: 1, type: 'organizations' } },
+      group: { data: { id: 1, type: 'groups' } },
+      owner: { data: { id: 3, type: 'users' } }
+    }
+  }],
+  included: [
+    { type: 'organizations', id: 1, attributes: { name: 'DeveloperTown'} },
+    { type: 'groups', id: 1, attributes: { name: 'Group' } },
+    { type: 'groups', id: 3, attributes: { name: 'Group' } },
+    { type: 'users', id: 2 },
+    { type: 'users', id: 3 },
+  ]
+};

--- a/source/SIL.AppBuilder.Portal.Frontend/src/ui/routes/project-directory/filters/index.tsx
+++ b/source/SIL.AppBuilder.Portal.Frontend/src/ui/routes/project-directory/filters/index.tsx
@@ -10,13 +10,15 @@ import MomentLocaleUtils, {
   parseDate,
 } from 'react-day-picker/moment';
 
-import { attributesFor, ORGANIZATIONS_TYPE, idFromRecordIdentity } from '@data';
+import { attributesFor, OrganizationResource, idFromRecordIdentity } from '@data';
 import { OrganizationAttributes, TYPE_NAME as ORGANIZATION } from '@data/models/organization';
 import { IFilter } from '@data/containers/api/with-filtering';
 import {
   withCurrentOrganization,
   IProvidedProps as ICurrentOrgProps
 } from '@data/containers/with-current-organization';
+
+import OrganizationSelect from '@ui/components/inputs/organization-select/display';
 
 import 'react-day-picker/lib/style.css';
 import './filters.scss';
@@ -32,7 +34,7 @@ interface IState {
 
 interface IOwnProps {
   updateFilter: (filter: IFilter) => void;
-  organizations: Array<ResourceObject<ORGANIZATIONS_TYPE, OrganizationAttributes>>;
+  organizations: OrganizationResource[];
 }
 
 type IProps =
@@ -60,8 +62,7 @@ class Filter extends React.Component<IProps, IState> {
     this.setState({ selectedProduct: value });
   }
 
-  handleOrganizationChange = (e, dropdownEvent) => {
-    const { value } = dropdownEvent;
+  handleOrganizationChange = (value) => {
     const { updateFilter } = this.props;
 
     if (value === 'all') {
@@ -108,15 +109,8 @@ class Filter extends React.Component<IProps, IState> {
   }
 
   render() {
-
     const { t, organizations } = this.props;
     const { from, to, products, selectedProduct, selectedOrganization } = this.state;
-    const organizationOptions = [{ text: 'All Organizations', value: 'all'}].concat(
-      organizations.map(o => ({
-        text: attributesFor(o).name || '',
-        value: o.id
-      }))
-    );
 
     return (
       <div className='flex filters'>
@@ -129,11 +123,12 @@ class Filter extends React.Component<IProps, IState> {
               defaultValue={selectedProduct} />
           </div>
           <div className='input'>
-            <Dropdown
+            <OrganizationSelect
               className='w-100'
               onChange={this.handleOrganizationChange}
-              options={organizationOptions}
-              defaultValue={selectedOrganization} />
+              organizations={organizations}
+              defaultValue={selectedOrganization}
+            />
           </div>
         </div>
 

--- a/source/SIL.AppBuilder.Portal.Frontend/src/ui/routes/project-directory/index.tsx
+++ b/source/SIL.AppBuilder.Portal.Frontend/src/ui/routes/project-directory/index.tsx
@@ -108,7 +108,7 @@ export default compose (
   })),
   withSorting({ defaultSort: 'name' }),
   withPagination(),
-  withProjects({ organizationHeader: '' }),
+  withProjects({ all: true }),
   withLoader(({ error, projects }) => !error && !projects),
   withError('error', ({ error }) => error !== undefined),
   withProps(({ projects }) => ({

--- a/source/SIL.AppBuilder.Portal.Frontend/src/ui/routes/project-directory/index.tsx
+++ b/source/SIL.AppBuilder.Portal.Frontend/src/ui/routes/project-directory/index.tsx
@@ -69,9 +69,11 @@ class ProjectDirectoryRoute extends React.Component<IProps> {
     // TODO: consider this for search instead of the existing
     //       https://github.com/smclab/react-faceted-token-input
     return (
-      <div className='ui container'>
+      <div data-test-project-directory className='ui container'>
         <div className='flex-row justify-content-space-between align-items-center'>
-          <h2 className='page-heading flex-50'>{t('directory.title', { numProjects })}</h2>
+          <h2 data-test-directory-header className='page-heading flex-50'>
+            {t('directory.title', { numProjects })}
+          </h2>
 
           <ProjectSearch updateFilter={updateFilter}
           />

--- a/source/SIL.AppBuilder.Portal.Frontend/tests/helpers/auth.ts
+++ b/source/SIL.AppBuilder.Portal.Frontend/tests/helpers/auth.ts
@@ -38,7 +38,7 @@ export function useFakeAuthentication(currentUser?: object) {
         {
           type: 'organizations',
           id: 1,
-          attributes: {}
+          attributes: { name: 'DeveloperTown' }
         },
         {
           id: 1,

--- a/source/SIL.AppBuilder.Portal.Frontend/tests/helpers/request-intercepting/polly.ts
+++ b/source/SIL.AppBuilder.Portal.Frontend/tests/helpers/request-intercepting/polly.ts
@@ -13,93 +13,19 @@ import { mockGet, mockPatch, mockPost, mockDelete } from './requests';
 Polly.register(XHRAdapter);
 Polly.register(FetchAdapter);
 
+
 // inspiration from:
 // https://github.com/Netflix/pollyjs/blob/master/packages/%40pollyjs/core/src/test-helpers/mocha.js
 export function setupRequestInterceptor(config: any = {}) {
   beforeEach(function() {
-    const name = generateRecordingName(this);
-    const pollyConfig = {
-      // passthorugh bypasses Polly's request recording feature
-      mode: 'passthrough',
-      adapters: ['fetch', 'xhr'],
-      adapterOptions: {
-        fetch: {
-          context: window
-        }
-      },
-      // logging: true,
-      recordFailedRequests: false,
-      recordIfMissing: false,
-      matchRequestsBy: {
-        order: false,
-        headers: true,
-        // url: {
-        //   protocol: true,
-        //   username: true,
-        //   password: true,
-        //   hostname: true,
-        //   port: true,
-        //   pathname: true,
-        //   query: true,
-        //   hash: false
-        // }
-      },
-      ...config
-    };
+    this.setupIntercepting = () => setup.call(this, config);
+    this.teardownIntercepting = () => teardown.call(this, context);
 
-    this.polly = new Polly(name, pollyConfig);
-
-    Orbit.fetch = window.fetch.bind(window);
-
-    const { server } = this.polly;
-
-    this.mockGet = mockGet(server);
-    this.mockPatch = mockPatch(server);
-    this.mockPost = mockPost(server);
-    this.mockDelete = mockDelete(server);
-    this.stubOrbit = () => Orbit.fetch = window.fetch;
-    this.debugFetch = () => {
-      const originalFetch = window.fetch;
-      const fakeFetch = (...args) => {
-        // debugger;
-        originalFetch(...args);
-      };
-
-      window.fetch = fakeFetch.bind(window);
-      Orbit.fetch = fakeFetch.bind(window);
-    };
-
-    // by default? stub out auth0 so that auth0/lock.js doesn't
-    // try to contact auth0 during testing.
-    server.options('*anypath').intercept((req, res) => {
-      req.headers.Allow = 'OPTIONS, GET, HEAD, POST, PUT, PATCH, DELETE, TRACE';
-    });
-
-    // This won't work unless we create a polly adapter for
-    // https://github.com/auth0/auth0.js/blob/fb53e8c318416ab1b29c99907a9e3cf63fe25164/src/helper/request-builder.js
-    // server.host('https://cdn.auth0.com', () => {
-    //   server.get('*').on('request', (req, res) => {
-    //     res.status(200);
-    //     res.headers['Content-Type'] = 'application/x-javascript; charset=utf-8';
-    //     res.send(
-    //       'Auth0.setClient({"id":"n8IAE2O17FBrlQ667x5mydhpqelCBUWG","tenant":"sil-appbuilder","subscription":"oss","authorize":"https://sil-appbuilder.auth0.com/authorize","callback":"http://localhost:1234","hasAllowedOrigins":true,"strategies":[{"name":"auth0","connections":[{"name":"Username-Password-Authentication","forgot_password_url":"https://login.auth0.com/lo/forgot?wtrealm=urn:auth0:sil-appbuilder:Username-Password-Authentication","signup_url":"https://login.auth0.com/lo/signup?wtrealm=urn:auth0:sil-appbuilder:Username-Password-Authentication","passwordPolicy":"good","showSignup":true,"showForgot":true}]},{"name":"email","connections":[{"name":"email"}]},{"name":"google-oauth2","connections":[{"name":"google-oauth2","scope":["email","profile"]}]},{"name":"samlp","connections":[{"name":"SIL-IdP-Hub"}]}]});'
-    //     );
-    //   });
-    // });
+    this.setupIntercepting(config);
   });
 
   afterEach(async function() {
-    await this.polly.stop();
-
-    Object.defineProperty(context, 'polly', {
-      enumerable: true,
-      configurable: true,
-      get() {
-        throw new Error(
-          `[Polly] You are trying to access an instance of Polly that is no longer available.\n`
-        );
-      }
-    });
+    await this.teardownIntercepting();
   });
 }
 
@@ -118,3 +44,92 @@ export function generateRecordingName(context) {
 
   return parts.reverse().join('/');
 }
+
+const teardown = async function(context) {
+  await this.polly.stop();
+
+  Object.defineProperty(context, 'polly', {
+    enumerable: true,
+    configurable: true,
+    get() {
+      throw new Error(
+        `[Polly] You are trying to access an instance of Polly that is no longer available.\n`
+      );
+    }
+  });
+
+};
+
+const setup = function(config) {
+  const name = generateRecordingName(this);
+  const pollyConfig = {
+    // passthorugh bypasses Polly's request recording feature
+    mode: 'passthrough',
+    adapters: ['fetch', 'xhr'],
+    adapterOptions: {
+      fetch: {
+        context: window
+      }
+    },
+    // logging: true,
+    recordFailedRequests: false,
+    recordIfMissing: false,
+    matchRequestsBy: {
+      order: false,
+      headers: true,
+      // url: {
+      //   protocol: true,
+      //   username: true,
+      //   password: true,
+      //   hostname: true,
+      //   port: true,
+      //   pathname: true,
+      //   query: true,
+      //   hash: false
+      // }
+    },
+    ...config
+  };
+
+  this.polly = new Polly(name, pollyConfig);
+
+  Orbit.fetch = window.fetch.bind(window);
+
+  const { server } = this.polly;
+
+  this.mockGet = mockGet(server);
+  this.mockPatch = mockPatch(server);
+  this.mockPost = mockPost(server);
+  this.mockDelete = mockDelete(server);
+  this.stubOrbit = () => Orbit.fetch = window.fetch;
+  this.debugFetch = () => {
+    const originalFetch = window.fetch;
+    const fakeFetch = (...args) => {
+      // debugger;
+      originalFetch(...args);
+    };
+
+    window.fetch = fakeFetch.bind(window);
+    Orbit.fetch = fakeFetch.bind(window);
+  };
+
+  // by default? stub out auth0 so that auth0/lock.js doesn't
+  // try to contact auth0 during testing.
+  server.options('*anypath').intercept((req, res) => {
+    req.headers.Allow = 'OPTIONS, GET, HEAD, POST, PUT, PATCH, DELETE, TRACE';
+  });
+
+  // This won't work unless we create a polly adapter for
+  // https://github.com/auth0/auth0.js/blob/fb53e8c318416ab1b29c99907a9e3cf63fe25164/src/helper/request-builder.js
+  // server.host('https://cdn.auth0.com', () => {
+  //   server.get('*').on('request', (req, res) => {
+  //     res.status(200);
+  //     res.headers['Content-Type'] = 'application/x-javascript; charset=utf-8';
+  //     res.send(
+  //       'Auth0.setClient({"id":"n8IAE2O17FBrlQ667x5mydhpqelCBUWG","tenant":"sil-appbuilder","subscription":"oss","authorize":"https://sil-appbuilder.auth0.com/authorize","callback":"http://localhost:1234","hasAllowedOrigins":true,"strategies":[{"name":"auth0","connections":[{"name":"Username-Password-Authentication","forgot_password_url":"https://login.auth0.com/lo/forgot?wtrealm=urn:auth0:sil-appbuilder:Username-Password-Authentication","signup_url":"https://login.auth0.com/lo/signup?wtrealm=urn:auth0:sil-appbuilder:Username-Password-Authentication","passwordPolicy":"good","showSignup":true,"showForgot":true}]},{"name":"email","connections":[{"name":"email"}]},{"name":"google-oauth2","connections":[{"name":"google-oauth2","scope":["email","profile"]}]},{"name":"samlp","connections":[{"name":"SIL-IdP-Hub"}]}]});'
+  //     );
+  //   });
+  // });
+
+};
+

--- a/source/SIL.AppBuilder.Portal.Frontend/types/@bigtest/interactor.d.ts
+++ b/source/SIL.AppBuilder.Portal.Frontend/types/@bigtest/interactor.d.ts
@@ -1,20 +1,24 @@
 export function interactor<T>(WrappedClass: T) : Interactor & T;
 export function text(selector: string) : any;
 export function clickable(selector: string): () => Promise<void>;
-export function findAll(selector: string): Array<HTMLElement>;
+export function findAll(selector: string): HTMLElement[];
 export function isPresent(selector: string): boolean;
 export function selectable(selector: string): (text: string) => Promise<void>;
+export function fillable(selector: string): (text: string) => Promise<void>;
 export function isHidden(selector: string): boolean;
 export function hasClass(selector: string, className: string): boolean;
+export function collection(selector: string): () => HTMLElement[];
+export function value(selector: string): string;
+export function is(selector: string): boolean;
 
 export class Interactor {
   constructor(selector?: string);
 
   $$(selector): this;
   when<T>(condition: (element?: HTMLElement) => T): this;
-  
+
   do<T>(doFn: (element: Interactor) => void);
-  
+
   click(selector?: string): Promise<void>;
   find(findFn: (element: HTMLElement) => boolean): HTMLElement;
 


### PR DESCRIPTION
Description pulled from https://github.com/sillsdev/appbuilder-portal/pull/129
And supercedes: https://github.com/sillsdev/appbuilder-portal/pull/150
And supercedes: https://github.com/sillsdev/appbuilder-portal/pull/154

---------------------------------------------------

## Relevant stories and acceptance criteria: 
### [26305 - View Project Directory](https://developertown.visualstudio.com/SIL%20International%20Scriptoria/_workitems/edit/26305)
 - [x] ( FILTER ) All projects for the organization are listed
    - [x] Test case: make sure filter is working for a single org
 - [ ] ( SORTING ) User can sort projects 
 - [ ] ( DISPLAY ) Product icon types visible 
    - **Q: do products coming from the database have a type?**
       - _A: relation is: project.products[].product-definition.application-type_
 - [x] ( DISPLAY) Number of projects in directory displayed
 - [x] ( DISPLAY ) List should be paginated, displaying 20 projects per page

### [26411 - Search Help](https://developertown.visualstudio.com/SIL%20International%20Scriptoria/_workitems/edit/26411)
- [ ] ( FILTER ) Search assistant should display what search options are 

### [26422 - Filter Project Directory](https://developertown.visualstudio.com/SIL%20International%20Scriptoria/_workitems/edit/26422)
 - [ ] ( FILTER ) User can choose range of results displayed, and list of projects adjust based on dates selected 
   - [ ] User cannot select a 'to' date in the future
   - [x] User cannot select a 'from' date past today
 - [ ] (FILTER ) When projects are filtered by a product type, only projects containing that product type are displayed 
 - [x] ( FILTER ) When projects are filtered by a org, only projects inside of that org are displayed 
    - [x] Should be allowed even when the current user is not a member of the organization
 - [ ] ( FILTER ) When filter has been set for a certain language, only projects in that language appear 

These 3 stories are combined into one PR because they are all every tightly coupled to each other. As I work through this and whatever issues come up, I may split out another PR.

## Dependent On:

Note: when querying projects, the backend must support the following (outside the scope of this PR):
 - [x] Query projects outside of the users organization
 - [x] Prevent projects from showing that are private



## Unexpected things:

2018-09-25
 - Can't update database with `./run bootstrap` https://github.com/aspnet/EntityFrameworkCore/issues/12220

20180-09-28
 - Inconsistencies with tests vs reality. 
   - We should probably be testing that request headers are set.