### PR TITLE
Support deploying to AWS

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -49,7 +49,7 @@ jobs:
 
     - stage: "Deploy"
       name: "Build and Push Docker Images"
-      if: branch IN (develop, master) OR (branch =~ /^deploy-.*$/)
+      if: branch IN (develop, master)
       language: generic
       sudo: required
       services:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,9 @@
 env:
   - DOCKER_COMPOSE_VERSION=1.17.0 MOZ_HEADLESS=1
 
+stages:
+  - "Tests"
+  - "Deploy"
 
 jobs:
   include:
@@ -46,7 +49,7 @@ jobs:
 
     - stage: "Deploy"
       name: "Build and Push Docker Images"
-      if: branch = master
+      if: branch IN (develop, master) OR (branch =~ /^deploy-.*$/)
       language: generic
       sudo: required
       services:
@@ -55,9 +58,7 @@ jobs:
         apt:
           packages:
             - docker-ce
-      before_deploy:
+      script:
         # must cleanup root owned files
         - time ( sudo ./run clean:api )
-      deploy:
-        provider: script
-        script: time ./scripts/deploy-travis.sh $TRAVIS_COMMIT latest
+        - time ./scripts/deploy-travis.sh $TRAVIS_COMMIT $TRAVIS_BRANCH

--- a/Dockerfile.backend
+++ b/Dockerfile.backend
@@ -5,15 +5,15 @@
 FROM microsoft/dotnet:2.1.402-sdk-bionic as dependencies
 WORKDIR /app
 
-COPY OptimaJet.DWKit.Application/*.csproj /app/OptimaJet.DWKit.Application/
-COPY OptimaJet.DWKit.StarterApplication/*.csproj /app/OptimaJet.DWKit.StarterApplication/
+COPY source/OptimaJet.DWKit.Application/*.csproj /app/OptimaJet.DWKit.Application/
+COPY source/OptimaJet.DWKit.StarterApplication/*.csproj /app/OptimaJet.DWKit.StarterApplication/
 WORKDIR /app/OptimaJet.DWKit.StarterApplication/
 RUN dotnet restore
 
 ###############################
 # Development
 FROM dependencies as development
-COPY . /app
+COPY source /app
 COPY --from=dependencies /app /app
 WORKDIR /app/OptimaJet.DWKit.StarterApplication
 
@@ -22,21 +22,21 @@ WORKDIR /app/OptimaJet.DWKit.StarterApplication
 # Release
 FROM dependencies as build-release
 WORKDIR /app/
-COPY ./ /app/
+COPY source/ /app/
 COPY --from=dependencies /app /app
 WORKDIR /app/OptimaJet.DWKit.StarterApplication
-RUN dotnet publish -c Release -o out
-# Need dummy values for POSTGRES_* variables for migrations to run
-RUN POSTGRES_HOST=build \
+RUN dotnet publish -c Release -o out && \
+    POSTGRES_HOST=build \
     POSTGRES_DB=build \
     POSTGRES_USER=build \
     POSTGRES_PASSWORD=build \
-    dotnet ef migrations script --idempotent --output "out/migrations.sql"
+    dotnet ef migrations --msbuildprojectextensionspath /app/out/OptimaJet.DWKit.StarterApplication/obj/ script --idempotent --output "out/scripts/api_migrations.sql"
 
 FROM microsoft/dotnet:2.1.402-sdk-bionic AS runtime-release
 WORKDIR /app
 COPY --from=build-release /app/OptimaJet.DWKit.StarterApplication/out ./
 COPY --from=build-release /app/run-api.sh ./
+COPY scripts/DB/*.sql scripts/DB/PostgreSQL/*.sql /app/scripts/
 RUN curl -o /usr/local/bin/runny https://raw.githubusercontent.com/silinternational/runny/0.2/runny \
     && chmod a+x /usr/local/bin/runny
 RUN apt-get update && apt-get install -y \

--- a/Dockerfile.nginx
+++ b/Dockerfile.nginx
@@ -11,8 +11,8 @@ WORKDIR /src
 # ---- Dependencies ----
 FROM base AS dependencies
 COPY \
-  SIL.AppBuilder.Portal.Frontend/package.json \
-  SIL.AppBuilder.Portal.Frontend/yarn.lock \
+  source/SIL.AppBuilder.Portal.Frontend/package.json \
+  source/SIL.AppBuilder.Portal.Frontend/yarn.lock \
   /src/
 RUN yarn
 
@@ -26,13 +26,12 @@ ENV AUTH0_CONNECTION Username-Password-Authentication
 
 WORKDIR /src
 COPY --from=dependencies /src/node_modules ./node_modules
-COPY ./SIL.AppBuilder.Portal.Frontend /src
-COPY ./run-nginx.sh /src
+COPY source/SIL.AppBuilder.Portal.Frontend /src
 RUN yarn webpack:build --output-path /src/_html_tmp
 
 # ---- Release ----
 FROM nginx:stable-alpine AS release
 COPY --from=build /src/_html_tmp /usr/share/nginx/html
-COPY config/nginx.conf etc/nginx/conf.d/default.conf.template
-
-
+COPY source/run-nginx.sh /usr/local/bin
+COPY source/config/nginx.conf etc/nginx/conf.d/default.conf.template
+CMD ["/usr/local/bin/run-nginx.sh"]

--- a/README.md
+++ b/README.md
@@ -35,12 +35,10 @@ For email notification delivery:
 CURRENT_VERSION=$(git rev-parse HEAD)
 
 # nginx
-cd source && \
   docker build . -f Dockerfile.nginx \
     --tag "nginx-$CURRENT_VERSION" --target release
 
 # api
-cd source && \
   docker build . -f Dockerfile.backend \
     --tag "api-$CURRENT_VERSION" --target runtime-release
 

--- a/deployment/ci/docker-compose.yml
+++ b/deployment/ci/docker-compose.yml
@@ -1,8 +1,8 @@
 version: '3.4'
 
-# NOTE: that --project-directory ./source
+# NOTE: that --project-directory .
 # must be passed to every docker-compose command
-# ./source is the docker-compose context
+# . is the docker-compose context
 #
 # NOTE: environment vars are public, and should not contain secrets ^_~
 #       use `env_file: [.env]` for secret things.
@@ -27,26 +27,26 @@ services:
 
     volumes:
       - postgres-data:/var/lib/postgresql/data
-      - ../scripts/DB:/scripts
+      - ./scripts/DB:/scripts
 
   api:
     build:
-      context: ./
+      context: .
       dockerfile: Dockerfile.backend
       target: development
     command: bash -c " dotnet watch run"
     links:
       - db:db.docker
     env_file:
-      - ${PWD}/source/OptimaJet.DWKit.StarterApplication/.env.dev
+      - ./source/OptimaJet.DWKit.StarterApplication/.env.dev
     volumes:
-      - ./:/app
+      - ./source/:/app
       # - api-obj:/app/obj
       # - api-bin:/app/bin
 
   ui:
     build:
-      context: ./SIL.AppBuilder.Portal.Frontend/
+      context: ./source/SIL.AppBuilder.Portal.Frontend/
       dockerfile: Dockerfile.ci
     command: bash -c "yarn && yarn start:dev"
 
@@ -54,18 +54,18 @@ services:
       API_HOST: api:7081
 
     env_file:
-      - ${PWD}/source/SIL.AppBuilder.Portal.Frontend/.env.dev
+      - ./source/SIL.AppBuilder.Portal.Frontend/.env.dev
 
     volumes:
-      - ${PWD}/source/SIL.AppBuilder.Portal.Frontend/src:/app/src
-      - ${PWD}/source/SIL.AppBuilder.Portal.Frontend/tests:/app/tests
-      - ${PWD}/source/SIL.AppBuilder.Portal.Frontend/types:/app/types
+      - ./source/SIL.AppBuilder.Portal.Frontend/src:/app/src
+      - ./source/SIL.AppBuilder.Portal.Frontend/tests:/app/tests
+      - ./source/SIL.AppBuilder.Portal.Frontend/types:/app/types
 
-      - ${PWD}/source/SIL.AppBuilder.Portal.Frontend/.babelrc:/app/.babelrc
-      - ${PWD}/source/SIL.AppBuilder.Portal.Frontend/package.json:/app/package.json
-      - ${PWD}/source/SIL.AppBuilder.Portal.Frontend/tsconfig.json:/app/tsconfig.json
-      - ${PWD}/source/SIL.AppBuilder.Portal.Frontend/tslint.json:/app/tslint.json
-      - ${PWD}/source/SIL.AppBuilder.Portal.Frontend/yarn.lock:/app/yarn.lock
+      - ./source/SIL.AppBuilder.Portal.Frontend/.babelrc:/app/.babelrc
+      - ./source/SIL.AppBuilder.Portal.Frontend/package.json:/app/package.json
+      - ./source/SIL.AppBuilder.Portal.Frontend/tsconfig.json:/app/tsconfig.json
+      - ./source/SIL.AppBuilder.Portal.Frontend/tslint.json:/app/tslint.json
+      - ./source/SIL.AppBuilder.Portal.Frontend/yarn.lock:/app/yarn.lock
 
       - ui-tmp:/app/tmp
       - ui-dist:/app/dist

--- a/deployment/development/docker-compose.yml
+++ b/deployment/development/docker-compose.yml
@@ -30,7 +30,7 @@ services:
 
     volumes:
       - postgres-data:/var/lib/postgresql/data
-      - ../scripts/DB:/scripts
+      - ./scripts/DB:/scripts
 
   # Debugging database
   adminer:
@@ -44,7 +44,7 @@ services:
 
   api:
     build:
-      context: ./
+      context: .
       dockerfile: Dockerfile.backend
       target: development
     command: bash -c " dotnet watch run"
@@ -53,14 +53,15 @@ services:
     links:
       - db:db.docker
     env_file:
-      - ${PWD}/source/OptimaJet.DWKit.StarterApplication/.env.dev
+      - ./source/OptimaJet.DWKit.StarterApplication/.env.dev
     volumes:
-      - ./:/app
+      - ./source/:/app
       - "outdir:/app/out"
+  
 
   ui:
     build:
-      context: ./SIL.AppBuilder.Portal.Frontend/
+      context: ./source/SIL.AppBuilder.Portal.Frontend/
       dockerfile: Dockerfile
     command: bash -c "yarn && yarn start:dev"
 
@@ -72,10 +73,10 @@ services:
       API_HOST: api:7081
 
     env_file:
-      - ${PWD}/source/SIL.AppBuilder.Portal.Frontend/.env.dev
+      - ./source/SIL.AppBuilder.Portal.Frontend/.env.dev
 
     volumes:
-      - ${PWD}/source/SIL.AppBuilder.Portal.Frontend:/app
+      - ./source/SIL.AppBuilder.Portal.Frontend:/app
 
       - ui-tmp:/app/tmp
       - ui-dist:/app/dist

--- a/run
+++ b/run
@@ -7,9 +7,9 @@
 
 UI_PATH="source/SIL.AppBuilder.Portal.Frontend"
 API_PATH="source/OptimaJet.DWKit.StarterApplication"
-COMPOSE="docker-compose -f deployment/development/docker-compose.yml --project-directory ./source -p appbuilder-portal"
+COMPOSE="docker-compose -f deployment/development/docker-compose.yml --project-directory . -p appbuilder-portal"
 
-CI_COMPOSE="docker-compose -f deployment/ci/docker-compose.yml --project-directory ./source -p appbuilder-portal-ci"
+CI_COMPOSE="docker-compose -f deployment/ci/docker-compose.yml --project-directory . -p appbuilder-portal-ci"
 
 PSQL="PGPASSWORD=\$POSTGRES_PASSWORD psql -h localhost -U \$POSTGRES_USER"
 

--- a/scripts/deploy-travis.sh
+++ b/scripts/deploy-travis.sh
@@ -6,17 +6,20 @@
 REPO_PORTAL_NGINX=appbuilder-portal-nginx
 REPO_PORTAL_API=appbuilder-portal-api
 CURRENT_VERSION=$1
-case "$2" in
-  master)  DEPLOY_LEVEL=production ;;
-  develop) DEPLOY_LEVEL=staging ;;
-  "")      DEPLOY_LEVEL=unknown ;;
-  *)       DEPLOY_LEVEL=$2 ;;
-esac 
 
-case "$2" in
-  master)  ECS_CLUSTER=aps-prd ;;
-  *)       ECS_CLUSTER=aps-stg ;;
-esac 
+DEPLOY_LEVEL=staging
+#case "$2" in
+#  master)  DEPLOY_LEVEL=production ;;
+#  develop) DEPLOY_LEVEL=staging ;;
+#  "")      DEPLOY_LEVEL=unknown ;;
+#  *)       DEPLOY_LEVEL=$2 ;;
+#esac 
+
+ECS_CLUSTER=aps-stg
+#case "$2" in
+#  master)  ECS_CLUSTER=aps-prd ;;
+#  *)       ECS_CLUSTER=aps-stg ;;
+#esac 
 
 
 docker --version # document the version travis is using

--- a/scripts/deploy-travis.sh
+++ b/scripts/deploy-travis.sh
@@ -1,13 +1,27 @@
 #!/bin/bash
 # $1 - current version (e.g. commit sha)
-# $2 - deployment level (e.g. staging/production)
+# $2 - branch
+
 
 REPO_PORTAL_NGINX=appbuilder-portal-nginx
 REPO_PORTAL_API=appbuilder-portal-api
 CURRENT_VERSION=$1
-DEPLOY_LEVEL=$2
+case "$2" in
+  master)  DEPLOY_LEVEL=production ;;
+  develop) DEPLOY_LEVEL=staging ;;
+  "")      DEPLOY_LEVEL=unknown ;;
+  *)       DEPLOY_LEVEL=$2 ;;
+esac 
+
+case "$2" in
+  master)  ECS_CLUSTER=aps-prd ;;
+  *)       ECS_CLUSTER=aps-stg ;;
+esac 
+
 
 docker --version # document the version travis is using
+sudo apt-get install jq
+which jq && jq --version
 pip install --user awscli # install aws cli w/o sudo
 export PATH=$PATH:$HOME/.local/bin # put aws in path
 (cd $HOME/.local/bin && curl -O https://raw.githubusercontent.com/silinternational/ecs-deploy/master/ecs-deploy && chmod +x ecs-deploy) 
@@ -15,7 +29,7 @@ eval $(aws ecr get-login --no-include-email --region us-east-1) #needs AWS_ACCES
 
 NGINX_BUILD_TAG=nginx-$CURRENT_VERSION
 NGINX_IMAGE_URL=$AWS_ECR_ACCOUNT.dkr.ecr.us-east-1.amazonaws.com/$REPO_PORTAL_NGINX
-(cd source && docker build . -f Dockerfile.nginx -t $NGINX_BUILD_TAG --target release)
+docker build . -f Dockerfile.nginx -t $NGINX_BUILD_TAG --target release
 docker tag $NGINX_BUILD_TAG $NGINX_IMAGE_URL:$DEPLOY_LEVEL
 docker push $NGINX_IMAGE_URL:$DEPLOY_LEVEL
 docker tag $NGINX_BUILD_TAG $NGINX_IMAGE_URL:$CURRENT_VERSION
@@ -23,9 +37,10 @@ docker push $NGINX_IMAGE_URL:$CURRENT_VERSION
 
 API_BUILD_TAG=api-$CURRENT_VERSION
 API_IMAGE_URL=$AWS_ECR_ACCOUNT.dkr.ecr.us-east-1.amazonaws.com/$REPO_PORTAL_API
-(cd source && docker build . -f Dockerfile.backend -t $API_BUILD_TAG --target runtime-release)
+docker build . -f Dockerfile.backend -t $API_BUILD_TAG --target runtime-release
 docker tag $API_BUILD_TAG $API_IMAGE_URL:$DEPLOY_LEVEL
 docker push $API_IMAGE_URL:$DEPLOY_LEVEL
 docker tag $API_BUILD_TAG $API_IMAGE_URL:$CURRENT_VERSION
 docker push $API_IMAGE_URL:$CURRENT_VERSION
 
+ecs-deploy -c $ECS_CLUSTER -n portal -i ignore -to $CURRENT_VERSION --max-definitions 20 --timeout 300

--- a/source/run-api.sh
+++ b/source/run-api.sh
@@ -1,8 +1,33 @@
 #!/bin/bash
 
-# run migrations
-PGPASSWORD=$POSTGRES_PASSWORD runny psql -h $POSTGRES_HOST -U $POSTGRES_USER -d $POSTGRES_DB -f migrations.sql
+env
+
+if [ "$DB_BOOTSTRAP" -eq "1" ]; then
+  PGPASSWORD=$POSTGRES_PASSWORD runny psql -h $POSTGRES_HOST -U $POSTGRES_USER -d postgres \
+    -tc "SELECT 1 FROM pg_database WHERE datname = '$POSTGRES_DB'" | grep -q 1 && \
+    PGPASSWORD=$POSTGRES_PASSWORD runny psql -h $POSTGRES_HOST -U $POSTGRES_USER -d postgres \
+    -c "DROP DATABASE $POSTGRES_DB"
+  PGPASSWORD=$POSTGRES_PASSWORD runny psql -h $POSTGRES_HOST -U $POSTGRES_USER -d postgres \
+    -c "CREATE DATABASE $POSTGRES_DB WITH ENCODING 'UTF8'"
+  PGPASSWORD=$POSTGRES_PASSWORD runny psql -h $POSTGRES_HOST -U $POSTGRES_USER -d $POSTGRES_DB \
+    -f /app/scripts/DWKitScript.sql
+  PGPASSWORD=$POSTGRES_PASSWORD runny psql -h $POSTGRES_HOST -U $POSTGRES_USER -d $POSTGRES_DB \
+    -f /app/scripts/Workflow_CreatePersistenceObjects.sql 
+fi
+
+# run api migrations
+PGPASSWORD=$POSTGRES_PASSWORD runny psql -h $POSTGRES_HOST -U $POSTGRES_USER -d $POSTGRES_DB \
+  -f /app/scripts/api_migrations.sql
+
+if [ "$DB_BOOTSTRAP" -eq "1" ]; then
+  PGPASSWORD=$POSTGRES_PASSWORD runny psql -h $POSTGRES_HOST -U $POSTGRES_USER -d $POSTGRES_DB \
+    -f /app/scripts/application_types.sql
+fi
+
+if [ "$DB_SAMPLEDATA" -eq "1" ]; then
+  PGPASSWORD=$POSTGRES_PASSWORD runny psql -h $POSTGRES_HOST -U $POSTGRES_USER -d $POSTGRES_DB \
+    -f /app/scripts/sample_data.sql
+fi
 
 # start api server
-dotnet OptimaJet.DWKit.StarterApplication.dll
-
+dotnet "OptimaJet.DWKit.StarterApplication.dll"

--- a/source/run-nginx.sh
+++ b/source/run-nginx.sh
@@ -1,9 +1,12 @@
 #!/usr/bin/env sh
 
+env
+
 if [ "$NGINX_CONF_DIR" = "" ]
 then
 	NGINX_CONF_DIR=/etc/nginx/conf.d
 fi
 envsubst '$$API_URL' < $NGINX_CONF_DIR/default.conf.template > $NGINX_CONF_DIR/default.conf
 
-#nginx -g 'daemon off;'
+echo "Starting NGINX"
+nginx -g 'daemon off;'


### PR DESCRIPTION
Update http://dev.scriptoria.io with latest build from master.  

- [x] Build release docker images
- [x] Push images to AWS ECR
- [x] Update AWS ECS to use new images
- [x] On startup, optionally bootstrap the database (`DB_BOOTSTRAP=1`) and load sample data (`DB_SAMPLEDATA=1`)

When we separate our work into master (for production) and develop (for staging), then uncomment code in `scripts/deploy-travis.sh`.