### PR TITLE
Hide Projects count on directory

### DIFF
--- a/source/SIL.AppBuilder.Portal.Frontend/src/translations/locales/en-us.json
+++ b/source/SIL.AppBuilder.Portal.Frontend/src/translations/locales/en-us.json
@@ -25,7 +25,7 @@
     "login": "Log In"
   },
   "directory": {
-    "title": "Project Directory ({numProjects})",
+    "title": "Project Directory {numProjects, plural, =0 {} other {({ numProjects })}}",
     "filters": {
       "dateRange": "Date Range Between"
     }

--- a/source/SIL.AppBuilder.Portal.Frontend/src/ui/routes/project-directory/__tests__/filtering-by-organization-acceptance-test.ts
+++ b/source/SIL.AppBuilder.Portal.Frontend/src/ui/routes/project-directory/__tests__/filtering-by-organization-acceptance-test.ts
@@ -59,7 +59,7 @@ describe('Acceptance | Project Directory | Filtering | By Organization', () => {
       expect(page.orgSelect.selected).to.include('All Organizations');
     });
 
-    it('the header displays the total number of projects', () => {
+    xit('the header displays the total number of projects', () => {
       expect(page.header).to.include('(3)');
     });
 
@@ -99,7 +99,7 @@ describe('Acceptance | Project Directory | Filtering | By Organization', () => {
         expect(text).to.not.include('project 2');
       });
 
-      it('the count in the header is updated', () => {
+      xit('the count in the header is updated', () => {
         expect(page.header).to.include('(2)');
       });
     });

--- a/source/SIL.AppBuilder.Portal.Frontend/src/ui/routes/project-directory/display.tsx
+++ b/source/SIL.AppBuilder.Portal.Frontend/src/ui/routes/project-directory/display.tsx
@@ -62,7 +62,7 @@ export default class DirectoryDisplay extends React.Component<IProps> {
       <div data-test-project-directory className='ui container'>
         <div className='flex-row justify-content-space-between align-items-center'>
           <h2 data-test-directory-header className='page-heading flex-50'>
-            {t('directory.title', { numProjects })}
+            {t('directory.title', { numProjects: 0 })}
           </h2>
 
           <DebouncedSearch


### PR DESCRIPTION
due to a current technical limitation of orbit.js and request `meta` data, we cannot display the total amount of projects