### PR TITLE
BUG: Fix Boolean Defaults

### DIFF
--- a/source/OptimaJet.DWKit.StarterApplication/Migrations/20181011202622_FixBooleanDefaults.Designer.cs
+++ b/source/OptimaJet.DWKit.StarterApplication/Migrations/20181011202622_FixBooleanDefaults.Designer.cs
@@ -2,6 +2,7 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using OptimaJet.DWKit.StarterApplication.Data;
@@ -10,9 +11,10 @@ using OptimaJet.DWKit.StarterApplication.Models;
 namespace OptimaJet.DWKit.StarterApplication.Migrations
 {
     [DbContext(typeof(AppDbContext))]
-    partial class AppDbContextModelSnapshot : ModelSnapshot
+    [Migration("20181011202622_FixBooleanDefaults")]
+    partial class FixBooleanDefaults
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/source/OptimaJet.DWKit.StarterApplication/Migrations/20181011202622_FixBooleanDefaults.cs
+++ b/source/OptimaJet.DWKit.StarterApplication/Migrations/20181011202622_FixBooleanDefaults.cs
@@ -1,0 +1,115 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+namespace OptimaJet.DWKit.StarterApplication.Migrations
+{
+    public partial class FixBooleanDefaults : Migration
+    {
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AlterColumn<bool>(
+                name: "EmailNotification",
+                table: "Users",
+                nullable: true,
+                defaultValue: true,
+                oldClrType: typeof(bool),
+                oldDefaultValue: true);
+
+            migrationBuilder.AlterColumn<bool>(
+                name: "IsPublic",
+                table: "Projects",
+                nullable: true,
+                defaultValue: true,
+                oldClrType: typeof(bool),
+                oldDefaultValue: true);
+
+            migrationBuilder.AlterColumn<bool>(
+                name: "AutomaticBuilds",
+                table: "Projects",
+                nullable: true,
+                defaultValue: true,
+                oldClrType: typeof(bool),
+                oldDefaultValue: true);
+
+            migrationBuilder.AlterColumn<bool>(
+                name: "AllowDownloads",
+                table: "Projects",
+                nullable: true,
+                defaultValue: true,
+                oldClrType: typeof(bool),
+                oldDefaultValue: true);
+
+            migrationBuilder.AlterColumn<bool>(
+                name: "UseSilBuildInfrastructure",
+                table: "Organizations",
+                nullable: true,
+                defaultValue: true,
+                oldClrType: typeof(bool),
+                oldDefaultValue: true);
+
+            migrationBuilder.AlterColumn<bool>(
+                name: "PublicByDefault",
+                table: "Organizations",
+                nullable: true,
+                defaultValue: true,
+                oldClrType: typeof(bool),
+                oldDefaultValue: true);
+        }
+
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AlterColumn<bool>(
+                name: "EmailNotification",
+                table: "Users",
+                nullable: false,
+                defaultValue: true,
+                oldClrType: typeof(bool),
+                oldNullable: true,
+                oldDefaultValue: true);
+
+            migrationBuilder.AlterColumn<bool>(
+                name: "IsPublic",
+                table: "Projects",
+                nullable: false,
+                defaultValue: true,
+                oldClrType: typeof(bool),
+                oldNullable: true,
+                oldDefaultValue: true);
+
+            migrationBuilder.AlterColumn<bool>(
+                name: "AutomaticBuilds",
+                table: "Projects",
+                nullable: false,
+                defaultValue: true,
+                oldClrType: typeof(bool),
+                oldNullable: true,
+                oldDefaultValue: true);
+
+            migrationBuilder.AlterColumn<bool>(
+                name: "AllowDownloads",
+                table: "Projects",
+                nullable: false,
+                defaultValue: true,
+                oldClrType: typeof(bool),
+                oldNullable: true,
+                oldDefaultValue: true);
+
+            migrationBuilder.AlterColumn<bool>(
+                name: "UseSilBuildInfrastructure",
+                table: "Organizations",
+                nullable: false,
+                defaultValue: true,
+                oldClrType: typeof(bool),
+                oldNullable: true,
+                oldDefaultValue: true);
+
+            migrationBuilder.AlterColumn<bool>(
+                name: "PublicByDefault",
+                table: "Organizations",
+                nullable: false,
+                defaultValue: true,
+                oldClrType: typeof(bool),
+                oldNullable: true,
+                oldDefaultValue: true);
+        }
+    }
+}

--- a/source/OptimaJet.DWKit.StarterApplication/Models/Organization.cs
+++ b/source/OptimaJet.DWKit.StarterApplication/Models/Organization.cs
@@ -24,10 +24,10 @@ namespace OptimaJet.DWKit.StarterApplication.Models
         public string LogoUrl { get; set; }
 
         [Attr("use-sil-build-infrastructure")]
-        public bool UseSilBuildInfrastructure { get; set; } = true;
+        public bool? UseSilBuildInfrastructure { get; set; } = true;
 
         [Attr("public-by-default")]
-        public bool PublicByDefault { get; set; } = true;
+        public bool? PublicByDefault { get; set; } = true;
 
         [HasOne("owner")]
         public virtual User Owner { get; set; }

--- a/source/OptimaJet.DWKit.StarterApplication/Models/Project.cs
+++ b/source/OptimaJet.DWKit.StarterApplication/Models/Project.cs
@@ -35,7 +35,7 @@ namespace OptimaJet.DWKit.StarterApplication.Models
         public string Language { get; set; }
 
         [Attr("is-public")]
-        public bool IsPublic { get; set; } = true;
+        public bool? IsPublic { get; set; } = true;
 
         [Attr("date-created")]
         public DateTime? DateCreated { get; set; }
@@ -50,10 +50,10 @@ namespace OptimaJet.DWKit.StarterApplication.Models
         public virtual List<Reviewer> Reviewers { get; set; }
 
         [Attr("allow-downloads")]
-        public bool AllowDownloads { get; set; } = true;
+        public bool? AllowDownloads { get; set; } = true;
 
         [Attr("automatic-builds")]
-        public bool AutomaticBuilds { get; set; } = true;
+        public bool? AutomaticBuilds { get; set; } = true;
 
         [Attr("workflow-project-id")]
         public int WorkflowProjectId { get; set; }

--- a/source/OptimaJet.DWKit.StarterApplication/Models/User.cs
+++ b/source/OptimaJet.DWKit.StarterApplication/Models/User.cs
@@ -38,7 +38,7 @@ namespace OptimaJet.DWKit.StarterApplication.Models
         public ProfileVisibility ProfileVisibility { get; set; } = ProfileVisibility.Public;
 
         [Attr("email-notification")]
-        public bool EmailNotification { get; set; } = true;
+        public bool? EmailNotification { get; set; } = true;
 
         [Attr("publishing-key")]
         public string PublishingKey { get; set; }


### PR DESCRIPTION
With bool values with a default set, when a REST create object request is received, the
values of those fields are set to the default regardless of whether the field is not specified
in the request or if it is the opposite value as the default.
This fix changes all bool values with defaults to bool?.  If the value is not specified in the
REST request, it is set to the default.  Otherwise, it is set to the specified value.