### PR TITLE
Improve project test

### DIFF
--- a/source/SIL.AppBuilder.Portal.Backend.Tests/Acceptance/APIControllers/Projects/UpdateProjectTest.cs
+++ b/source/SIL.AppBuilder.Portal.Backend.Tests/Acceptance/APIControllers/Projects/UpdateProjectTest.cs
@@ -304,6 +304,7 @@ namespace SIL.AppBuilder.Portal.Backend.Tests.Acceptance.APIControllers.Projects
             };
             var backgroundJobClient = _fixture.GetService<IBackgroundJobClient>();
             var backgroundJobClientMock = Mock.Get(backgroundJobClient);
+            backgroundJobClientMock.Reset();
             var response = await Patch("/api/projects/" + project3.Id.ToString(), content);
 
             Assert.Equal(HttpStatusCode.OK, response.StatusCode);

--- a/source/SIL.AppBuilder.Portal.Backend.Tests/Acceptance/APIControllers/Projects/UpdateProjectTest.cs
+++ b/source/SIL.AppBuilder.Portal.Backend.Tests/Acceptance/APIControllers/Projects/UpdateProjectTest.cs
@@ -302,6 +302,8 @@ namespace SIL.AppBuilder.Portal.Backend.Tests.Acceptance.APIControllers.Projects
                     }
                 }
             };
+            var backgroundJobClient = _fixture.GetService<IBackgroundJobClient>();
+            var backgroundJobClientMock = Mock.Get(backgroundJobClient);
             var response = await Patch("/api/projects/" + project3.Id.ToString(), content);
 
             Assert.Equal(HttpStatusCode.OK, response.StatusCode);
@@ -310,7 +312,8 @@ namespace SIL.AppBuilder.Portal.Backend.Tests.Acceptance.APIControllers.Projects
 
             Assert.Equal(updatedProject.GroupId, group1.Id);
             Assert.Equal(updatedProject.OrganizationId, org1.Id);
-
+            // Hangfire does not get called if a change is made but does not change owner
+            backgroundJobClientMock.Verify(x => x.Create(It.IsAny<Job>(), It.IsAny<EnqueuedState>()), Times.Never());
         }
         //
         // Verify that you can't set the organization to a different value than the group.owner


### PR DESCRIPTION
Add assert to verify that build engine is not updated when
project is modified and owner is not part of the update.