### PR TITLE
Add Mechanism to initialize the BuildEngineApiAccessToken for CI

### DIFF
--- a/source/OptimaJet.DWKit.StarterApplication/Services/BuildEngine/BuildEngineSystemMonitor.cs
+++ b/source/OptimaJet.DWKit.StarterApplication/Services/BuildEngine/BuildEngineSystemMonitor.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.Linq;
 using JsonApiDotNetCore.Data;
 using OptimaJet.DWKit.StarterApplication.Models;
@@ -63,6 +64,45 @@ namespace OptimaJet.DWKit.StarterApplication.Services.BuildEngine
                 }
             }
         }
+
+        public void SetSampleDataApiToken(string sampleDataApiToken)
+        {
+            var tokens = ParseApiTokens(sampleDataApiToken);
+            var organizations = OrganizationRepository.Get().ToList();
+            foreach (var organization in organizations)
+            {
+                var token = sampleDataApiToken;
+                if (tokens.ContainsKey(organization.Id.ToString()))
+                {
+                    token = tokens[organization.Id.ToString()];
+                }
+                
+                if (organization.BuildEngineApiAccessToken != token)
+                {
+                    organization.BuildEngineApiAccessToken = token;
+                    OrganizationRepository.UpdateAsync(organization).Wait();
+                }
+            }
+        }
+
+        private static Dictionary<string,string> ParseApiTokens(string sampleDataApiToken)
+        {
+            var tokens = new Dictionary<string, string>();
+            if (sampleDataApiToken.Contains('|'))
+            {
+                var entries = sampleDataApiToken.Split('|');
+                foreach (var entry in entries)
+                {
+                    var values = entry.Split('=');
+                    if (values.Count() == 2)
+                    {
+                        tokens[values[0]] = values[1];
+                    }
+                }
+            }
+            return tokens;
+        }
+
         private bool CheckConnection(SystemStatus systemEntry)
         {
             BuildEngineApi.SetEndpoint(systemEntry.BuildEngineUrl, systemEntry.BuildEngineApiAccessToken);

--- a/source/OptimaJet.DWKit.StarterApplication/Utility/ApplicationExtensions.cs
+++ b/source/OptimaJet.DWKit.StarterApplication/Utility/ApplicationExtensions.cs
@@ -10,6 +10,7 @@ using OptimaJet.DWKit.Core;
 using OptimaJet.DWKit.StarterApplication.Services.BuildEngine;
 using OptimaJet.DWKit.StarterApplication.Services.Workflow;
 using OptimaJet.Workflow.Core.Runtime;
+using static OptimaJet.DWKit.StarterApplication.Utility.EnvironmentHelpers;
 
 namespace OptimaJet.DWKit.StarterApplication.Utility
 {
@@ -38,6 +39,11 @@ namespace OptimaJet.DWKit.StarterApplication.Utility
 
         public static IApplicationBuilder UseBuildEngine(this IApplicationBuilder app, IConfigurationRoot configuration)
         {
+            var sampleDataApiToken = GetVarOrDefault("SAMPLEDATA_BUILDENGINE_API_ACCESS_TOKEN", String.Empty);
+            if (!String.IsNullOrEmpty(sampleDataApiToken))
+            {
+                BackgroundJob.Enqueue<BuildEngineSystemMonitor>(service => service.SetSampleDataApiToken(sampleDataApiToken));
+            }
             RecurringJob.AddOrUpdate<BuildEngineSystemMonitor>("BuildEngineMonitor", service => service.CheckBuildEngineStatus(), Cron.MinuteInterval(5));
 
             return app;


### PR DESCRIPTION
For CI and Dev environments, we bootstrap regularly and need to have Organization.BuildEngineApiAccessToken updated.  This change enqueues a job at startup if `SAMPLEDATA_BUILDENGINE_API_ACCESS_TOKEN` is set.

set `SAMPLEDATA_BUILDENGINE_API_ACCESS_TOKEN=token` to change them all
set `SAMPLEDATA_BUILDENGINE_API_ACCESS_TOKEN=1=token1|2=token2|3=token3` to change them based on the Organization.Id (1=SIL, 2=DT, 3=Kalaam)

For development, set this in source/OptimaJet.DWKit.StarterApplication/.env (won't be checked in).

This variable will be set in TerraForm for CI environment so that the values are updated when the CI environment is reset.