### PR TITLE
Fix regression where my-projects screen no longer shows just the data that was fetched from the network.

### DIFF
--- a/scripts/DB/sample_data.sql
+++ b/scripts/DB/sample_data.sql
@@ -117,7 +117,7 @@ INSERT INTO "UserRoles" ("UserId", "RoleId", "OrganizationId") VALUES
 (	7,	1,	1), -- psego@developertown.com - AppBuilder - SIL
 (	9,	3,	1), -- loren_hawthorne@sil.org - AppBuilder - SIL
 (	7,	1,	2), -- psego@developertown.com - SuperAdmin - DT
-(	5,	2,	2), -- ltabor@developertown.com - OrgAdmin - DT
+(	5,	1,	2), -- ltabor@developertown.com - SuperAdmin - DT
 (	1,	2,	2), -- chris_hubbard@sil.org - OrgAdmin - DT
 (	3,	3,	2), -- lt.sego@gmail.com - AppBuilder - DT
 (	4,	3,	2), -- gian.corzo@gmail.com - AppBuilder - DT

--- a/source/SIL.AppBuilder.Portal.Frontend/src/data/containers/resources/project/list.tsx
+++ b/source/SIL.AppBuilder.Portal.Frontend/src/data/containers/resources/project/list.tsx
@@ -69,7 +69,10 @@ export function withNetwork<TWrappedProps>(options: IOptions = {}) {
     }
 
     return compose(
-      query(mapNetworkToProps, { passthroughError: true, useRemoteDirectly: true }),
+            query(mapNetworkToProps, {
+              passthroughError: true,
+              useRemoteDirectly: true
+            }),
     )(WrappedComponent);
   };
 }

--- a/source/SIL.AppBuilder.Portal.Frontend/src/ui/components/project-table/table/row/index.tsx
+++ b/source/SIL.AppBuilder.Portal.Frontend/src/ui/components/project-table/table/row/index.tsx
@@ -66,12 +66,16 @@ class Row extends React.Component<IProps & IProvidedProps> {
     const projectId = idFromRecordIdentity(project as any);
     const activeProjectColumns = this.getActiveProjectColumns();
 
-    const { name: projectName } = attributesFor(project);
+    const { name: projectName, dateArchived } = attributesFor(project);
 
     const clickPath = projectPath ? projectPath(projectId) : `/projects/${projectId}`;
 
     return (
-      <div data-test-project-row className='m-b-md with-shadow'>
+      <div
+        data-test-project-row
+        className='m-b-md with-shadow'
+        style={{ opacity: dateArchived ? 0.5 : 1 }}
+      >
         <div className='flex row-header grid align-items-center p-l-md p-r-md'>
           <div className='col flex-grow-xs flex-100'>
             <Link to={clickPath}>{projectName}</Link>
@@ -96,6 +100,9 @@ class Row extends React.Component<IProps & IProvidedProps> {
 
 export default compose(
   withOrbit(({ project }) => ({
+    // subscribes this component sub-tree to updates for the project
+    // this is what enables the row to fade when a project is archived.
+    project: q => q.findRecord(project),
     organization: q => q.findRelatedRecord(project, 'organization'),
     owner: q => q.findRelatedRecord(project, 'owner'),
     group: q => q.findRelatedRecord(project, 'group'),

--- a/source/SIL.AppBuilder.Portal.Frontend/src/ui/routes/projects/list/my-projects.tsx
+++ b/source/SIL.AppBuilder.Portal.Frontend/src/ui/routes/projects/list/my-projects.tsx
@@ -37,25 +37,7 @@ export default compose(
   }),
   withNetwork(),
   withLoader(({ error, projects }) => !error && !projects),
-  withCache(() => ({
-    projects : q => q.findRecords(PROJECT)
-  })),
-  withProps(({ projects, currentUser }) => ({
-    // the additional filter here is required because someone in the
-    // "my projects" view could be performing actions from the table
-    // such as "Archive".
-    // the archived project would then be removed from the table,
-    // _because_ of the subscription to the data store in withCache
-    //
-    // This could all be avoided if we develop a way to subscribe
-    // to updates of individual records via the query HoC.
-    // though, we could manually subscribe to the individual records
-    // in the Row of each project. This is probably the best course of action.
-    projects: projects.filter(
-      resource => resource.type === PROJECT &&
-        resource.attributes.dateArchived == null &&
-        isRelatedTo(resource, 'owner', currentUser.id)
-    ),
+  withProps(() => ({
     tableName: 'my-projects'
   })),
   withTableColumns({

--- a/source/SIL.AppBuilder.Portal.Frontend/src/ui/routes/projects/list/my-projects.tsx
+++ b/source/SIL.AppBuilder.Portal.Frontend/src/ui/routes/projects/list/my-projects.tsx
@@ -2,7 +2,7 @@ import * as React from 'react';
 import { compose, withProps } from 'recompose';
 import { withData as withCache } from 'react-orbitjs';
 
-import { idFromRecordIdentity, TEMP_DEFAULT_PAGE_SIZE, isRelatedTo } from '@data';
+import { idFromRecordIdentity, TEMP_DEFAULT_PAGE_SIZE } from '@data';
 import { PaginationFooter } from '@data/containers/api';
 import { withCurrentUser } from '@data/containers/with-current-user';
 import { withSorting } from '@data/containers/api/sorting';

--- a/source/SIL.AppBuilder.Portal.Frontend/src/ui/routes/projects/list/my-projects.tsx
+++ b/source/SIL.AppBuilder.Portal.Frontend/src/ui/routes/projects/list/my-projects.tsx
@@ -48,7 +48,9 @@ export default compose(
     // _because_ of the subscription to the data store in withCache
     //
     // This could all be avoided if we develop a way to subscribe
-    // to updates of individual records via the query HoC
+    // to updates of individual records via the query HoC.
+    // though, we could manually subscribe to the individual records
+    // in the Row of each project. This is probably the best course of action.
     projects: projects.filter(
       resource => resource.type === PROJECT &&
         resource.attributes.dateArchived == null &&

--- a/source/SIL.AppBuilder.Portal.Frontend/src/ui/routes/projects/list/my-projects.tsx
+++ b/source/SIL.AppBuilder.Portal.Frontend/src/ui/routes/projects/list/my-projects.tsx
@@ -16,7 +16,6 @@ import { TYPE_NAME as PROJECT } from '@data/models/project';
 
 import { withTableColumns, COLUMN_KEY } from '@ui/components/project-table';
 
-import { logProps } from '@lib/debug';
 import Display from './display';
 
 export const pathName = '/projects/own';
@@ -57,7 +56,6 @@ export default compose(
     ),
     tableName: 'my-projects'
   })),
-  logProps('my-projects: after withProps'),
   withTableColumns({
     tableName: 'my-projects',
     defaultColumns: [
@@ -67,5 +65,4 @@ export default compose(
       COLUMN_KEY.PRODUCT_UPDATED_ON
     ]
   }),
-  logProps('my-projects: after table columns')
 )(Display);

--- a/source/SIL.AppBuilder.Portal.Frontend/src/ui/routes/projects/list/organization-projects.tsx
+++ b/source/SIL.AppBuilder.Portal.Frontend/src/ui/routes/projects/list/organization-projects.tsx
@@ -30,8 +30,7 @@ export default compose(
   }),
   withNetwork(),
   withLoader(({ error, projects }) => !error && !projects),
-  withProps(({ projects }) => ({
-    projects: projects.filter(resource => resource.type === PROJECT),
+  withProps(() => ({
     tableName: 'organization'
   })),
   withTableColumns({


### PR DESCRIPTION
bug: https://developertown.visualstudio.com/SIL%20International%20Scriptoria/_workitems/edit/30412


caused by: https://github.com/sillsdev/appbuilder-portal/commit/a4b78c4324146c8f7f39cc49817cceb8e74385a2#diff-98fa5f6886d98232bd28db6a8a890173R39


This is a temp fix.
The real fix would be to setup subscriptions to orbit.js for individual models retrieved from the network.