### PR TITLE
Modify Notifications Table

### DIFF
--- a/source/OptimaJet.DWKit.StarterApplication/Migrations/20181211214345_changeNotifications.Designer.cs
+++ b/source/OptimaJet.DWKit.StarterApplication/Migrations/20181211214345_changeNotifications.Designer.cs
@@ -2,6 +2,7 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using OptimaJet.DWKit.StarterApplication.Data;
@@ -10,9 +11,10 @@ using OptimaJet.DWKit.StarterApplication.Models;
 namespace OptimaJet.DWKit.StarterApplication.Migrations
 {
     [DbContext(typeof(AppDbContext))]
-    partial class AppDbContextModelSnapshot : ModelSnapshot
+    [Migration("20181211214345_changeNotifications")]
+    partial class changeNotifications
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/source/OptimaJet.DWKit.StarterApplication/Migrations/20181211214345_changeNotifications.cs
+++ b/source/OptimaJet.DWKit.StarterApplication/Migrations/20181211214345_changeNotifications.cs
@@ -1,0 +1,42 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+namespace OptimaJet.DWKit.StarterApplication.Migrations
+{
+    public partial class changeNotifications : Migration
+    {
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "MessageId",
+                table: "Notifications");
+
+            migrationBuilder.RenameColumn(
+                name: "MessageSubstitutionsJson",
+                table: "Notifications",
+                newName: "Message");
+
+            migrationBuilder.AddColumn<bool>(
+                name: "SendEmail",
+                table: "Notifications",
+                nullable: false,
+                defaultValue: false);
+        }
+
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "SendEmail",
+                table: "Notifications");
+
+            migrationBuilder.RenameColumn(
+                name: "Message",
+                table: "Notifications",
+                newName: "MessageSubstitutionsJson");
+
+            migrationBuilder.AddColumn<string>(
+                name: "MessageId",
+                table: "Notifications",
+                nullable: true);
+        }
+    }
+}

--- a/source/OptimaJet.DWKit.StarterApplication/Models/Notification.cs
+++ b/source/OptimaJet.DWKit.StarterApplication/Models/Notification.cs
@@ -9,9 +9,6 @@ namespace OptimaJet.DWKit.StarterApplication.Models
 {
     public class Notification : Identifiable, ITrackDate
     {
-        [Attr("message-id")]
-        public String MessageId { get; set; }
-
         [HasOne("user", Link.None)]
         public virtual User User { get; set; }
 
@@ -29,19 +26,10 @@ namespace OptimaJet.DWKit.StarterApplication.Models
         [Attr("date-updated")]
         public DateTime? DateUpdated { get; set; }
 
-        [Attr("message-substitutions"), NotMapped]
-        public object MessageSubstitutions { get; set; }
+        [Attr("message")]
+        public String Message { get; set; }
 
-        private const string EMPTY_JSON = "{}";
-        public string MessageSubstitutionsJson
-        {
-            get => (MessageSubstitutions == null)
-                ? EMPTY_JSON
-                : JsonConvert.SerializeObject(MessageSubstitutions);
-            set => MessageSubstitutions = string.IsNullOrWhiteSpace(value)
-                ? new Dictionary<string, object>()
-                : JObject.Parse(value).ToObject<Dictionary<string, object>>();
-        }
-
+        [Attr("send-email")]
+        public bool SendEmail { get; set; } = true;
     }
 }

--- a/source/OptimaJet.DWKit.StarterApplication/Services/BuildEngine/BuildEngineProjectService.cs
+++ b/source/OptimaJet.DWKit.StarterApplication/Services/BuildEngine/BuildEngineProjectService.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 using Hangfire;
@@ -66,12 +67,12 @@ namespace OptimaJet.DWKit.StarterApplication.Services.BuildEngine
                     // If the build engine isn't available, there is no point in continuing
                     // Notifications for this are handled by the monitor
                     // Throw exception to retry
-                    var messageParms = new
+                    var messageParms = new Dictionary<string, object>()
                     {
-                        orgName = project.Organization.Name,
-                        projectName = project.Name
+                        { "orgName", project.Organization.Name },
+                        { "projectName", project.Name }
                     };
-                    await SendNotificationService.SendNotificationToOrgAdminsAsync(project.Organization,
+                    await SendNotificationService.SendNotificationToOrgAdminsAndOwnerAsync(project.Organization, project.Owner,
                                                                                    "notifications.projectFailedBuildEngine",
                                                                                    messageParms);
                     throw new Exception("Connection not available");

--- a/source/OptimaJet.DWKit.StarterApplication/Services/BuildEngine/BuildEngineSystemMonitor.cs
+++ b/source/OptimaJet.DWKit.StarterApplication/Services/BuildEngine/BuildEngineSystemMonitor.cs
@@ -141,10 +141,12 @@ namespace OptimaJet.DWKit.StarterApplication.Services.BuildEngine
                                                              && (o.BuildEngineApiAccessToken == systemEntry.BuildEngineApiAccessToken));
              foreach (Organization organization in organizations)
             {
-                var messageParms = new {
-                    orgName = organization.Name,
-                    url = organization.BuildEngineUrl,
-                    token = organization.BuildEngineApiAccessToken};
+                var messageParms = new Dictionary<string, object>()
+                {
+                    { "orgName", organization.Name },
+                    { "url", organization.BuildEngineUrl },
+                    { "token", organization.BuildEngineApiAccessToken }
+                };
                 await SendNotificationService.SendNotificationToOrgAdminsAsync(organization,
                                                                                systemEntry.SystemAvailable ? "notifications.buildengineConnected" : "notifications.buildengineDisconnected",
                                                                                messageParms);

--- a/source/OptimaJet.DWKit.StarterApplication/Services/SendNotificationService.cs
+++ b/source/OptimaJet.DWKit.StarterApplication/Services/SendNotificationService.cs
@@ -47,6 +47,18 @@ namespace OptimaJet.DWKit.StarterApplication.Services
                 await SendNotificationToUserAsync(orgAdmin.User, message, subs);
             }
         }
+        public async Task SendNotificationToSuperAdminsAsync(String message, object subs)
+        {
+            var superAdmins = UserRolesRepository.Get()
+                .Include(ur => ur.User)
+                .Include(ur => ur.Role)
+                .Where(ur => ur.Role.RoleName == RoleName.SuperAdmin)
+                .ToList();
+            foreach (UserRole superAdmin in superAdmins)
+            {
+                await SendNotificationToUserAsync(superAdmin.User, message, subs);
+            }
+        }
         public async Task SendNotificationToUserAsync(User user, String message, object subs)
         {
             var notification = new Notification

--- a/source/OptimaJet.DWKit.StarterApplication/Services/SendNotificationService.cs
+++ b/source/OptimaJet.DWKit.StarterApplication/Services/SendNotificationService.cs
@@ -92,7 +92,7 @@ namespace OptimaJet.DWKit.StarterApplication.Services
             var notifications = NotificationRepository.Get()
                                                     .Where(n => n.DateEmailSent == null
                                                            && n.DateRead == null
-                                                           && n.User.EmailNotification == true
+                                                           && n.SendEmail == true
                                                            && now.Subtract((DateTime)n.DateCreated).TotalMinutes > sendNotificationEmailMinutes
                                                            && now.Subtract((DateTime)n.DateCreated).TotalMinutes < dontSendNotificationEmailMinutes
                                                           )

--- a/source/SIL.AppBuilder.Portal.Backend.Tests/Acceptance/APIControllers/Notifications/NotificationTest.cs
+++ b/source/SIL.AppBuilder.Portal.Backend.Tests/Acceptance/APIControllers/Notifications/NotificationTest.cs
@@ -72,19 +72,18 @@ namespace SIL.AppBuilder.Portal.Backend.Tests.Acceptance.APIControllers.Notifica
             var serializedParm = JsonConvert.SerializeObject(notificationParm);
             notification1 = AddEntity<AppDbContext, Notification>(new Notification
             {
-                MessageId = "notifications.buildengineConnected",
+                Message = "Build Engine for organization SIL International status change: connected",
                 UserId = user1.Id,
-                MessageSubstitutionsJson = serializedParm,
             });
-            notification2 = new Notification
-            {
-                MessageId = "notifications.buildengineConnected",
-                UserId = user1.Id,
-                User = user1,
-                MessageSubstitutionsJson = serializedParm,
-                DateCreated = DateTime.UtcNow.AddMinutes(-100),
-                DateUpdated = DateTime.UtcNow.AddMinutes(-100)
-            };
+            //notification2 = new Notification
+            //{
+            //    MessageId = "notifications.buildengineConnected",
+            //    UserId = user1.Id,
+            //    User = user1,
+            //    MessageSubstitutionsJson = serializedParm,
+            //    DateCreated = DateTime.UtcNow.AddMinutes(-100),
+            //    DateUpdated = DateTime.UtcNow.AddMinutes(-100)
+            //};
         }
         public NotificationTest(TestFixture<BuildEngineStartup> fixture) : base(fixture)
         {
@@ -92,45 +91,21 @@ namespace SIL.AppBuilder.Portal.Backend.Tests.Acceptance.APIControllers.Notifica
         }
 
         [Fact]
-        public void Create_Notification_Object()
-        {
-            var substitutions = "{\"parm1\":\"sub1\",\"parm2\":\"sub2\",\"parm3\":\"sub3\"}";
-            var subObject = new { parm1 = "sub1", parm2 = "sub2", parm3 = "sub3" };
-            var notification = new Notification
-            {
-                MessageId = "test:subset1",
-                DateCreated = DateTime.UtcNow
-            };
-
-            notification.MessageSubstitutionsJson = substitutions;
-            var deserializedSubstitutions = notification.MessageSubstitutionsJson;
-            Assert.Equal(substitutions, deserializedSubstitutions);
-            var data = notification.MessageSubstitutions as Dictionary<string, object>;
-            Assert.Equal("sub1", data["parm1"]);
-            Assert.Equal("sub2", data["parm2"]);
-            Assert.Equal("sub3", data["parm3"]);
-
-            notification.MessageSubstitutions = subObject;
-            var deserializedSubstitutions2 = notification.MessageSubstitutionsJson;
-            Assert.Equal(substitutions, deserializedSubstitutions2);
-        }
-        [Fact]
         public async Task TestSendNotificationToUser()
         {
             BuildTestData();
-            var notificationParm = new
+            var notificationParm = new Dictionary<string, object>()
             {
-                orgName = "SIL International",
-                url = "http://gtis.guru.com:8443",
-                token = "replace"
+                { "orgName", "SIL International" },
+                { "url", "http://gtis.guru.com:8443" },
+                { "token", "replace" }
             };
 
             var sendNotificationService = _fixture.GetService<SendNotificationServiceTester>();
             await sendNotificationService.SendNotificationToUserAsync(CurrentUser, "notifications.buildengineConnected", notificationParm);
             var modifiedNotifications = ReadTestData<AppDbContext, Notification>();
             Assert.Equal(2, modifiedNotifications.Count);
-            var a = modifiedNotifications[1].MessageSubstitutionsJson;
-            Assert.Equal("{\"orgName\":\"SIL International\",\"url\":\"http://gtis.guru.com:8443\",\"token\":\"replace\"}", modifiedNotifications[1].MessageSubstitutionsJson);
+            Assert.Equal("Build Engine for organization SIL International status change: connected", modifiedNotifications[1].Message);
         }
         [Fact]
         public async Task Send_EmailAsync()
@@ -153,27 +128,16 @@ namespace SIL.AppBuilder.Portal.Backend.Tests.Acceptance.APIControllers.Notifica
         public async Task Test_Multiple_Substitutions()
         {
             BuildTestData();
-            var notificationParm = new
+            var notificationParm = new Dictionary<string, object>()
             {
-                orgName = "SIL International",
-                projectName = "Test project"
+                { "orgName", "SIL International" },
+                { "projectName", "Test project" }
             };
-            var serializedParm = JsonConvert.SerializeObject(notificationParm);
-            var notification3 = AddEntity<AppDbContext, Notification>(new Notification
-            {
-                MessageId = "notifications.projectFailedBuildEngine",
-                UserId = user1.Id,
-                MessageSubstitutionsJson = serializedParm,
-            });
             var sendNotificationService = _fixture.GetService<SendNotificationServiceTester>();
-            var notifications = ReadTestData<AppDbContext, Notification>();
-            await sendNotificationService.SendEmailTest(notifications[1]);
+            await sendNotificationService.SendNotificationToUserAsync(CurrentUser, "notifications.projectFailedBuildEngine", notificationParm);
             var modifiedNotifications = ReadTestData<AppDbContext, Notification>();
-            var emails = ReadTestData<AppDbContext, Email>();
-            Assert.Single(emails);
-            var email = emails[0];
-            Assert.Equal("[Scriptoria] Test Notification", email.Subject);
-            Assert.Equal("{\"Message\":\"Failed to create project Test project. Could not connect to build engine for organization SIL International.\"}", email.ContentModelJson);
+            Assert.Equal(2, modifiedNotifications.Count);
+            Assert.Equal("Failed to create project Test project. Could not connect to build engine for organization SIL International.", modifiedNotifications[1].Message);
         }
     }
 }


### PR DESCRIPTION
This pull request modifies the notification table to contain the translated message instead of the message id and substitutions.  It also changes the table to include a flag as to whether an email needs to be sent.  Changes were made to the send notification service to check that flag and to accept a dictionary with the parameters for the message to accommodate those changes 