### PR TITLE
Implement Default Build Engine

### DIFF
--- a/source/OptimaJet.DWKit.StarterApplication/Data/AppDbContext.cs
+++ b/source/OptimaJet.DWKit.StarterApplication/Data/AppDbContext.cs
@@ -92,7 +92,7 @@ namespace OptimaJet.DWKit.StarterApplication.Data
                 .HasDefaultValue(true);
 
             orgEntity
-                .Property(o => o.UseSilBuildInfrastructure)
+                .Property(o => o.UseDefaultBuildEngine)
                 .HasDefaultValue(true);
             orgEntity
                 .Property(o => o.PublicByDefault)

--- a/source/OptimaJet.DWKit.StarterApplication/Metadata/metadata.json
+++ b/source/OptimaJet.DWKit.StarterApplication/Metadata/metadata.json
@@ -1335,7 +1335,7 @@
         },
         {
           "id": "91f15fbd-a667-4035-904d-a546b8763eaf",
-          "name": "UseSilBuildInfrastructure",
+          "name": "UseDefaultBuildEngine",
           "type": "Boolean",
           "typeId": 0,
           "isNullable": true,

--- a/source/OptimaJet.DWKit.StarterApplication/Migrations/20181108143545_ProductGuildRebase.Designer.cs
+++ b/source/OptimaJet.DWKit.StarterApplication/Migrations/20181108143545_ProductGuildRebase.Designer.cs
@@ -117,7 +117,7 @@ namespace OptimaJet.DWKit.StarterApplication.Migrations
                         .ValueGeneratedOnAdd()
                         .HasDefaultValue(true);
 
-                    b.Property<bool?>("UseSilBuildInfrastructure")
+                    b.Property<bool?>("UseDefaultBuildEngine")
                         .ValueGeneratedOnAdd()
                         .HasDefaultValue(true);
 

--- a/source/OptimaJet.DWKit.StarterApplication/Migrations/20181108143545_ProductGuildRebase.cs
+++ b/source/OptimaJet.DWKit.StarterApplication/Migrations/20181108143545_ProductGuildRebase.cs
@@ -224,7 +224,7 @@ namespace OptimaJet.DWKit.StarterApplication.Migrations
                     BuildEngineUrl = table.Column<string>(nullable: true),
                     BuildEngineApiAccessToken = table.Column<string>(nullable: true),
                     LogoUrl = table.Column<string>(nullable: true),
-                    UseSilBuildInfrastructure = table.Column<bool>(nullable: true, defaultValue: true),
+                    UseDefaultBuildEngine = table.Column<bool>(nullable: true, defaultValue: true),
                     PublicByDefault = table.Column<bool>(nullable: true, defaultValue: true),
                     OwnerId = table.Column<int>(nullable: false)
                 },

--- a/source/OptimaJet.DWKit.StarterApplication/Migrations/20181114162313_ProductWorkflowComment.Designer.cs
+++ b/source/OptimaJet.DWKit.StarterApplication/Migrations/20181114162313_ProductWorkflowComment.Designer.cs
@@ -117,7 +117,7 @@ namespace OptimaJet.DWKit.StarterApplication.Migrations
                         .ValueGeneratedOnAdd()
                         .HasDefaultValue(true);
 
-                    b.Property<bool?>("UseSilBuildInfrastructure")
+                    b.Property<bool?>("UseDefaultBuildEngine")
                         .ValueGeneratedOnAdd()
                         .HasDefaultValue(true);
 

--- a/source/OptimaJet.DWKit.StarterApplication/Migrations/20181115151630_AddNotifications.Designer.cs
+++ b/source/OptimaJet.DWKit.StarterApplication/Migrations/20181115151630_AddNotifications.Designer.cs
@@ -143,7 +143,7 @@ namespace OptimaJet.DWKit.StarterApplication.Migrations
                         .ValueGeneratedOnAdd()
                         .HasDefaultValue(true);
 
-                    b.Property<bool?>("UseSilBuildInfrastructure")
+                    b.Property<bool?>("UseDefaultBuildEngine")
                         .ValueGeneratedOnAdd()
                         .HasDefaultValue(true);
 

--- a/source/OptimaJet.DWKit.StarterApplication/Migrations/20181128203918_AddProductTransition.Designer.cs
+++ b/source/OptimaJet.DWKit.StarterApplication/Migrations/20181128203918_AddProductTransition.Designer.cs
@@ -143,7 +143,7 @@ namespace OptimaJet.DWKit.StarterApplication.Migrations
                         .ValueGeneratedOnAdd()
                         .HasDefaultValue(true);
 
-                    b.Property<bool?>("UseSilBuildInfrastructure")
+                    b.Property<bool?>("UseDefaultBuildEngine")
                         .ValueGeneratedOnAdd()
                         .HasDefaultValue(true);
 

--- a/source/OptimaJet.DWKit.StarterApplication/Migrations/20181130184430_AddProductBuild.Designer.cs
+++ b/source/OptimaJet.DWKit.StarterApplication/Migrations/20181130184430_AddProductBuild.Designer.cs
@@ -143,7 +143,7 @@ namespace OptimaJet.DWKit.StarterApplication.Migrations
                         .ValueGeneratedOnAdd()
                         .HasDefaultValue(true);
 
-                    b.Property<bool?>("UseSilBuildInfrastructure")
+                    b.Property<bool?>("UseDefaultBuildEngine")
                         .ValueGeneratedOnAdd()
                         .HasDefaultValue(true);
 

--- a/source/OptimaJet.DWKit.StarterApplication/Migrations/20181211214345_changeNotifications.Designer.cs
+++ b/source/OptimaJet.DWKit.StarterApplication/Migrations/20181211214345_changeNotifications.Designer.cs
@@ -143,7 +143,7 @@ namespace OptimaJet.DWKit.StarterApplication.Migrations
                         .ValueGeneratedOnAdd()
                         .HasDefaultValue(true);
 
-                    b.Property<bool?>("UseSilBuildInfrastructure")
+                    b.Property<bool?>("UseDefaultBuildEngine")
                         .ValueGeneratedOnAdd()
                         .HasDefaultValue(true);
 

--- a/source/OptimaJet.DWKit.StarterApplication/Migrations/AppDbContextModelSnapshot.cs
+++ b/source/OptimaJet.DWKit.StarterApplication/Migrations/AppDbContextModelSnapshot.cs
@@ -141,7 +141,7 @@ namespace OptimaJet.DWKit.StarterApplication.Migrations
                         .ValueGeneratedOnAdd()
                         .HasDefaultValue(true);
 
-                    b.Property<bool?>("UseSilBuildInfrastructure")
+                    b.Property<bool?>("UseDefaultBuildEngine")
                         .ValueGeneratedOnAdd()
                         .HasDefaultValue(true);
 

--- a/source/OptimaJet.DWKit.StarterApplication/Models/Organization.cs
+++ b/source/OptimaJet.DWKit.StarterApplication/Models/Organization.cs
@@ -23,8 +23,8 @@ namespace OptimaJet.DWKit.StarterApplication.Models
         [Attr("logo-url")]
         public string LogoUrl { get; set; }
 
-        [Attr("use-sil-build-infrastructure")]
-        public bool? UseSilBuildInfrastructure { get; set; } = true;
+        [Attr("use-default-build-engine")]
+        public bool? UseDefaultBuildEngine { get; set; } = true;
 
         [Attr("public-by-default")]
         public bool? PublicByDefault { get; set; } = true;

--- a/source/OptimaJet.DWKit.StarterApplication/Services/BuildEngine/BuildEngineEndpoint.cs
+++ b/source/OptimaJet.DWKit.StarterApplication/Services/BuildEngine/BuildEngineEndpoint.cs
@@ -1,0 +1,13 @@
+﻿using System;
+namespace OptimaJet.DWKit.StarterApplication.Services.BuildEngine
+{
+    public class BuildEngineEndpoint
+    {
+        public string Url { get; set; }
+        public string ApiAccessToken { get; set; }
+        public bool IsValid()
+        {
+            return Url != null && ApiAccessToken != null;
+        }
+    }
+}

--- a/source/OptimaJet.DWKit.StarterApplication/Services/BuildEngine/BuildEngineServiceBase.cs
+++ b/source/OptimaJet.DWKit.StarterApplication/Services/BuildEngine/BuildEngineServiceBase.cs
@@ -1,8 +1,10 @@
-﻿using System.Linq;
+﻿using System;
+using System.Linq;
 using Microsoft.EntityFrameworkCore;
 using OptimaJet.DWKit.StarterApplication.Models;
 using OptimaJet.DWKit.StarterApplication.Repositories;
 using SIL.AppBuilder.BuildEngineApiClient;
+using static OptimaJet.DWKit.StarterApplication.Utility.EnvironmentHelpers;
 
 namespace OptimaJet.DWKit.StarterApplication.Services.BuildEngine
 {
@@ -37,13 +39,34 @@ namespace OptimaJet.DWKit.StarterApplication.Services.BuildEngine
         }
         protected bool SetBuildEngineEndpoint(Organization organization)
         {
-            if (organization.BuildEngineUrl is null || organization.BuildEngineApiAccessToken is null)
-            {
-                return false;
-            }
+            var endpoint = GetBuildEngineEndpoint(organization);
+            if (!endpoint.IsValid()) { return  false; }
             BuildEngineApi.SetEndpoint(organization.BuildEngineUrl, organization.BuildEngineApiAccessToken);
             return true;
         }
 
+        public static BuildEngineEndpoint GetDefaultEndpoint()
+        {
+            return new BuildEngineEndpoint
+            {
+                Url = GetVarOrDefault("DEFAULT_BUILDENGINE_URL", null),
+                ApiAccessToken = GetVarOrDefault("DEFAULT_BUILDENGINE_API_ACCESS_TOKEN", null)
+            };
+
+        }
+        public static BuildEngineEndpoint GetBuildEngineEndpoint(Organization organization)
+        {
+            var endpoint = new BuildEngineEndpoint
+            {
+                Url = organization.BuildEngineUrl,
+                ApiAccessToken = organization.BuildEngineApiAccessToken
+            };
+            if (organization.UseSilBuildInfrastructure.GetValueOrDefault())
+            {
+                var defaultEndpoint = GetDefaultEndpoint();
+                if (defaultEndpoint.IsValid()) return defaultEndpoint;
+            }
+            return endpoint;
+        }
     }
 }

--- a/source/OptimaJet.DWKit.StarterApplication/Services/BuildEngine/BuildEngineServiceBase.cs
+++ b/source/OptimaJet.DWKit.StarterApplication/Services/BuildEngine/BuildEngineServiceBase.cs
@@ -61,7 +61,7 @@ namespace OptimaJet.DWKit.StarterApplication.Services.BuildEngine
                 Url = organization.BuildEngineUrl,
                 ApiAccessToken = organization.BuildEngineApiAccessToken
             };
-            if (organization.UseSilBuildInfrastructure.GetValueOrDefault())
+            if (organization.UseDefaultBuildEngine.GetValueOrDefault())
             {
                 var defaultEndpoint = GetDefaultEndpoint();
                 if (defaultEndpoint.IsValid()) return defaultEndpoint;

--- a/source/OptimaJet.DWKit.StarterApplication/Services/BuildEngine/BuildEngineSystemMonitor.cs
+++ b/source/OptimaJet.DWKit.StarterApplication/Services/BuildEngine/BuildEngineSystemMonitor.cs
@@ -41,7 +41,10 @@ namespace OptimaJet.DWKit.StarterApplication.Services.BuildEngine
         }
         private async Task SyncDatabaseTablesAsync()
         {
-            var organizations = await OrganizationRepository.GetListAsync();
+            var organizations = await OrganizationRepository
+                .Get()
+                .Where(o => o.UseDefaultBuildEngine != null && o.UseDefaultBuildEngine.Value == false)
+                .ToListAsync();
             var defaultOrganization = GetOrganizationDefaultSettings();
             if (defaultOrganization != null) { organizations.Add(defaultOrganization); }
             var statuses = await SystemStatusRepository.GetListAsync();

--- a/source/OptimaJet.DWKit.StarterApplication/Services/BuildEngine/BuildEngineSystemMonitor.cs
+++ b/source/OptimaJet.DWKit.StarterApplication/Services/BuildEngine/BuildEngineSystemMonitor.cs
@@ -42,6 +42,8 @@ namespace OptimaJet.DWKit.StarterApplication.Services.BuildEngine
         private async Task SyncDatabaseTablesAsync()
         {
             var organizations = await OrganizationRepository.GetListAsync();
+            var defaultOrganization = GetOrganizationDefaultSettings();
+            if (defaultOrganization != null) { organizations.Add(defaultOrganization); }
             var statuses = await SystemStatusRepository.GetListAsync();
             var removeList = statuses.Except(organizations, new BuildEngineReferenceComparer()).ToList();
             var addList = organizations.Except(statuses, new BuildEngineReferenceComparer()).ToList();
@@ -58,6 +60,19 @@ namespace OptimaJet.DWKit.StarterApplication.Services.BuildEngine
                 };
                 await SystemStatusRepository.CreateAsync(newEntry);
             }
+        }
+        private Organization GetOrganizationDefaultSettings()
+        {
+            var defaultEndPoint = BuildEngineServiceBase.GetDefaultEndpoint();
+            if (defaultEndPoint.IsValid())
+            {
+                return new Organization
+                {
+                    BuildEngineUrl = defaultEndPoint.Url,
+                    BuildEngineApiAccessToken = defaultEndPoint.ApiAccessToken
+                };
+            }
+            return null;
         }
         private async Task CheckSystemStatusesAsync()
         {

--- a/source/SIL.AppBuilder.Portal.Backend.Tests/Acceptance/APIControllers/Organizations/CreateOrganizationTest.cs
+++ b/source/SIL.AppBuilder.Portal.Backend.Tests/Acceptance/APIControllers/Organizations/CreateOrganizationTest.cs
@@ -32,7 +32,7 @@ namespace SIL.AppBuilder.Portal.Backend.Tests.Acceptance.APIControllers.Organiza
                         {"website-url", "http://test.org"},
                         {"build-engine-url", "http://buildengine.com"},
                         {"build-engine-api-access-token", "4323864"},
-                        {"use-sil-build-infrastructure", "false"},
+                        {"use-default-build-engine", "false"},
                         {"public-by-default", "false"}
                     }
                 }
@@ -43,7 +43,7 @@ namespace SIL.AppBuilder.Portal.Backend.Tests.Acceptance.APIControllers.Organiza
             var org = await Deserialize<Organization>(response);
 
             Assert.Equal(CurrentUser.Id, org.OwnerId);
-            Assert.False(org.UseSilBuildInfrastructure);
+            Assert.False(org.UseDefaultBuildEngine);
             Assert.False(org.PublicByDefault);
         }
         [Fact]
@@ -62,7 +62,7 @@ namespace SIL.AppBuilder.Portal.Backend.Tests.Acceptance.APIControllers.Organiza
                         {"website-url", "http://test.org"},
                         {"build-engine-url", "http://buildengine.com"},
                         {"build-engine-api-access-token", "4323864"},
-                        {"use-sil-build-infrastructure", "true"},
+                        {"use-default-build-engine", "true"},
                         {"public-by-default", "true"}
                     }
                 }
@@ -73,7 +73,7 @@ namespace SIL.AppBuilder.Portal.Backend.Tests.Acceptance.APIControllers.Organiza
             var org = await Deserialize<Organization>(response);
 
             Assert.Equal(CurrentUser.Id, org.OwnerId);
-            Assert.True(org.UseSilBuildInfrastructure);
+            Assert.True(org.UseDefaultBuildEngine);
             Assert.True(org.PublicByDefault);
         }
 
@@ -102,7 +102,7 @@ namespace SIL.AppBuilder.Portal.Backend.Tests.Acceptance.APIControllers.Organiza
             var org = await Deserialize<Organization>(response);
 
             Assert.Equal(CurrentUser.Id, org.OwnerId);
-            Assert.True(org.UseSilBuildInfrastructure);
+            Assert.True(org.UseDefaultBuildEngine);
             Assert.True(org.PublicByDefault);
 
         }
@@ -122,7 +122,7 @@ namespace SIL.AppBuilder.Portal.Backend.Tests.Acceptance.APIControllers.Organiza
                         {"website-url", "http://test.org"},
                         {"build-engine-url", "http://buildengine.com"},
                         {"build-engine-api-access-token", "4323864"},
-                        {"use-sil-build-infrastructure", "false"},
+                        {"use-default-build-engine", "false"},
                         {"public-by-default", "false"}
                     },
                     relationships = new Dictionary<string, Dictionary<string, Dictionary<string, string>>>() {
@@ -140,7 +140,7 @@ namespace SIL.AppBuilder.Portal.Backend.Tests.Acceptance.APIControllers.Organiza
             var org = await Deserialize<Organization>(response);
 
             Assert.Equal(user2.Id, org.OwnerId);
-            Assert.False(org.UseSilBuildInfrastructure);
+            Assert.False(org.UseDefaultBuildEngine);
             Assert.False(org.PublicByDefault);
             var orgs = ReadTestData<AppDbContext, Organization>();
             Assert.Equal(4, orgs.Count);

--- a/source/SIL.AppBuilder.Portal.Backend.Tests/Acceptance/BuildEngine/BuildEngineSystemMonitorTests.cs
+++ b/source/SIL.AppBuilder.Portal.Backend.Tests/Acceptance/BuildEngine/BuildEngineSystemMonitorTests.cs
@@ -53,6 +53,7 @@ namespace SIL.AppBuilder.Portal.Backend.Tests.Acceptance.BuildEngine
                 WebsiteUrl = "https://testorg1.org",
                 BuildEngineUrl = "https://buildengine.testorg1",
                 BuildEngineApiAccessToken = "5161678",
+                UseDefaultBuildEngine = false,
                 OwnerId = CurrentUser.Id
 
             });
@@ -62,6 +63,7 @@ namespace SIL.AppBuilder.Portal.Backend.Tests.Acceptance.BuildEngine
                 WebsiteUrl = "https://testorg2.org",
                 BuildEngineUrl = "https://buildengine.testorg3",
                 BuildEngineApiAccessToken = "5161678",
+                UseDefaultBuildEngine = false,
                 OwnerId = CurrentUser.Id
 
             });
@@ -71,6 +73,7 @@ namespace SIL.AppBuilder.Portal.Backend.Tests.Acceptance.BuildEngine
                 WebsiteUrl = "https://testorg3.org",
                 BuildEngineUrl = "https://buildengine.testorg3",
                 BuildEngineApiAccessToken = "5161678",
+                UseDefaultBuildEngine = false,
                 OwnerId = CurrentUser.Id
 
             });
@@ -80,6 +83,7 @@ namespace SIL.AppBuilder.Portal.Backend.Tests.Acceptance.BuildEngine
                 WebsiteUrl = "https://testorg3.org",
                 BuildEngineUrl = "https://buildengine.testorg3",
                 BuildEngineApiAccessToken = "4323864",
+                UseDefaultBuildEngine = false,
                 OwnerId = CurrentUser.Id
 
             });

--- a/source/SIL.AppBuilder.Portal.Frontend/src/data/models/organization.ts
+++ b/source/SIL.AppBuilder.Portal.Frontend/src/data/models/organization.ts
@@ -13,7 +13,7 @@ export interface OrganizationAttributes extends AttributesObject {
   buildEngineUrl?: string;
   buildEngineApiAccessToken?: string;
   publicByDefault?: boolean;
-  useSilBuildInfrastructure?: boolean;
+  useDefaultBuildEngine?: boolean;
   logoUrl?: string;
 }
 

--- a/source/SIL.AppBuilder.Portal.Frontend/src/data/schema.ts
+++ b/source/SIL.AppBuilder.Portal.Frontend/src/data/schema.ts
@@ -25,7 +25,7 @@ const schemaDefinition: SchemaSettings = {
         logoUrl: { type: 'string' },
 
         publicByDefault: { type: 'boolean' },
-        useSilBuildInfrastructure: { type: 'boolean' },
+        useDefaultBuildEngine: { type: 'boolean' },
 
         // note, that the Build Engine API access token probably should
         // never be *received* from the Scriptura API

--- a/source/SIL.AppBuilder.Portal.Frontend/src/translations/locales/en-us.json
+++ b/source/SIL.AppBuilder.Portal.Frontend/src/translations/locales/en-us.json
@@ -93,7 +93,7 @@
     "groupDeleted": "Group deleted",
     "navInfrastructure": "Infrastructure",
     "infrastructureTitle": "Infrastructure",
-    "useSilInfrastructureTitle": "Use SIL International's AWS Build Infrastructure",
+    "useDefaultBuildEngineTitle": "Use Default Build Engine",
     "groupsTitle": "Groups",
     "noGroups": "Your organization has no groups",
     "addGroupButton": "Add Group",

--- a/source/SIL.AppBuilder.Portal.Frontend/src/translations/locales/es-419.json
+++ b/source/SIL.AppBuilder.Portal.Frontend/src/translations/locales/es-419.json
@@ -81,7 +81,7 @@
     "navGroups": "Grupos",
     "navInfrastructure": "Infraestructura",
     "infrastructureTitle": "Infraestructura",
-    "useSilInfrastructureTitle": "Use la infraestructura de compilación AWS de SIL International",
+    "useDefaultBuildEngineTitle": "Use la infraestructura de compilación AWS de SIL International",
     "groupsTitle": "Grupos",
     "noGroups": "Su organización no tiene grupos",
     "addGroupButton": "Agregar grupo",

--- a/source/SIL.AppBuilder.Portal.Frontend/src/translations/locales/fr-FR.json
+++ b/source/SIL.AppBuilder.Portal.Frontend/src/translations/locales/fr-FR.json
@@ -81,7 +81,7 @@
     "navGroups": "Groups",
     "navInfrastructure": "Infrastructure",
     "infrastructureTitle": "Infrastructure",
-    "useSilInfrastructureTitle": "Use SIL International's AWS Build Infrastructure",
+    "useDefaultBuildEngineTitle": "Use Default Build Engine",
     "groupsTitle": "Groups",
     "noGroups": "Your organization has no groups",
     "addGroupButton": "Add Group",

--- a/source/SIL.AppBuilder.Portal.Frontend/src/ui/routes/organizations/settings/infrastructure/display.tsx
+++ b/source/SIL.AppBuilder.Portal.Frontend/src/ui/routes/organizations/settings/infrastructure/display.tsx
@@ -24,12 +24,12 @@ class InfrastructureDisplay extends React.Component<IProps & i18nProps> {
 
     const { organization } = props;
     const {
-      useSilBuildInfrastructure,
+      useDefaultBuildEngine,
       buildEngineUrl, buildEngineApiAccessToken
     } = attributesFor(organization);
 
     this.state = {
-      useSilBuildInfrastructure,
+      useDefaultBuildEngine,
       buildEngineUrl,
       buildEngineApiAccessToken
     };
@@ -45,7 +45,7 @@ class InfrastructureDisplay extends React.Component<IProps & i18nProps> {
     const { mut, toggle } = this;
     const { organization, t } = this.props;
     const {
-      useSilBuildInfrastructure,
+      useDefaultBuildEngine,
       buildEngineUrl, buildEngineApiAccessToken
     } = this.state;
 
@@ -59,15 +59,15 @@ class InfrastructureDisplay extends React.Component<IProps & i18nProps> {
 
         <div className='flex-row align-items-center p-l-lg p-r-lg m-b-lg'>
           <div>
-            <h3>{t('org.useSilInfrastructureTitle')}</h3>
+            <h3>{t('org.useDefaultBuildEngineTitle')}</h3>
           </div>
           <Checkbox toggle className='m-l-lg'
-            checked={useSilBuildInfrastructure}
-            onChange={toggle('useSilBuildInfrastructure')}
+            checked={useDefaultBuildEngine}
+            onChange={toggle('useDefaultBuildEngine')}
             />
         </div>
 
-        { !useSilBuildInfrastructure && (<>
+        { !useDefaultBuildEngine && (<>
 
           <Form.Field className='m-b-md'>
             <label>{t('org.buildEngineUrl')}</label>

--- a/source/SIL.AppBuilder.Portal.Frontend/src/ui/routes/organizations/settings/infrastructure/index.tsx
+++ b/source/SIL.AppBuilder.Portal.Frontend/src/ui/routes/organizations/settings/infrastructure/index.tsx
@@ -24,12 +24,12 @@ class InfrastructureRoute extends React.Component<IProps> {
   update = (attributes) => {
     const { updateOrganization } = this.props;
     const {
-      useSilBuildInfrastructure,
+      useDefaultBuildEngine,
       buildEngineUrl, buildEngineApiAccessToken
     } = attributes;
 
     updateOrganization({
-      useSilBuildInfrastructure,
+      useDefaultBuildEngine,
       buildEngineUrl,
       buildEngineApiAccessToken
     });

--- a/source/SIL.AppBuilder.Portal.Frontend/src/ui/routes/project-directory/show/-scenarios.ts
+++ b/source/SIL.AppBuilder.Portal.Frontend/src/ui/routes/project-directory/show/-scenarios.ts
@@ -39,7 +39,7 @@ export const projectOne = {
         'build-engine-url': 'https://buildengine.gtis.guru:8443',
         'build-engine-api-access-token': 'NS7kCjCRNFPmCGMCs3cQ',
         'logo-url': 'https://www.developertown.com/wp-content/uploads/2018/01/DT-PoundHouse-Blue.png',
-        'use-sil-build-infrastructure': true,
+        'use-default-build-engine': true,
         'public-by-default': true
       },
       relationships: {


### PR DESCRIPTION
* Change `UseSilInfrastructure` to `UseDefaultBuildEngine` -- SIL should not be used in the product since someone else could deploy this and it wouldn't be SIL
* Get Default Build Engine configuration from Env Vars
* Use Default Build Engine configuration if valid

Note: I used `./run db:migrations add` to perform the column name change.  The tool went through the previous files and renamed the column.  I didn't make these changes by hand.

TerraForm defines the DEFAULT_BUILD_ENGINE_URL and DEFAULT_BUILD_ENGINE_API_ACCESS_TOKEN env vars for the api container from the deployment.