### PR TITLE
pbi-30683: fixup authorization and authentication for websockets

### DIFF
--- a/source/OptimaJet.DWKit.StarterApplication/BackendServicesExtension.cs
+++ b/source/OptimaJet.DWKit.StarterApplication/BackendServicesExtension.cs
@@ -147,6 +147,20 @@ namespace OptimaJet.DWKit.StarterApplication
                 options.SaveToken = true;
                 options.Events = new JwtBearerEvents
                 {
+                    OnMessageReceived = context =>
+                    {
+                        var accessToken = context.Request.Query["access_token"];
+
+                        // If the request is for our hub...
+                        var path = context.HttpContext.Request.Path;
+                        if (!string.IsNullOrEmpty(accessToken) &&
+                            (path.StartsWithSegments("/hubs")))
+                        {
+                            // Read the token out of the query string
+                            context.Token = accessToken;
+                        }
+                        return Task.CompletedTask;
+                    },
                     OnTokenValidated = context =>
                     {
                         // Add the access_token as a claim, as we may actually need it

--- a/source/OptimaJet.DWKit.StarterApplication/Utility/ScriptoriaHub.cs
+++ b/source/OptimaJet.DWKit.StarterApplication/Utility/ScriptoriaHub.cs
@@ -1,8 +1,11 @@
 ﻿using System;
+using Microsoft.AspNetCore.Authentication.JwtBearer;
+using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.SignalR;
 
 namespace OptimaJet.DWKit.StarterApplication.Utility
 {
+    [Authorize(AuthenticationSchemes = JwtBearerDefaults.AuthenticationScheme)]
     public class ScriptoriaHub : Hub
     {
         public ScriptoriaHub()

--- a/source/SIL.AppBuilder.Portal.Frontend/src/sockets/notifications.ts
+++ b/source/SIL.AppBuilder.Portal.Frontend/src/sockets/notifications.ts
@@ -4,6 +4,7 @@ import Store from '@orbit/store';
 
 import {defaultOptions} from '@data';
 import { buildFindRecord } from '@data/store-helpers';
+import { getToken } from '@lib/auth0';
 const NOTIFICATION_METHOD = "Notification";
 
 interface NotificationHub{
@@ -19,7 +20,13 @@ export default class NotificationsSocketClient implements SocketClient{
   connection: HubConnection<NotificationHub> = null;
   dataStore = null;
   init(hubFactory: HubConnectionFactory, dataStore: Store) {
-    hubFactory.create({ key: 'notifications', endpointUri: '/hubs/notifications' });
+    hubFactory.create({
+      key: 'notifications',
+      endpointUri: '/hubs/notifications',
+      options: {
+        accessTokenFactory:() => `${getToken()}`
+      }
+    });
     this.dataStore = dataStore;
     this.connection = hubFactory.get<NotificationHub>('notifications');
 


### PR DESCRIPTION
Added authorization requirements to SignalR hubs and configured the authorization provider to allow for access_tokens on the websocket request.  Updated client code to provide access tokens on hub connections.  Updated test notification end point to require authentication and only send a notification to the current user (instead of all users which it was doing before... womp womp.)