### PR TITLE
Fix how Default BuildEngine is handled

### DIFF
--- a/source/OptimaJet.DWKit.StarterApplication/Services/BuildEngine/BuildEngineServiceBase.cs
+++ b/source/OptimaJet.DWKit.StarterApplication/Services/BuildEngine/BuildEngineServiceBase.cs
@@ -24,11 +24,12 @@ namespace OptimaJet.DWKit.StarterApplication.Services.BuildEngine
 
         protected bool BuildEngineLinkAvailable(Organization organization)
         {
+            var endpoint = GetBuildEngineEndpoint(organization);
             var systemStatus = SystemStatusRepository.Get()
-                 .Where(ss => (ss.BuildEngineApiAccessToken == organization.BuildEngineApiAccessToken)
-                        && (ss.BuildEngineUrl == organization.BuildEngineUrl))
+                 .Where(ss => (ss.BuildEngineApiAccessToken == endpoint.ApiAccessToken)
+                        && (ss.BuildEngineUrl == endpoint.Url))
                  .FirstOrDefaultAsync().Result;
-
+                        
             if (systemStatus == null)
             {
                 // TODO: Send Notification
@@ -41,7 +42,7 @@ namespace OptimaJet.DWKit.StarterApplication.Services.BuildEngine
         {
             var endpoint = GetBuildEngineEndpoint(organization);
             if (!endpoint.IsValid()) { return  false; }
-            BuildEngineApi.SetEndpoint(organization.BuildEngineUrl, organization.BuildEngineApiAccessToken);
+            BuildEngineApi.SetEndpoint(endpoint.Url, endpoint.ApiAccessToken);
             return true;
         }
 

--- a/source/SIL.AppBuilder.Portal.Backend.Tests/Acceptance/BuildEngine/BuildEngineReleaseServiceTests.cs
+++ b/source/SIL.AppBuilder.Portal.Backend.Tests/Acceptance/BuildEngine/BuildEngineReleaseServiceTests.cs
@@ -57,6 +57,7 @@ namespace SIL.AppBuilder.Portal.Backend.Tests.Acceptance.BuildEngine
                 WebsiteUrl = "https://testorg1.org",
                 BuildEngineUrl = "https://buildengine.testorg1",
                 BuildEngineApiAccessToken = "replace",
+                UseDefaultBuildEngine = false
 
             });
             CurrentUserMembership = AddEntity<AppDbContext, OrganizationMembership>(new OrganizationMembership

--- a/source/SIL.AppBuilder.Portal.Backend.Tests/Acceptance/BuildEngine/BuildEngineSystemMonitorTests.cs
+++ b/source/SIL.AppBuilder.Portal.Backend.Tests/Acceptance/BuildEngine/BuildEngineSystemMonitorTests.cs
@@ -28,6 +28,8 @@ namespace SIL.AppBuilder.Portal.Backend.Tests.Acceptance.BuildEngine
         public UserRole ur2 { get; set; }
         public UserRole ur3 { get; set; }
         public UserRole ur4 { get; set; }
+        public String DefaultBuildEngineUrl { get; set; }
+        public String DefaultBuildEngineApiAccessToken { get; set; }
 
         public BuildEngineSystemMonitorTests(TestFixture<BuildEngineStartup> fixture) : base(fixture)
         {
@@ -121,7 +123,10 @@ namespace SIL.AppBuilder.Portal.Backend.Tests.Acceptance.BuildEngine
                 BuildEngineUrl = "https://testorg4.org",
                 BuildEngineApiAccessToken = "5161678"
             });
-
+            DefaultBuildEngineUrl = "https://default-buildengine:8443";
+            DefaultBuildEngineApiAccessToken = "default_token";
+            Environment.SetEnvironmentVariable("DEFAULT_BUILDENGINE_URL", DefaultBuildEngineUrl);
+            Environment.SetEnvironmentVariable("DEFAULT_BUILDENGINE_API_ACCESS_TOKEN", DefaultBuildEngineApiAccessToken);
         }
         [Fact]
         public void MonitorSystem_Available()
@@ -134,7 +139,7 @@ namespace SIL.AppBuilder.Portal.Backend.Tests.Acceptance.BuildEngine
             buildEngineService.CheckBuildEngineStatus();
 
             var systemStatuses = ReadTestData<AppDbContext, SystemStatus>();
-            Assert.Equal(3, systemStatuses.Count);
+            Assert.Equal(4, systemStatuses.Count);
 
             var systemStatus1 = systemStatuses[0];
             Assert.True(systemStatus1.SystemAvailable);
@@ -158,7 +163,7 @@ namespace SIL.AppBuilder.Portal.Backend.Tests.Acceptance.BuildEngine
             buildEngineService.CheckBuildEngineStatus();
 
             var systemStatuses = ReadTestData<AppDbContext, SystemStatus>();
-            Assert.Equal(3, systemStatuses.Count);
+            Assert.Equal(4, systemStatuses.Count);
 
             var systemStatus1 = systemStatuses[0];
             Assert.False(systemStatus1.SystemAvailable);


### PR DESCRIPTION
* BuildEngineLinkAvailable will now use DefaultEndpoint
* SetBuildEngineEndpoint will now use DefaultEndpoint
* Add Unit Tests