### PR TITLE
Editable Description + new Autosave Field

### DIFF
--- a/source/SIL.AppBuilder.Portal.Frontend/src/data/models/project.ts
+++ b/source/SIL.AppBuilder.Portal.Frontend/src/data/models/project.ts
@@ -1,3 +1,4 @@
+import { Record } from '@orbit/data';
 import { AttributesObject, ResourceObject } from 'jsonapi-typescript';
 
 export type PROJECTS_TYPE = 'projects';
@@ -19,4 +20,4 @@ export interface ProjectAttributes extends AttributesObject {
   workflowProjectUrl?: string;
 }
 
-export type ProjectResource = ResourceObject<PROJECTS_TYPE, ProjectAttributes>;
+export type ProjectResource = ResourceObject<PROJECTS_TYPE, ProjectAttributes> & Record;

--- a/source/SIL.AppBuilder.Portal.Frontend/src/translations/locales/en-us.json
+++ b/source/SIL.AppBuilder.Portal.Frontend/src/translations/locales/en-us.json
@@ -107,7 +107,9 @@
     "buildEngineUrl": "Build Engine URL",
     "buildEngineApiAccessToken": "Build Engine API Access Token"
   },
-  "products": {},
+  "products": {
+    "definition": "Useful files that result from a series of steps."
+  },
   "profile": {
     "title": "Profile",
     "pictureTitle": "Profile Picture",

--- a/source/SIL.AppBuilder.Portal.Frontend/src/ui/routes/projects/show/overview/details/index.tsx
+++ b/source/SIL.AppBuilder.Portal.Frontend/src/ui/routes/projects/show/overview/details/index.tsx
@@ -6,20 +6,15 @@ import { ProjectResource, ApplicationTypeResource, attributesFor } from '@data';
 
 import { withTranslations, i18nProps } from '@lib/i18n';
 
-interface Params {
+interface INeededProps {
   project: ProjectResource;
+}
+
+interface IDataProps {
   applicationType: ApplicationTypeResource;
 }
 
-type IProps = Params & i18nProps;
-
-const mapRecordsToProps = (passedProps) => {
-  const { project } = passedProps;
-
-  return {
-    applicationType: (q) => q.findRelatedRecord(project, 'type'),
-  };
-};
+type IProps = INeededProps & IDataProps & i18nProps;
 
 class Details extends React.Component<IProps> {
   render() {
@@ -50,7 +45,11 @@ class Details extends React.Component<IProps> {
   }
 }
 
-export default compose(
+export default compose<IProps, INeededProps>(
   withTranslations,
-  withOrbit(mapRecordsToProps)
+  withOrbit(({ project }) => {
+    return {
+      applicationType: (q) => q.findRelatedRecord(project, 'type'),
+    };
+  })
 )(Details);

--- a/source/SIL.AppBuilder.Portal.Frontend/src/ui/routes/projects/show/overview/owners/index.tsx
+++ b/source/SIL.AppBuilder.Portal.Frontend/src/ui/routes/projects/show/overview/owners/index.tsx
@@ -13,11 +13,11 @@ import { i18nProps, withTranslations } from '@lib/i18n';
 import GroupSelect from '@ui/components/inputs/group-select';
 import UserSelect from '@ui/components/inputs/user-select';
 
-interface Params {
+interface INeededProps {
   project: ProjectResource;
 }
 
-type IProps = Params & IDataActionProps & i18nProps;
+type IProps = INeededProps & IDataActionProps & i18nProps;
 
 class Owners extends React.Component<IProps> {
   updateGroup = async (groupId) => {
@@ -87,9 +87,9 @@ class Owners extends React.Component<IProps> {
   }
 }
 
-export default compose(
+export default compose<IProps, INeededProps>(
   withTranslations,
-  withOrbit((passedProps: IProps) => {
+  withOrbit((passedProps: INeededProps) => {
     const { project } = passedProps;
 
     return {

--- a/source/SIL.AppBuilder.Portal.Frontend/src/ui/routes/projects/show/overview/products/index.tsx
+++ b/source/SIL.AppBuilder.Portal.Frontend/src/ui/routes/projects/show/overview/products/index.tsx
@@ -20,14 +20,17 @@ import ProductItem from './item';
 
 import './styles.scss';
 
-interface IOwnProps {
+interface INeededProps {
   project: ProjectResource;
+}
+
+interface IOwnProps {
   products: ProductResource[];
   organization: OrganizationResource;
   isEmptyWorkflowProjectUrl: boolean;
 }
 
-type IProps = IOwnProps & i18nProps;
+type IProps = IOwnProps & i18nProps & INeededProps;
 
 class Products extends React.Component<IProps> {
   render() {
@@ -50,7 +53,9 @@ class Products extends React.Component<IProps> {
 
     return (
       <div data-test-project-products className='product p-t-lg p-b-xl m-b-lg thin-bottom-border'>
-        <h3 className='m-b-md fs-21'>{t('project.products.title')}</h3>
+        <h3 className='m-b-sm fs-21'>{t('project.products.title')}</h3>
+        <p className='italic m-b-md'>{t('products.definition')}</p>
+
         {!isEmpty(products) && (
           <div className='flex align-items-center fs-13 bold gray-text m-b-sm d-xs-only-none d-sm-only-none'>
             <div className='w-55' />
@@ -65,7 +70,7 @@ class Products extends React.Component<IProps> {
     );
   }
 }
-export default compose(
+export default compose<IProps, INeededProps>(
   withTranslations,
   withOrbit(({ project }) => ({
     organization: (q) => q.findRelatedRecord(project, 'organization'),

--- a/source/SIL.AppBuilder.Portal.Frontend/src/ui/routes/projects/show/overview/reviewers/index.tsx
+++ b/source/SIL.AppBuilder.Portal.Frontend/src/ui/routes/projects/show/overview/reviewers/index.tsx
@@ -1,10 +1,7 @@
 import * as React from 'react';
 import { compose } from 'recompose';
-import { ResourceObject } from 'jsonapi-typescript';
-import { ProjectAttributes } from '@data/models/project';
-import { ReviewerAttributes } from '@data/models/reviewer';
 
-import { PROJECTS_TYPE, REVIEWERS_TYPE } from '@data';
+import { ProjectResource, ReviewerResource } from '@data';
 
 import { withTranslations, i18nProps } from '@lib/i18n';
 
@@ -14,12 +11,15 @@ import ReviewerItem from './item';
 
 import './styles.scss';
 
-interface Params {
-  project: ResourceObject<PROJECTS_TYPE, ProjectAttributes>;
-  reviewers: Array<ResourceObject<REVIEWERS_TYPE, ReviewerAttributes>>;
+interface INeededProps {
+  project: ProjectResource;
 }
 
-type IProps = Params & i18nProps;
+interface IDataProps {
+  reviewers: ReviewerResource[];
+}
+
+type IProps = IDataProps & INeededProps & i18nProps;
 
 class Reviewers extends React.Component<IProps> {
   state = {
@@ -57,7 +57,7 @@ class Reviewers extends React.Component<IProps> {
   }
 }
 
-export default compose(
+export default compose<IProps, INeededProps>(
   withTranslations,
   withReviewers
 )(Reviewers);

--- a/source/SIL.AppBuilder.Portal.Frontend/src/ui/routes/projects/show/overview/settings/index.tsx
+++ b/source/SIL.AppBuilder.Portal.Frontend/src/ui/routes/projects/show/overview/settings/index.tsx
@@ -8,12 +8,14 @@ import { withTranslations, i18nProps } from '@lib/i18n';
 
 import { withSettings } from './with-settings';
 
-interface Params {
+interface INeededProps {
   project: ProjectResource;
+}
+interface ISettingsProps {
   toggleField: (fieldName: string, newToggleState: boolean) => void;
 }
 
-type IProps = Params & i18nProps;
+type IProps = INeededProps & ISettingsProps & i18nProps;
 
 class Settings extends React.Component<IProps> {
   toggle = (e, toggleData) => {
@@ -81,7 +83,7 @@ class Settings extends React.Component<IProps> {
   }
 }
 
-export default compose(
+export default compose<IProps, INeededProps>(
   withTranslations,
   withSettings
 )(Settings);


### PR DESCRIPTION
Add description text to he products section of the project page: https://developertown.visualstudio.com/SIL%20International%20Scriptoria/_workitems/edit/31432

project description is now editable: https://developertown.visualstudio.com/SIL%20International%20Scriptoria/_workitems/edit/31433

+ autosave field (this is where most of the time went, cause I'm betting on this being used in a few more places)