### PR TITLE
only show public projects on the directory

### DIFF
--- a/source/SIL.AppBuilder.Portal.Frontend/src/ui/routes/project-directory/list/index.tsx
+++ b/source/SIL.AppBuilder.Portal.Frontend/src/ui/routes/project-directory/list/index.tsx
@@ -31,7 +31,10 @@ export default compose(
   ),
   withCurrentUserContext,
   withFiltering(() => ({
-    requiredFilters: [{ attribute: 'date-archived', value: 'isnull:' }],
+    requiredFilters: [
+      { attribute: 'date-archived', value: 'isnull:' },
+      { attribute: 'is-public', value: 'true' },
+    ],
   })),
   withSorting({ defaultSort: 'name' }),
   withPagination(),


### PR DESCRIPTION
previously, private projects that you would have access to were visible. this was confusing. 
now the directory is public projects regardless of if you can see certain private projects.