### PR TITLE
CI Updates

### DIFF
--- a/Dockerfile.nginx
+++ b/Dockerfile.nginx
@@ -1,10 +1,15 @@
 # ---- Base ----
 FROM nginx:1.15.8-alpine AS base
+# nginx 1.15.8 uses alpine 3.9
+#
+# so here is the nodejs search for that version of alpine 
+# https://pkgs.alpinelinux.org/packages?name=nodejs&branch=v3.9&repo=main
+#
 RUN apk add --no-cache git curl
 RUN apk add --no-cache \
       --repository http://dl-3.alpinelinux.org/alpine/edge/community \
-      nodejs=8.14.0-r0 \
-      npm=8.14.0-r0 \
+      nodejs=10.14.2-r0 \
+      npm=10.14.2-r0 \
       build-base \
     && npm install -qg yarn
 WORKDIR /src

--- a/scripts/build-api.sh
+++ b/scripts/build-api.sh
@@ -4,8 +4,12 @@ source ./scripts/build-setup.sh
 
 API_BUILD_TAG="api-$CURRENT_VERSION"
 API_IMAGE_URL=$AWS_ECR_ACCOUNT.dkr.ecr.us-east-1.amazonaws.com/$REPO_PORTAL_API
+
 docker build . -f Dockerfile.backend -t $API_BUILD_TAG --target runtime-release
-docker tag $API_BUILD_TAG $API_IMAGE_URL:$DEPLOY_LEVEL
-docker push $API_IMAGE_URL:$DEPLOY_LEVEL
-docker tag $API_BUILD_TAG $API_IMAGE_URL:$CURRENT_VERSION
-docker push $API_IMAGE_URL:$CURRENT_VERSION
+
+if [[ $PUSH_TO_DOCKER_REGISTRY == "true" ]]; then
+  docker tag $API_BUILD_TAG $API_IMAGE_URL:$DEPLOY_LEVEL
+  docker push $API_IMAGE_URL:$DEPLOY_LEVEL
+  docker tag $API_BUILD_TAG $API_IMAGE_URL:$CURRENT_VERSION
+  docker push $API_IMAGE_URL:$CURRENT_VERSION
+fi

--- a/scripts/build-api.sh
+++ b/scripts/build-api.sh
@@ -1,4 +1,9 @@
-set -a
+#!/bin/bash
+#
+# shell flags
+#  -e aborts the script if any subcommand fails
+#  -a shares the environment variables between parent and subshells
+set -ea
 
 source ./scripts/build-setup.sh
 

--- a/scripts/build-nginx.sh
+++ b/scripts/build-nginx.sh
@@ -1,5 +1,9 @@
-
-set -a
+#!/bin/bash
+#
+# shell flags
+#  -e aborts the script if any subcommand fails
+#  -a shares the environment variables between parent and subshells
+set -ea
 
 source ./scripts/build-setup.sh
 

--- a/scripts/build-nginx.sh
+++ b/scripts/build-nginx.sh
@@ -6,7 +6,7 @@ source ./scripts/build-setup.sh
 NGINX_BUILD_TAG="nginx-$CURRENT_VERSION"
 NGINX_IMAGE_URL=$AWS_ECR_ACCOUNT.dkr.ecr.us-east-1.amazonaws.com/$REPO_PORTAL_NGINX
 
-if [[ $2 == *"develop"* ]]; then
+if [[ $CURRENT_BRANCH == *"develop"* ]]; then
   echo "Building a develop-only image. This will show debug info in the bottom left."
 
   docker build . -f Dockerfile.nginx \
@@ -18,7 +18,9 @@ else
   docker build . -f Dockerfile.nginx -t $NGINX_BUILD_TAG --target release
 fi
 
-docker tag $NGINX_BUILD_TAG $NGINX_IMAGE_URL:$DEPLOY_LEVEL
-docker push $NGINX_IMAGE_URL:$DEPLOY_LEVEL
-docker tag $NGINX_BUILD_TAG $NGINX_IMAGE_URL:$CURRENT_VERSION
-docker push $NGINX_IMAGE_URL:$CURRENT_VERSION
+if [[ $PUSH_TO_DOCKER_REGISTRY == "true" ]]; then
+  docker tag $NGINX_BUILD_TAG $NGINX_IMAGE_URL:$DEPLOY_LEVEL
+  docker push $NGINX_IMAGE_URL:$DEPLOY_LEVEL
+  docker tag $NGINX_BUILD_TAG $NGINX_IMAGE_URL:$CURRENT_VERSION
+  docker push $NGINX_IMAGE_URL:$CURRENT_VERSION
+fi

--- a/scripts/build-setup.sh
+++ b/scripts/build-setup.sh
@@ -7,19 +7,26 @@
 export REPO_PORTAL_NGINX=appbuilder-portal-nginx
 export REPO_PORTAL_API=appbuilder-portal-api
 export CURRENT_VERSION=$1
+export CURRENT_BRANCH=$2
 
 export DEPLOY_LEVEL=staging
-case "$2" in
+case "$CURRENT_BRANCH" in
   master)  export DEPLOY_LEVEL=alpha ;;
   develop) export DEPLOY_LEVEL=staging ;;
   "")      export DEPLOY_LEVEL=unknown ;;
-  *)       export DEPLOY_LEVEL=$2 ;;
+  *)       export DEPLOY_LEVEL=$CURRENT_BRANCH ;;
 esac
 
-case "$2" in
+case "$CURRENT_BRANCH" in
   master)  export ECS_CLUSTER=aps-alpha ;;
   develop) export ECS_CLUSTER=aps-stg ;;
 esac
+
+# Are we going to deploy this C.I. run? If so, we need to tell the build scripts
+# to also push the images after building them.
+if [[ $CURRENT_BRANCH == *"develop"* ]] || [[ $CURRENT_BRANCH == *"master"* ]]; then
+  export PUSH_TO_DOCKER_REGISTRY='true'
+fi
 
 
 docker --version # document the version travis is using

--- a/scripts/build-setup.sh
+++ b/scripts/build-setup.sh
@@ -6,8 +6,9 @@
 
 export REPO_PORTAL_NGINX=appbuilder-portal-nginx
 export REPO_PORTAL_API=appbuilder-portal-api
-export CURRENT_VERSION=$1
-export CURRENT_BRANCH=$2
+
+export CURRENT_VERSION=$1 # $TRAVIS_COMMIT
+export CURRENT_BRANCH=$2  # $TRAVIS_BRANCH
 
 export DEPLOY_LEVEL=staging
 case "$CURRENT_BRANCH" in


### PR DESCRIPTION
The original intent behind the original set of updates was to:
 - make it so we could run the scripts locally
 - have the scripts be idempotent, so that if you already have the deps installed, it doesn't try to re-install them
 - reuse a bunch of variables that may have been previously duplicated
 - provide more messaging in the logs to see what is going on
 - and most importantly, ensure that `docker build` isn't going to fail due to dep changes within either project (frontend and api)

However, I made the mistake of not scrubbing tag names for illegal characters when tagging docker images. 
Tagging and pushing doesn't actually need to happen for the non-deployable branches, so in this PR, I've added a condition to only push and tag on master and develop.