### PR TITLE
Bug: Eliminate exception thrown during processing artifacts after build

### DIFF
--- a/source/OptimaJet.DWKit.StarterApplication/Services/BuildEngine/BuildEngineBuildService.cs
+++ b/source/OptimaJet.DWKit.StarterApplication/Services/BuildEngine/BuildEngineBuildService.cs
@@ -291,10 +291,10 @@ namespace OptimaJet.DWKit.StarterApplication.Services.BuildEngine
             if (existingArtifact != null)
             {
                 // Not sure why we are getting multiple of these, but we don't want multiple entries.
-                // Should we ignore it or update?  Update for now.
+                // Should we ignore it or update?  Ignore for now. Updating threw exceptions
                 Log.Information($"Updating Artifact: Id={existingArtifact.Id}");
                 updatedArtifact.Id = existingArtifact.Id;
-                await ProductArtifactRepository.UpdateAsync(updatedArtifact);
+                // await ProductArtifactRepository.UpdateAsync(updatedArtifact);
             }
             else
             {


### PR DESCRIPTION
Still not sure why this occurs but it is occurring on multiple builds
and the exception being thrown by attempting to update when it was
already tracking the same entry was causing problems.