### PR TITLE
Allow Super Admins to use the Organizations/Stores screen

### DIFF
--- a/source/SIL.AppBuilder.Portal.Frontend/package.json
+++ b/source/SIL.AppBuilder.Portal.Frontend/package.json
@@ -69,7 +69,7 @@
     "react-hooks-fetch": "^0.8.0",
     "react-i18next": "^10.0.2",
     "react-notify-toast": "^0.5.0",
-    "react-orbitjs": "github:DeveloperTown/react-orbitjs#ebc8d8133891ec208ec4fecb5b74231a1d896706",
+    "react-orbitjs": "github:DeveloperTown/react-orbitjs#9913bdeac3495a9f75413c30f168ed617cf29124",
     "react-redux": "^6.0.0",
     "react-router": "^4.3.1",
     "react-router-dom": "^4.3.1",

--- a/source/SIL.AppBuilder.Portal.Frontend/src/data/containers/with-current-user/index.tsx
+++ b/source/SIL.AppBuilder.Portal.Frontend/src/data/containers/with-current-user/index.tsx
@@ -6,7 +6,7 @@ import { withDisplay } from './display';
 
 export { ICurrentUserProps } from './types';
 
-const CurrentUserContext = React.createContext<ICurrentUserProps>({
+export const CurrentUserContext = React.createContext<ICurrentUserProps>({
   currentUser: undefined,
   currentUserProps: {},
 });

--- a/source/SIL.AppBuilder.Portal.Frontend/src/data/containers/with-role.tsx
+++ b/source/SIL.AppBuilder.Portal.Frontend/src/data/containers/with-role.tsx
@@ -1,3 +1,6 @@
+// NOTE: much of this should probably be deprecated, as
+//       @lib/auth/get-permissions is much more ergonomic.
+
 import * as React from 'react';
 import { compose } from 'recompose';
 import { withData as withOrbit, ILegacyProvidedProps } from 'react-orbitjs';

--- a/source/SIL.AppBuilder.Portal.Frontend/src/lib/auth/get-current-permissions.ts
+++ b/source/SIL.AppBuilder.Portal.Frontend/src/lib/auth/get-current-permissions.ts
@@ -1,0 +1,104 @@
+import { useContext } from 'react';
+import { useOrbit, attributesFor } from 'react-orbitjs';
+import Store from '@orbit/store';
+
+import { OrganizationResource, UserResource, UserRoleResource } from '@data';
+
+import { ROLE } from '@data/models/role';
+import { CurrentUserContext } from '@data/containers/with-current-user';
+
+interface IHasRoleInOrganizationArgs {
+  organization?: OrganizationResource;
+  roleName: ROLE;
+}
+
+export function getPermissions(organization?: OrganizationResource) {
+  const { currentUser } = useContext(CurrentUserContext);
+  const { dataStore } = useOrbit();
+
+  return {
+    isSuperAdmin: isSuperAdmin(dataStore, currentUser),
+    isOrgAdmin: isOrgAdmin(dataStore, currentUser, organization),
+    isAppBuilder: isAppBuilder(dataStore, currentUser, organization),
+    hasRoleInOrganization(args: IHasRoleInOrganizationArgs) {
+      return hasRoleInOrganization(
+        dataStore,
+        currentUser,
+        args.organization || organization,
+        args.roleName
+      );
+    },
+  };
+}
+
+export function isSuperAdmin(dataStore: Store, user: UserResource) {
+  const userRoles = getUserRoles(dataStore, user);
+
+  return userRolesContainRoleNamed(dataStore, userRoles, ROLE.SuperAdmin);
+}
+
+export function hasRoleInOrganization(
+  dataStore: Store,
+  user: UserResource,
+  organization: OrganizationResource,
+  roleName: ROLE
+) {
+  if (!organization) return false;
+
+  const userRoles = getUserRolesForOrganization(dataStore, user, organization);
+
+  return userRolesContainRoleNamed(dataStore, userRoles, roleName);
+}
+
+export function isAppBuilder(
+  dataStore: Store,
+  user: UserResource,
+  organization?: OrganizationResource
+) {
+  return hasRoleInOrganization(dataStore, user, organization, ROLE.AppBuilder);
+}
+
+export function isOrgAdmin(
+  dataStore: Store,
+  user: UserResource,
+  organization?: OrganizationResource
+) {
+  return hasRoleInOrganization(dataStore, user, organization, ROLE.OrganizationAdmin);
+}
+
+export function userRolesContainRoleNamed(
+  dataStore: Store,
+  userRoles: UserRoleResource[],
+  name: ROLE
+) {
+  for (let i = 0; i < userRoles.length; i++) {
+    let userRole = userRoles[i];
+    let role = dataStore.cache.query((q) => q.findRelatedRecord(userRole, 'role'));
+
+    if (attributesFor(role).roleName === name) {
+      return true;
+    }
+  }
+
+  return false;
+}
+
+export function getUserRoles(dataStore: Store, user: UserResource) {
+  const userRoles = dataStore.cache.query((q) => q.findRelatedRecords(user, 'userRoles'));
+
+  return userRoles;
+}
+
+export function getUserRolesForOrganization(
+  dataStore: Store,
+  user: UserResource,
+  organization: OrganizationResource
+) {
+  const userRoles = dataStore.cache.query((q) =>
+    q
+      .findRelatedRecords(user, 'userRoles')
+      .filter({ relation: 'organization', record: organization })
+  );
+
+  return userRoles;
+}

--- a/source/SIL.AppBuilder.Portal.Frontend/src/lib/auth/index.tsx
+++ b/source/SIL.AppBuilder.Portal.Frontend/src/lib/auth/index.tsx
@@ -1,3 +1,4 @@
 export { requireNoAuth } from './require-no-auth';
 export { requireAuth } from './require-auth';
 export { storePath, retrievePath } from './return-to';
+export { getPermissions } from './get-current-permissions';

--- a/source/SIL.AppBuilder.Portal.Frontend/yarn.lock
+++ b/source/SIL.AppBuilder.Portal.Frontend/yarn.lock
@@ -7786,9 +7786,9 @@ react-onclickoutside@^6.7.1:
   resolved "https://registry.yarnpkg.com/react-onclickoutside/-/react-onclickoutside-6.7.1.tgz#6a5b5b8b4eae6b776259712c89c8a2b36b17be93"
   integrity sha512-p84kBqGaMoa7VYT0vZ/aOYRfJB+gw34yjpda1Z5KeLflg70HipZOT+MXQenEhdkPAABuE2Astq4zEPdMqUQxcg==
 
-"react-orbitjs@github:DeveloperTown/react-orbitjs#ebc8d8133891ec208ec4fecb5b74231a1d896706":
+"react-orbitjs@github:DeveloperTown/react-orbitjs#9913bdeac3495a9f75413c30f168ed617cf29124":
   version "0.1.10"
-  resolved "https://codeload.github.com/DeveloperTown/react-orbitjs/tar.gz/ebc8d8133891ec208ec4fecb5b74231a1d896706"
+  resolved "https://codeload.github.com/DeveloperTown/react-orbitjs/tar.gz/9913bdeac3495a9f75413c30f168ed617cf29124"
   dependencies:
     "@types/recompose" "0.30.3"
     hoist-non-react-statics "3.3.0"


### PR DESCRIPTION
 - add permission hooks
 - conditionally allow super admins to make changes to the organizations/stores screen

outside of this PR were some changes to dt/react-orbitjs to add a `useOrbit` hook.