### PR TITLE
Linting for .net code

### DIFF
--- a/source/OptimaJet.DWKit.StarterApplication/OptimaJet.DWKit.StarterApplication.csproj
+++ b/source/OptimaJet.DWKit.StarterApplication/OptimaJet.DWKit.StarterApplication.csproj
@@ -50,6 +50,10 @@
     <PackageReference Include="React.AspNet" Version="3.2.0" />
     <PackageReference Include="Serilog.AspNetCore" Version="2.1.1" />
     <PackageReference Include="Serilog.Sinks.Console" Version="3.1.2-dev-00777" />
+    <PackageReference Include="StyleCop.Analyzers" Version="1.0.2">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
     <PackageReference Include="WorkflowEngine.NETCore-Core" Version="3.3.1" />
     <PackageReference Include="DWKit-ProviderForMSSQL" Version="2.4.1" />
     <PackageReference Include="DWKit-ProviderForPostgreSQL" Version="2.4.1" />

--- a/source/OptimaJet.DWKit.StarterApplication/OptimaJet.DWKit.StarterApplication.csproj
+++ b/source/OptimaJet.DWKit.StarterApplication/OptimaJet.DWKit.StarterApplication.csproj
@@ -19,6 +19,13 @@
     <MvcRazorCompileOnPublish>false</MvcRazorCompileOnPublish>
   </PropertyGroup>
 
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <CodeAnalysisRuleSet>../dotnet.ruleset</CodeAnalysisRuleSet>
+  </PropertyGroup>
+  <ItemGroup>
+    <AdditionalFiles Include="../stylecop.json" />
+  </ItemGroup>
+
   <PropertyGroup Condition=" '$(RunConfiguration)' == 'Default' ">
     <StartAction>Project</StartAction>
     <LaunchBrowser>false</LaunchBrowser>

--- a/source/SIL.AppBuilder.BuildEngineApiClient/SIL.AppBuilder.BuildEngineApiClient.csproj
+++ b/source/SIL.AppBuilder.BuildEngineApiClient/SIL.AppBuilder.BuildEngineApiClient.csproj
@@ -7,5 +7,16 @@
   <ItemGroup>
     <PackageReference Include="RestSharp" Version="106.3.1" />
     <PackageReference Include="Humanizer" Version="2.5.16" />
+      <PackageReference Include="StyleCop.Analyzers" Version="1.0.2">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+  </ItemGroup>
+
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <CodeAnalysisRuleSet>../dotnet.ruleset</CodeAnalysisRuleSet>
+  </PropertyGroup>
+  <ItemGroup>
+    <AdditionalFiles Include="../stylecop.json" />
   </ItemGroup>
 </Project>

--- a/source/SIL.AppBuilder.Portal.Backend.Tests/SIL.AppBuilder.Portal.Backend.Tests.csproj
+++ b/source/SIL.AppBuilder.Portal.Backend.Tests/SIL.AppBuilder.Portal.Backend.Tests.csproj
@@ -20,6 +20,10 @@
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="2.1.1" />
     <PackageReference Include="FluentAssertions" Version="5.6.0" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.3.1" />
+    <PackageReference Include="StyleCop.Analyzers" Version="1.0.2">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
     <DotNetCliToolReference Include="dotnet-xunit" Version="2.3.1" />
   </ItemGroup>
 
@@ -61,5 +65,12 @@
     <EmbeddedResource Include="source\locales\en-us.json">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </EmbeddedResource>
+  </ItemGroup>
+
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <CodeAnalysisRuleSet>../dotnet.ruleset</CodeAnalysisRuleSet>
+  </PropertyGroup>
+  <ItemGroup>
+    <AdditionalFiles Include="../stylecop.json" />
   </ItemGroup>
 </Project>

--- a/source/dotnet.ruleset
+++ b/source/dotnet.ruleset
@@ -1,0 +1,40 @@
+<RuleSet 
+  Name="Rules for Hello World project" 
+  Description="These rules focus on critical issues for the Hello World app." 
+  ToolsVersion="10.0"
+>
+  <Localization 
+    ResourceAssembly="Microsoft.VisualStudio.CodeAnalysis.RuleSets.Strings.dll" 
+    ResourceBaseName="Microsoft.VisualStudio.CodeAnalysis.RuleSets.Strings.Localized"
+  >
+    <Name Resource="Styles for Scriptoria" />
+    <Description Resource="Styles for Scriptoria" />
+  </Localization>
+  
+  <Rules AnalyzerId="Microsoft.Analyzers.ManagedCodeAnalysis" RuleNamespace="Microsoft.Rules.Managed">
+    <Rule Id="CA1001" Action="Warning" />
+    <Rule Id="CA1009" Action="Warning" />
+    <Rule Id="CA1016" Action="Warning" />
+    <Rule Id="CA1033" Action="Warning" />
+  </Rules>
+
+  <Rules AnalyzerId="Microsoft.CodeQuality.Analyzers" RuleNamespace="Microsoft.CodeQuality.Analyzers">
+    <Rule Id="CA1802" Action="Error" />
+    <Rule Id="CA1814" Action="Info" />
+    <Rule Id="CA1823" Action="None" />
+    <Rule Id="CA2217" Action="Warning" />
+
+    <!-- Documentation -->
+    <Rule Id="SA1652" Action="None" />
+    <Rule Id="SA1633" Action="None" />
+
+  </Rules>
+
+  <Rules AnalyzerId="xunit.analyzers" RuleNamespace="xunit.analyzers">
+
+    <!-- TODO: -->
+    <Rule Id="xUnit2013" Action="None" />
+    <Rule Id="xUnit2000" Action="None" />
+  </Rules>
+
+</RuleSet>

--- a/source/stylecop.json
+++ b/source/stylecop.json
@@ -1,0 +1,3 @@
+{
+  "$schema": "https://raw.githubusercontent.com/DotNetAnalyzers/StyleCopAnalyzers/master/StyleCop.Analyzers/StyleCop.Analyzers/Settings/stylecop.schema.json"
+}

--- a/source/stylecop.json
+++ b/source/stylecop.json
@@ -1,3 +1,45 @@
 {
-  "$schema": "https://raw.githubusercontent.com/DotNetAnalyzers/StyleCopAnalyzers/master/StyleCop.Analyzers/StyleCop.Analyzers/Settings/stylecop.schema.json"
+  "$schema": "https://raw.githubusercontent.com/DotNetAnalyzers/StyleCopAnalyzers/master/StyleCop.Analyzers/StyleCop.Analyzers/Settings/stylecop.schema.json",
+  "settings": {
+    "indentation": {
+      "indentationSize": 4,
+      "useTabs": false
+    },
+    "documentationRules": {
+      "documentExposedElements": false,
+      "documentInterfaces": false,
+      "documentInternalElements": false,
+      "documentPrivateElements": false,
+      "documentPrivateFields": false
+    },
+    "layoutRules": {
+      "newlineAtEndOfFile": "require"
+    },
+    "maintainabilityRules": {
+      "topLevelTypes": [
+        "class"
+      ]
+    },
+    "namingRules": {
+      "allowCommonHungarianPrefixes": false,
+      "allowedHungarianPrefixes": []
+    },
+    "orderingRules": {
+      "blankLinesBetweenUsingGroups": "require",
+      "elementOrder": [
+        "kind",
+        "accessibility",
+        "constant",
+        "static",
+        "readonly"
+      ],
+      "systemUsingDirectivesFirst": true,
+      "usingDirectivesPlacement": "insideNamespace"
+    },
+    "readabilityRules": {
+      "allowBuiltInTypeAliases": false
+    },
+    "spacingRules": {}
+
+  }
 }


### PR DESCRIPTION
Why - Lack of consistent formatting was bothering me

Adds StyleCop.Analyzers
 - Roslyn-based linter / code style analysis
 - Styles not applied in this PR, but we should run this on every file we edit from now on (there is some git diff -fu that can be done to do this for us, but that's outside the scope of this PR / the time we have)


Editor Support:
 - VS Code: https://github.com/OmniSharp/omnisharp-vscode/issues/43 (soon :tm: )
 - Visual Sutdio

Info:
 - https://github.com/DotNetAnalyzers/StyleCopAnalyzers