### PR TITLE
Convert from alltags.json to langtags.json

### DIFF
--- a/source/SIL.AppBuilder.Portal.Frontend/.gitignore
+++ b/source/SIL.AppBuilder.Portal.Frontend/.gitignore
@@ -11,4 +11,5 @@ tests/cypress/videos/
 /test.results
 
 src/public/assets/language/alltags.json
+src/public/assets/language/langtags.json
 src/public/assets/language/**/ldml*

--- a/source/SIL.AppBuilder.Portal.Frontend/.gitignore
+++ b/source/SIL.AppBuilder.Portal.Frontend/.gitignore
@@ -10,6 +10,5 @@ tests/cypress/screenshots/
 tests/cypress/videos/
 /test.results
 
-src/public/assets/language/alltags.json
-src/public/assets/language/langtags.json
+src/public/assets/language/*.json
 src/public/assets/language/**/ldml*

--- a/source/SIL.AppBuilder.Portal.Frontend/scripts/refresh-languages.sh
+++ b/source/SIL.AppBuilder.Portal.Frontend/scripts/refresh-languages.sh
@@ -13,9 +13,9 @@
 set -e
 
 
-url="https://raw.githubusercontent.com/silnrsi/sldr/master/extras/alltags.json"
+url="https://raw.githubusercontent.com/silnrsi/sldr/master/extras/langtags.json"
 folder="./src/public/assets/language/"
-targetPath="${folder}alltags.json"
+targetPath="${folder}langtags.json"
 
 mkdir -p $folder
 

--- a/source/SIL.AppBuilder.Portal.Frontend/scripts/refresh-languages.sh
+++ b/source/SIL.AppBuilder.Portal.Frontend/scripts/refresh-languages.sh
@@ -15,12 +15,15 @@ set -e
 
 url="https://raw.githubusercontent.com/silnrsi/sldr/master/extras/langtags.json"
 folder="./src/public/assets/language/"
-targetPath="${folder}langtags.json"
+tempPath="${folder}langtags.tmp.json"
+target1Path="${folder}langtags.json"
+target2Path="${folder}specialtags.json"
 
 mkdir -p $folder
 
 echo "downloading all supported languages..."
-wget --output-document $targetPath $url
+wget --output-document $tempPath $url
+node scripts/split-langtags-json.js $tempPath $target1Path $target2Path
 echo "downloaded all supported languages"
 
 echo "downloading transaltion support for the language data..."

--- a/source/SIL.AppBuilder.Portal.Frontend/scripts/split-langtags-json.js
+++ b/source/SIL.AppBuilder.Portal.Frontend/scripts/split-langtags-json.js
@@ -1,0 +1,23 @@
+const fs = require('fs');
+
+const [_executor, _file, inputName, output1Name, output2Name] = process.argv;
+
+let raw = fs.readFileSync(inputName);
+let data = JSON.parse(raw);
+
+let output1 = data.filter(function (el){
+  return !el.tag.startsWith("_")
+});
+let output1String = JSON.stringify(output1,null,2);
+
+let output2 = data.filter(function (el){
+  return el.tag.startsWith("_")
+});
+
+let output2String = JSON.stringify(output2, null, 2);
+
+fs.writeFileSync(output1Name, output1String);
+
+fs.writeFileSync(output2Name, output2String);
+
+console.log(`JSON output at ${output1Name} and ${output2Name}`);

--- a/source/SIL.AppBuilder.Portal.Frontend/src/translations/locales/en-us.json
+++ b/source/SIL.AppBuilder.Portal.Frontend/src/translations/locales/en-us.json
@@ -16,6 +16,7 @@
     "region": "{num, plural, one {Region} other {Regions}}",
     "name": "{num, plural, one {Name} other {Names}}",
     "tag": "{num, plural, one {Tag} other {Tags}}",
+    "variant": "{num, plural, one {Variant} other {Variants}}",
     "regionName": "Region Name"
   },
   "attributions": {

--- a/source/SIL.AppBuilder.Portal.Frontend/src/ui/components/inputs/locale-input/-utils/find-additional-matches.tsx
+++ b/source/SIL.AppBuilder.Portal.Frontend/src/ui/components/inputs/locale-input/-utils/find-additional-matches.tsx
@@ -16,6 +16,7 @@ const translationMap = {
   region: 'region',
   regions: 'region',
   regionname: 'regionName',
+  variants: 'variant',
   tag: 'tag',
   tags: 'tag',
 };

--- a/source/SIL.AppBuilder.Portal.Frontend/src/ui/components/inputs/locale-input/-utils/find-additional-matches.tsx
+++ b/source/SIL.AppBuilder.Portal.Frontend/src/ui/components/inputs/locale-input/-utils/find-additional-matches.tsx
@@ -60,10 +60,6 @@ export function findAdditionalMatches(
     let value = Array.isArray(rawValue) ? rawValue.join(', ') : rawValue;
     let num = Array.isArray(rawValue) ? rawValue.length : 1;
 
-    if (rawValue && key === 'regions') {
-      num = rawValue.split(' ').length;
-    }
-
     if (has(value)) {
       updateResult({ key: translationMap[key], value, num });
     }

--- a/source/SIL.AppBuilder.Portal.Frontend/src/ui/components/inputs/locale-input/-utils/helpers.tsx
+++ b/source/SIL.AppBuilder.Portal.Frontend/src/ui/components/inputs/locale-input/-utils/helpers.tsx
@@ -16,13 +16,15 @@ export const getSuggestions = (data: ILanguageInfo[]) => (value) => {
   const has = hasSearchTerm(value);
 
   return data.filter(
-    ({ name, nameInLocale, region, tag, localname, regions, names }) =>
+    ({ name, nameInLocale, region, tag, localname, regions, names, variants }) =>
       has(nameInLocale) ||
       has((names || []).join()) ||
       has(localname || name) ||
-      has(regions || region) ||
+      has((regions || []).join()) ||
+      has(region) ||
+      has((variants || []).join()) ||
       has(tag)
-  );
+   );
 };
 
 export const getSuggestionValue = (suggestion: ILanguageInfo) => suggestion.tag;

--- a/source/SIL.AppBuilder.Portal.Frontend/src/ui/components/inputs/locale-input/-utils/helpers.tsx
+++ b/source/SIL.AppBuilder.Portal.Frontend/src/ui/components/inputs/locale-input/-utils/helpers.tsx
@@ -24,7 +24,7 @@ export const getSuggestions = (data: ILanguageInfo[]) => (value) => {
       has(region) ||
       has((variants || []).join()) ||
       has(tag)
-   );
+  );
 };
 
 export const getSuggestionValue = (suggestion: ILanguageInfo) => suggestion.tag;

--- a/source/SIL.AppBuilder.Portal.Frontend/src/ui/components/inputs/locale-input/-utils/localize.ts
+++ b/source/SIL.AppBuilder.Portal.Frontend/src/ui/components/inputs/locale-input/-utils/localize.ts
@@ -36,7 +36,6 @@ export function localizeTagData(data: ILanguageInfo[], t): ILanguageInfo[] {
         info.regions &&
         info.regions
           .map((region) => tryLocalize('territories', region, region))
-          .join(', '),
     };
   });
 }

--- a/source/SIL.AppBuilder.Portal.Frontend/src/ui/components/inputs/locale-input/-utils/localize.ts
+++ b/source/SIL.AppBuilder.Portal.Frontend/src/ui/components/inputs/locale-input/-utils/localize.ts
@@ -27,6 +27,7 @@ export function localizeTagData(data: ILanguageInfo[], t): ILanguageInfo[] {
       //  - sldr: boolean;
       //  - tag: string;
       //  - tags?: string[];
+      //  - variants?: string[];
       nameInLocale: tryLocalize('languages', info.tag, info.name),
 
       // These are the only fields that need localization
@@ -34,7 +35,6 @@ export function localizeTagData(data: ILanguageInfo[], t): ILanguageInfo[] {
       regions:
         info.regions &&
         info.regions
-          .split(' ')
           .map((region) => tryLocalize('territories', region, region))
           .join(', '),
     };

--- a/source/SIL.AppBuilder.Portal.Frontend/src/ui/components/inputs/locale-input/-utils/localize.ts
+++ b/source/SIL.AppBuilder.Portal.Frontend/src/ui/components/inputs/locale-input/-utils/localize.ts
@@ -33,9 +33,7 @@ export function localizeTagData(data: ILanguageInfo[], t): ILanguageInfo[] {
       // These are the only fields that need localization
       region: info.region && tryLocalize('territories', info.region, info.region),
       regions:
-        info.regions &&
-        info.regions
-          .map((region) => tryLocalize('territories', region, region))
+        info.regions && info.regions.map((region) => tryLocalize('territories', region, region)),
     };
   });
 }

--- a/source/SIL.AppBuilder.Portal.Frontend/src/ui/components/inputs/locale-input/index.tsx
+++ b/source/SIL.AppBuilder.Portal.Frontend/src/ui/components/inputs/locale-input/index.tsx
@@ -13,7 +13,7 @@ export interface IProps {
 }
 
 function LocaleInput(props: IProps) {
-  const { error, data } = useFetch('/assets/language/alltags.json');
+  const { error, data } = useFetch('/assets/language/langtags.json');
 
   if (error) return <ErrorMessage error={error} />;
   if (!data) return null;

--- a/source/SIL.AppBuilder.Portal.Frontend/src/ui/routes/project-directory/list/__tests__/filtering-by-organization-acceptance-test.ts
+++ b/source/SIL.AppBuilder.Portal.Frontend/src/ui/routes/project-directory/list/__tests__/filtering-by-organization-acceptance-test.ts
@@ -41,7 +41,7 @@ describe('Acceptance | Project Directory | Filtering | By Organization', () => {
       });
     });
 
-    server.get('/assets/language/alltags.json').intercept((req, res) => {
+    server.get('/assets/language/langtgs.json').intercept((req, res) => {
       res.status(200);
       res.json([]);
     });

--- a/source/SIL.AppBuilder.Portal.Frontend/src/ui/routes/projects/new/__tests__/acceptance-test.ts
+++ b/source/SIL.AppBuilder.Portal.Frontend/src/ui/routes/projects/new/__tests__/acceptance-test.ts
@@ -144,7 +144,7 @@ describe('Acceptance | New Project', () => {
 
       beforeEach(function() {
         this.mockGet(200, '/application-types', scenarios.applicationTypes());
-        this.server.get('/assets/language/alltags.json').intercept((req, res) => {
+        this.server.get('/assets/language/langtags.json').intercept((req, res) => {
           res.status(200);
           res.json([
             {

--- a/source/SIL.AppBuilder.Portal.Frontend/tests/helpers/request-intercepting/polly.ts
+++ b/source/SIL.AppBuilder.Portal.Frontend/tests/helpers/request-intercepting/polly.ts
@@ -119,7 +119,7 @@ const setup = function(config) {
   this.mockGet(200, '/user-tasks', { data: [] });
   this.mockGet(200, '/notifications', { data: [] });
 
-  server.get('/assets/language/alltags.json').intercept((req, res) => {
+  server.get('/assets/language/langtags.json').intercept((req, res) => {
     res.status(200);
     res.json([]);
   });

--- a/source/SIL.AppBuilder.Portal.Frontend/types/index.d.ts
+++ b/source/SIL.AppBuilder.Portal.Frontend/types/index.d.ts
@@ -56,10 +56,11 @@ interface ILanguageInfo {
   names?: string[];
   region: string;
   regionname: string;
-  regions?: string;
+  regions?: string[];
   sldr: boolean;
   tag: string;
   tags?: string[];
+  variants?: string[];
 
   // app-managed
   nameInLocale: string;


### PR DESCRIPTION
* WritingSystemsTechnology is switching the alltags.json to
  langtags.json
* regions attribute is changing from being a space separated list
  in a string to being an array
* New file is https://raw.githubusercontent.com/silnrsi/sldr/master/extras/langtags.json
* Include known variants (not sure how this should be used in
  suggestions)

Issue:
* in /projects/new, I get error "Cannot read property
'toLocaleLowerCase' of undefined
** this is in src/ui/components/input/locale-input/-utils/helpers.tsx,
   line 136
* VCode thinks there is an error in .../locale-input/-utils/localize.ts
** I remove info.regions.split(' ') since regions is a string[] instead
   of string.  I thought the existing .map() would work in string[]