### PR TITLE
Bug: Notification always being sent

### DIFF
--- a/source/OptimaJet.DWKit.StarterApplication/Controllers/NotificationTestController.cs
+++ b/source/OptimaJet.DWKit.StarterApplication/Controllers/NotificationTestController.cs
@@ -43,7 +43,8 @@ namespace OptimaJet.DWKit.StarterApplication.Controllers
             var notification = new Notification()
             {
                 User = user,
-                Message = message
+                Message = message,
+                SendEmail = true
             };
             notification =  await _notificationService.CreateAsync(notification);
             await _hubContext.Clients.User(user.ExternalId).SendAsync("Notification", notification.Id);

--- a/source/OptimaJet.DWKit.StarterApplication/Data/AppDbContext.cs
+++ b/source/OptimaJet.DWKit.StarterApplication/Data/AppDbContext.cs
@@ -165,10 +165,6 @@ namespace OptimaJet.DWKit.StarterApplication.Data
                 .Property(p => p.WorkflowProjectId)
                 .HasDefaultValue(0);
 
-            notificationEntity
-                .Property(p => p.SendEmail)
-                .HasDefaultValue(true);
-
             workflowDefinitionEntity
                 .Property(w => w.Type)
                 .HasDefaultValue(WorkflowType.Startup);

--- a/source/OptimaJet.DWKit.StarterApplication/Migrations/20190320194411_RemoveNotificationEmailDefault.Designer.cs
+++ b/source/OptimaJet.DWKit.StarterApplication/Migrations/20190320194411_RemoveNotificationEmailDefault.Designer.cs
@@ -2,6 +2,7 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using OptimaJet.DWKit.StarterApplication.Data;
@@ -10,9 +11,10 @@ using OptimaJet.DWKit.StarterApplication.Models;
 namespace OptimaJet.DWKit.StarterApplication.Migrations
 {
     [DbContext(typeof(AppDbContext))]
-    partial class AppDbContextModelSnapshot : ModelSnapshot
+    [Migration("20190320194411_RemoveNotificationEmailDefault")]
+    partial class RemoveNotificationEmailDefault
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/source/OptimaJet.DWKit.StarterApplication/Migrations/20190320194411_RemoveNotificationEmailDefault.cs
+++ b/source/OptimaJet.DWKit.StarterApplication/Migrations/20190320194411_RemoveNotificationEmailDefault.cs
@@ -1,0 +1,27 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+namespace OptimaJet.DWKit.StarterApplication.Migrations
+{
+    public partial class RemoveNotificationEmailDefault : Migration
+    {
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AlterColumn<bool>(
+                name: "SendEmail",
+                table: "Notifications",
+                nullable: false,
+                oldClrType: typeof(bool),
+                oldDefaultValue: true);
+        }
+
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AlterColumn<bool>(
+                name: "SendEmail",
+                table: "Notifications",
+                nullable: false,
+                defaultValue: true,
+                oldClrType: typeof(bool));
+        }
+    }
+}

--- a/source/OptimaJet.DWKit.StarterApplication/Models/Notification.cs
+++ b/source/OptimaJet.DWKit.StarterApplication/Models/Notification.cs
@@ -47,7 +47,7 @@ namespace OptimaJet.DWKit.StarterApplication.Models
         }
 
         [Attr("send-email")]
-        public bool SendEmail { get; set; } = true;
+        public bool SendEmail { get; set; }
 
         [Attr("link-url")]
         public string LinkUrl { get; set; }

--- a/source/SIL.AppBuilder.Portal.Backend.Tests/Acceptance/Services/Notifications/NotificationTest.cs
+++ b/source/SIL.AppBuilder.Portal.Backend.Tests/Acceptance/Services/Notifications/NotificationTest.cs
@@ -115,7 +115,8 @@ namespace SIL.AppBuilder.Portal.Backend.Tests.Acceptance.Services.Notifications
                 MessageId = "buildengineConnected",
                 MessageSubstitutionsJson = serializedParm,
                 Message = "Build Engine for organization SIL International status change: connected",
-                UserId = user1.Id
+                UserId = user1.Id,
+                SendEmail = true
             });
         }
         public NotificationTest(TestFixture<BuildEngineStartup> fixture) : base(fixture)

--- a/source/SIL.AppBuilder.Portal.Backend.Tests/Acceptance/Services/SendEmails/SendEmailServiceTest.cs
+++ b/source/SIL.AppBuilder.Portal.Backend.Tests/Acceptance/Services/SendEmails/SendEmailServiceTest.cs
@@ -129,7 +129,8 @@ namespace SIL.AppBuilder.Portal.Backend.Tests.Acceptance.Services.SendEmails
                 MessageId = "buildengineConnected",
                 MessageSubstitutionsJson = serializedParm,
                 Message = "Build Engine for organization SIL International status change: connected",
-                UserId = user1.Id
+                UserId = user1.Id,
+                SendEmail = true
             });
             type1 = AddEntity<AppDbContext, ApplicationType>(new ApplicationType
             {


### PR DESCRIPTION
Notification default always set the value to true.
The default for a boolean should only apply to a conditional
boolean (bool?).  The default here was really not needed since
the value was always being explicitly set.  Did make changes to
set the value in some tests where it was not previously explicitly set.