### PR TITLE
use additional condition to check for failures

### DIFF
--- a/source/SIL.AppBuilder.Portal.Frontend/scripts/tests.sh
+++ b/source/SIL.AppBuilder.Portal.Frontend/scripts/tests.sh
@@ -18,18 +18,27 @@ export REVISION=$(git rev-parse HEAD)
 export BUILD_DATE=$(date)
 # export COVERAGE=true
 
+# Don't fail before we have a chance to capture the error
+set +e
+
 yarn karma:start --single-run | tee test.results
 
 # the output file will contain a block of test that looks like this
-# SUMMARY: 
-# ✔ 285 tests completed 
-# ℹ 24 tests skipped 
+# SUMMARY:
+# ✔ 285 tests completed
+# ℹ 24 tests skipped
 # ✖ 3 tests failed
 completed_tests=$(cat test.results | grep " tests completed" | cut -d " " -f2)
+failed_tests=$(cat test.results | grep -E " tests? failed" | cut -d " " -f2)
+
+if [ ! -z "$failed_tests" ]; then
+  echo "tests failed"
+  exit 1
+fi
 
 # This is kind of a hack, but for now it'll work as C.I. is passing with only 77 tests ran.
 # and ... that's only a third of the suite at the time of writing this...
-if [ "$completed_tests" -lt "286" ]; then
+if [ "$completed_tests" -lt "287" ]; then
   echo "the entire test suite didn't run. Something is very wrong"
   exit 1
 fi


### PR DESCRIPTION
When the test script was created, the results of stdout were piped to a file -- this made the exit code always return 0, as the pipe always succeeded.

This PR adds a check to that piped file to see if any tests failed.