### PR TITLE
When a build artifact version is null, show that the build is pending

### DIFF
--- a/source/SIL.AppBuilder.Portal.Frontend/src/translations/locales/en-us.json
+++ b/source/SIL.AppBuilder.Portal.Frontend/src/translations/locales/en-us.json
@@ -204,6 +204,7 @@
   "projects": {
     "noBuilds": "No Builds Yet",
     "latestBuild": "Latest Build ({version})",
+    "buildPending": "Build Pending",
     "switcher": {
       "myProjects": "My Projects ({numProjects})",
       "archived": "Archived ({numProjects})",

--- a/source/SIL.AppBuilder.Portal.Frontend/src/ui/components/product-artifact/index.tsx
+++ b/source/SIL.AppBuilder.Portal.Frontend/src/ui/components/product-artifact/index.tsx
@@ -27,13 +27,13 @@ export default function Builds({ product }) {
       <ResourceSelect
         items={sortedBuilds}
         labelField={(build: ProductBuildResource) => {
-          const version = attributesFor(build).version;
+          const version = attributesFor(build).version || ` ${t('projects.buildPending')} `;
 
           if (build === sortedBuilds[0]) {
             return t('projects.latestBuild', { version });
           }
 
-          return version || t('projects.buildPending');
+          return version;
         }}
         value={activeVersion}
         onChange={setActiveVersion}

--- a/source/SIL.AppBuilder.Portal.Frontend/src/ui/components/product-artifact/index.tsx
+++ b/source/SIL.AppBuilder.Portal.Frontend/src/ui/components/product-artifact/index.tsx
@@ -27,6 +27,16 @@ export default function Builds({ product }) {
       <ResourceSelect
         items={sortedBuilds}
         labelField={(build: ProductBuildResource) => {
+          // Looking at the default value here, you may notice that there are extra spaces
+          // around the t(...). This is intentional, as the outputs are either:
+          //
+          // `Current Build (v1.0.0)`
+          // or
+          // `Current Build ( Build Pending )`
+          //
+          // without the spaces it does:
+          // `Current Build (build Pending)`
+          // TODO: see: https://developertown.visualstudio.com/SIL%20International%20Scriptoria/_workitems/edit/34532
           const version = attributesFor(build).version || ` ${t('projects.buildPending')} `;
 
           if (build === sortedBuilds[0]) {

--- a/source/SIL.AppBuilder.Portal.Frontend/src/ui/components/product-artifact/index.tsx
+++ b/source/SIL.AppBuilder.Portal.Frontend/src/ui/components/product-artifact/index.tsx
@@ -17,23 +17,23 @@ export default function Builds({ product }) {
     productBuilds: (q) => q.findRelatedRecords(product, 'productBuilds'),
   });
 
-  const [activeVersion, setActiveVersion] = useState((productBuilds || [])[0]);
-
-  const sortedBuilds = productBuilds.sort(compareVia((build) => attributesFor(build).version));
+  const sortedBuilds = productBuilds.sort(
+    compareVia((build) => attributesFor(build).version, true)
+  );
+  const [activeVersion, setActiveVersion] = useState((sortedBuilds || [])[0]);
 
   return (
     <div data-test-build>
       <ResourceSelect
         items={sortedBuilds}
         labelField={(build: ProductBuildResource) => {
-          console.log(build);
           const version = attributesFor(build).version;
 
           if (build === sortedBuilds[0]) {
             return t('projects.latestBuild', { version });
           }
 
-          return version;
+          return version || t('projects.buildPending');
         }}
         value={activeVersion}
         onChange={setActiveVersion}

--- a/source/SIL.AppBuilder.Portal.Frontend/src/ui/routes/projects/show/__tests__/product-files-acceptance-test.tsx
+++ b/source/SIL.AppBuilder.Portal.Frontend/src/ui/routes/projects/show/__tests__/product-files-acceptance-test.tsx
@@ -11,6 +11,161 @@ import {
 
 import page from './page';
 
+async function visitTheFilesTab() {
+  visit('/projects/1');
+  await when(() => page.isPresent);
+  await page.switchToFilesTab();
+  await when(() => page.projectFiles.isPresent);
+}
+
+const projectResource = (attributes = {}, relationships = {}) => {
+  return {
+    type: 'projects',
+    id: 1,
+    attributes: {
+      name: 'Fake project',
+      workflowProjectUrl: 'project.url',
+      ...attributes,
+    },
+    relationships: {
+      organization: { data: { id: 1, type: 'organizations' } },
+      group: { data: { id: 1, type: 'groups' } },
+      owner: { data: { id: 2, type: 'users' } },
+      reviewers: { data: [] },
+      products: { data: [{ id: 1, type: 'products' }] },
+      ...relationships,
+    },
+  };
+};
+
+const defaultIncluded = () => {
+  return [
+    { type: 'organizations', id: 1 },
+    { type: 'groups', id: 1, attributes: { name: 'Some Group' } },
+    { type: 'users', id: 2, attributes: { familyName: 'last', givenName: 'first' } },
+    {
+      type: 'organization-product-definitions',
+      id: 1,
+      attributes: {},
+      relationships: {
+        organization: { data: { type: 'organization', id: 1 } },
+        'product-definition': { data: { type: 'product-definitions', id: 1 } },
+      },
+    },
+    {
+      type: 'organization-product-definitions',
+      id: 2,
+      attributes: {},
+      relationships: {
+        organization: { data: { type: 'organization', id: 1 } },
+        'product-definition': { data: { type: 'product-definitions', id: 2 } },
+      },
+    },
+    {
+      type: 'product-definitions',
+      id: 1,
+      attributes: {
+        description: 'Publish Android app to S3',
+        name: 'android_s3',
+      },
+    },
+    {
+      type: 'product-definitions',
+      id: 2,
+      attributes: {
+        description: 'Publish Android App to Google Play',
+        name: 'android_amazon_app',
+      },
+    },
+  ];
+};
+
+const scenarios = {
+  noBuilds: {
+    data: projectResource(),
+    included: [
+      ...defaultIncluded(),
+      {
+        type: 'products',
+        id: 1,
+        attributes: {
+          'date-created': '2018-10-20T16:19:09.878193',
+          'date-updated': '2018-10-20T16:19:09.878193',
+          'date-built': null,
+          'date-published': null,
+        },
+        relationships: {
+          'product-definition': { data: { type: 'product-definitions', id: 1 } },
+          project: { data: { type: 'projects', id: 1 } },
+          productBuilds: { data: [] },
+        },
+      },
+    ],
+  },
+  oneBuildSuccess: {
+    data: projectResource(),
+    included: [
+      ...defaultIncluded(),
+      {
+        type: 'products',
+        id: 1,
+        attributes: {
+          'date-created': '2018-10-20T16:19:09.878193',
+          'date-updated': '2018-10-20T16:19:09.878193',
+          'date-built': null,
+          'date-published': null,
+        },
+        relationships: {
+          'product-definition': { data: { type: 'product-definitions', id: 1 } },
+          project: { data: { type: 'projects', id: 1 } },
+          productBuilds: { data: [{ type: 'product-build', id: 1 }] },
+        },
+      },
+      {
+        type: 'product-build',
+        id: 1,
+        attributes: {
+          version: 'v1.0.0',
+        },
+        relationships: {
+          product: { data: { type: 'product', id: 1 } },
+        },
+      },
+    ],
+  },
+  oneBuildPending: {
+    data: projectResource(),
+    included: [
+      ...defaultIncluded(),
+      {
+        type: 'products',
+        id: 1,
+        attributes: {
+          'date-created': '2018-10-20T16:19:09.878193',
+          'date-updated': '2018-10-20T16:19:09.878193',
+          'date-built': null,
+          'date-published': null,
+        },
+        relationships: {
+          'product-definition': { data: { type: 'product-definitions', id: 1 } },
+          project: { data: { type: 'projects', id: 1 } },
+          productBuilds: { data: [{ type: 'product-build', id: 1 }] },
+        },
+      },
+      {
+        type: 'product-build',
+        id: 1,
+        attributes: {
+          version: null,
+        },
+        relationships: {
+          product: { data: { type: 'product', id: 1 } },
+        },
+      },
+    ],
+  },
+};
+
 describe('Acceptance | Project View | Product Files', () => {
   resetBrowser();
   useFakeAuthentication();
@@ -28,81 +183,7 @@ describe('Acceptance | Project View | Product Files', () => {
       customizer = null;
       this.mockGet(200, 'users', { data: [] }, requestCustomizer);
       this.mockGet(200, '/groups', { data: [] }, requestCustomizer);
-      this.mockGet(
-        200,
-        'projects/1',
-        {
-          data: {
-            type: 'projects',
-            id: 1,
-            attributes: {
-              name: 'Fake project',
-              workflowProjectUrl: 'project.url',
-            },
-            relationships: {
-              organization: { data: { id: 1, type: 'organizations' } },
-              group: { data: { id: 1, type: 'groups' } },
-              owner: { data: { id: 2, type: 'users' } },
-              reviewers: { data: [] },
-              products: { data: [{ id: 1, type: 'products' }] },
-            },
-          },
-          included: [
-            { type: 'organizations', id: 1 },
-            { type: 'groups', id: 1, attributes: { name: 'Some Group' } },
-            { type: 'users', id: 2, attributes: { familyName: 'last', givenName: 'first' } },
-            {
-              type: 'products',
-              id: 1,
-              attributes: {
-                'date-created': '2018-10-20T16:19:09.878193',
-                'date-updated': '2018-10-20T16:19:09.878193',
-                'date-built': null,
-                'date-published': null,
-              },
-              relationships: {
-                'product-definition': { data: { type: 'product-definitions', id: 1 } },
-                project: { data: { type: 'projects', id: 1 } },
-              },
-            },
-            {
-              type: 'organization-product-definitions',
-              id: 1,
-              attributes: {},
-              relationships: {
-                organization: { data: { type: 'organization', id: 1 } },
-                'product-definition': { data: { type: 'product-definitions', id: 1 } },
-              },
-            },
-            {
-              type: 'organization-product-definitions',
-              id: 2,
-              attributes: {},
-              relationships: {
-                organization: { data: { type: 'organization', id: 1 } },
-                'product-definition': { data: { type: 'product-definitions', id: 2 } },
-              },
-            },
-            {
-              type: 'product-definitions',
-              id: 1,
-              attributes: {
-                description: 'Publish Android app to S3',
-                name: 'android_s3',
-              },
-            },
-            {
-              type: 'product-definitions',
-              id: 2,
-              attributes: {
-                description: 'Publish Android App to Google Play',
-                name: 'android_amazon_app',
-              },
-            },
-          ],
-        },
-        requestCustomizer
-      );
+      this.mockGet(200, 'projects/1', scenarios.noBuilds, requestCustomizer);
     });
 
     beforeEach(async () => {
@@ -115,12 +196,44 @@ describe('Acceptance | Project View | Product Files', () => {
     it('shows one product for project with one product', () => {
       expect(page.projectFiles.products().length).to.equal(1);
     });
+
     it('render no builds', () => {
       expect(page.projectFiles.products(0).selectedBuild).equal('No Builds Yet');
     });
 
     it('renders no artifacts', () => {
       expect(page.projectFiles.products(0).artifactCount).contains('No Product Files');
+    });
+  });
+
+  describe('there is one build', () => {
+    beforeEach(function() {
+      this.mockGet(200, 'users', { data: [] });
+      this.mockGet(200, 'groups', { data: [] });
+    });
+
+    describe('the build was successful', () => {
+      beforeEach(async function() {
+        this.mockGet(200, 'projects/1', scenarios.oneBuildSuccess);
+
+        await visitTheFilesTab();
+      });
+
+      it('shows the version number', () => {
+        expect(page.projectFiles.products(0).selectedBuild).contains('v1.0.0');
+      });
+    });
+
+    describe('the build has not yet finished', () => {
+      beforeEach(async function() {
+        this.mockGet(200, 'projects/1', scenarios.oneBuildPending);
+
+        await visitTheFilesTab();
+      });
+
+      it('does not show a version, and instead indicates that it is pending', () => {
+        expect(page.projectFiles.products(0).selectedBuild).contains('Build Pending');
+      });
     });
   });
 });


### PR DESCRIPTION
this doesn't cover any error cases, but we've yet to have a way to capture errors, except maybe through a BuildEngineBuild record -- would need to investigate how that'd be accessed -- but that's out of scope for this PR

https://developertown.visualstudio.com/SIL%20International%20Scriptoria/_workitems/edit/34286