### PR TITLE
Display slash characters correctly in notifications and email subject…

### DIFF
--- a/source/OptimaJet.DWKit.StarterApplication/Services/SendEmailService.cs
+++ b/source/OptimaJet.DWKit.StarterApplication/Services/SendEmailService.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
+using System.Web;
 using I18Next.Net.Plugins;
 using Microsoft.EntityFrameworkCore;
 using Newtonsoft.Json;
@@ -38,6 +39,7 @@ namespace OptimaJet.DWKit.StarterApplication.Services
             var fullSubjectId = "notifications.subject." + notification.MessageId;
             var subsDict = notification.MessageSubstitutions as Dictionary<string, object>;
             var subject = await Translator.TranslateAsync(locale, "notifications", fullSubjectId, subsDict);
+            subject = HttpUtility.HtmlDecode(subject);
             var body = await Translator.TranslateAsync(locale, "notifications", fullBodyId, subsDict);
             if (!string.IsNullOrEmpty(notification.LinkUrl))
             {

--- a/source/OptimaJet.DWKit.StarterApplication/Services/SendNotificationService.cs
+++ b/source/OptimaJet.DWKit.StarterApplication/Services/SendNotificationService.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
+using System.Web;
 using I18Next.Net.Plugins;
 using Microsoft.AspNetCore.SignalR;
 using Microsoft.EntityFrameworkCore;
@@ -86,6 +87,7 @@ namespace OptimaJet.DWKit.StarterApplication.Services
             var locale = user.LocaleOrDefault();
             var fullMessageId = "notifications.notification." + messageId;
             var translated = await Translator.TranslateAsync(locale, "notifications", fullMessageId, subs);
+            translated = HttpUtility.HtmlDecode(translated);
             var sendEmail = !user.EmailNotification.HasValue || user.EmailNotification.Value;
             if (forceEmail.HasValue)
             {

--- a/source/SIL.AppBuilder.Portal.Backend.Tests/Acceptance/Services/Notifications/NotificationTest.cs
+++ b/source/SIL.AppBuilder.Portal.Backend.Tests/Acceptance/Services/Notifications/NotificationTest.cs
@@ -195,10 +195,34 @@ namespace SIL.AppBuilder.Portal.Backend.Tests.Acceptance.Services.Notifications
             var modifiedNotifications = ReadTestData<AppDbContext, Notification>();
             Assert.Equal(3, modifiedNotifications.Count);
             // Verify admin message
-            Assert.Equal("Build for product scriptureAppBuilder project Test Project failed. Status: failure  Review status at build engine http:&#x2F;&#x2F;gtis.guru.com:8443 for details", modifiedNotifications[1].Message);
+            Assert.Equal("Build for product scriptureAppBuilder project Test Project failed. Status: failure  Review status at build engine http://gtis.guru.com:8443 for details", modifiedNotifications[1].Message);
             Assert.Equal("http://gtis.guru.com:8443", modifiedNotifications[1].LinkUrl);
             // Verify user message
             Assert.Equal("Build for product scriptureAppBuilder project Test Project failed. Status: failure The organization administrator has been notified of this issue.", modifiedNotifications[2].Message);
+            Assert.Equal("http://gtis.guru.com:8443", modifiedNotifications[2].LinkUrl);
+        }
+        [Fact]
+        public async Task TestSlashInProjectName()
+        {
+            BuildTestData();
+            var link = "http://gtis.guru.com:8443";
+            var notificationParm = new Dictionary<string, object>()
+            {
+                { "productName", "scriptureAppBuilder"},
+                { "projectName", "Test Project 4/12"},
+                { "buildStatus", "failure"},
+                { "buildEngineUrl", link }
+            };
+
+            var sendNotificationService = _fixture.GetService<SendNotificationService>();
+            await sendNotificationService.SendNotificationToOrgAdminsAndOwnerAsync(org1, CurrentUser, "buildFailedOwner", "buildFailedAdmin", notificationParm, link);
+            var modifiedNotifications = ReadTestData<AppDbContext, Notification>();
+            Assert.Equal(3, modifiedNotifications.Count);
+            // Verify admin message
+            Assert.Equal("Build for product scriptureAppBuilder project Test Project 4/12 failed. Status: failure  Review status at build engine http://gtis.guru.com:8443 for details", modifiedNotifications[1].Message);
+            Assert.Equal("http://gtis.guru.com:8443", modifiedNotifications[1].LinkUrl);
+            // Verify user message
+            Assert.Equal("Build for product scriptureAppBuilder project Test Project 4/12 failed. Status: failure The organization administrator has been notified of this issue.", modifiedNotifications[2].Message);
             Assert.Equal("http://gtis.guru.com:8443", modifiedNotifications[2].LinkUrl);
         }
 


### PR DESCRIPTION
The ITranslator transforms characters for html such as / to $#x2f;.  While this is good for the email body portion, which is HTML encoded, it is not appropriate for the notification message or for the email subject line, which are not html.