### PR TITLE
Update ReassignUserTasksForProduct to account for product without workflow

### DIFF
--- a/source/OptimaJet.DWKit.StarterApplication/Services/Workflow/WorkflowProductService.cs
+++ b/source/OptimaJet.DWKit.StarterApplication/Services/Workflow/WorkflowProductService.cs
@@ -187,9 +187,14 @@ namespace OptimaJet.DWKit.StarterApplication.Services.Workflow
 
         public async Task<string> ReassignUserTasksForProduct(Product product)
         {
-            await ClearPreExecuteEntries(product.Id);
-
             var instance = await ProductWorkflowRepository.GetAsync(product.Id);
+            if (instance == null)
+            {
+                // No current running workflow for product.
+                return null;
+            }
+
+            await ClearPreExecuteEntries(product.Id);
 
             var comment = GetCurrentTaskComment(product);
 


### PR DESCRIPTION
The old model was that all products would always have a running workflow and rebuild and republish would be transitions in the same workflow.  The new model is that the primary workflow will run to get the app published the first time and then complete (and the workflow will stop).  Rebuild and Republish are separate smaller workflows.  

So when a project is reassigned to another user, the ReassignUserTasksForProduct has to account for the situation where there is currently no running workflow for the product and not do any work.