### PR TITLE
Add polling to the add/remove products button to account for race condition / timing issue

### DIFF
--- a/source/SIL.AppBuilder.Portal.Frontend/package.json
+++ b/source/SIL.AppBuilder.Portal.Frontend/package.json
@@ -67,6 +67,7 @@
     "react-state-helpers": "^1.6.6",
     "react-timezone": "^2.1.0",
     "react-toastify": "^4.5.2",
+    "react-useinterval": "^1.0.1",
     "recompose": "^0.30.0",
     "redux": "^4.0.0",
     "redux-actions": "^2.6.3",
@@ -81,8 +82,6 @@
     "uuid": "^3.3.2"
   },
   "devDependencies": {
-    "@developertown/react-generators-blueprint": "*",
-    "ember-cli": "^3.8.1",
     "@babel/core": "^7.2.2",
     "@babel/plugin-proposal-class-properties": "^7.3.0",
     "@babel/plugin-proposal-decorators": "^7.3.0",
@@ -96,6 +95,7 @@
     "@bigtest/mirage": "^0.0.1",
     "@bigtest/mocha": "^0.5.0",
     "@bigtest/react": "^0.1.1",
+    "@developertown/react-generators-blueprint": "*",
     "@pollyjs/adapter-fetch": "^2.0.0",
     "@pollyjs/adapter-xhr": "^2.0.0",
     "@pollyjs/cli": "^2.0.0",
@@ -146,6 +146,7 @@
     "crypto-js": "^3.1.9-1",
     "css-loader": "^2.0.0",
     "dotenv": "^6.0.0",
+    "ember-cli": "^3.8.1",
     "eslint": "^5.8.0",
     "eslint-config-prettier": "^3.1.0",
     "eslint-config-typescript": "^2.0.0",

--- a/source/SIL.AppBuilder.Portal.Frontend/src/lib/hooks.ts
+++ b/source/SIL.AppBuilder.Portal.Frontend/src/lib/hooks.ts
@@ -1,6 +1,7 @@
-import { useState, useContext, useMemo } from 'react';
+import { useState, useContext, useMemo, useCallback } from 'react';
 import { __RouterContext } from 'react-router';
 import { attributesFor } from 'react-orbitjs';
+import useInterval from 'react-useinterval';
 import moment from 'moment-timezone';
 
 import { useTranslations } from '~/lib/i18n';
@@ -16,7 +17,7 @@ export function useMemoIf<TReturn>(fn: () => TReturn, condition, memoOn) {
     if (condition) {
       return fn();
     }
-  }, memoOn);
+  }, [condition, fn]);
 }
 
 export function useToggle(defaultValue: boolean = false): [boolean, () => void] {
@@ -61,4 +62,23 @@ export function useTimezoneFormatters() {
       return moment(inTz(dateTime)).format(format);
     },
   };
+}
+
+export function useConditionalPoll(untilFn: () => Promise<boolean>, interval = 1000) {
+  const [isFinished, setFinished] = useState(false);
+
+  const callback = useCallback(async () => {
+    if (isFinished) {
+      return;
+    }
+
+    const result = await untilFn();
+
+    if (result) {
+      setFinished(true);
+    }
+  }, [isFinished, untilFn]);
+
+  useInterval(callback, interval);
+  return { isFinished };
 }

--- a/source/SIL.AppBuilder.Portal.Frontend/src/ui/components/inputs/group-select/with-data.tsx
+++ b/source/SIL.AppBuilder.Portal.Frontend/src/ui/components/inputs/group-select/with-data.tsx
@@ -60,7 +60,7 @@ export function useScopeGroupData({
   const isSelelectionDisabled =
     !isSuperAdmin &&
     (availableGroups.length === 1 || (availableGroups.length === 2 && groupIds.length === 1));
-  console.log(isSuperAdmin, availableGroups, groupIds);
+
   return {
     groups: availableGroups,
     disableSelection: isSelelectionDisabled,

--- a/source/SIL.AppBuilder.Portal.Frontend/src/ui/routes/projects/show/display.tsx
+++ b/source/SIL.AppBuilder.Portal.Frontend/src/ui/routes/projects/show/display.tsx
@@ -1,7 +1,7 @@
-import * as React from 'react';
+import React from 'react';
 import { match as Match } from 'react-router';
 import { Tab, Menu } from 'semantic-ui-react';
-import { idFromRecordIdentity, useOrbit } from 'react-orbitjs';
+import { idFromRecordIdentity, useOrbit, pushPayload, attributesFor } from 'react-orbitjs';
 
 import { ProjectResource } from '@data';
 
@@ -9,6 +9,7 @@ import { useCurrentUser } from '@data/containers/with-current-user';
 import { useDataActions } from '@data/containers/resources/project/with-data-actions';
 import { useTranslations } from '@lib/i18n';
 import * as toast from '@lib/toast';
+import { get as authenticatedGet } from '@lib/fetch';
 
 import Overview from './overview';
 import Header from './header';
@@ -38,7 +39,8 @@ export default function ProjectShowDisplay({ project }: IProps) {
   const { dataStore } = useOrbit();
   const { currentUser } = useCurrentUser();
   const { updateOwner, toggleArchiveProject } = useDataActions(project);
-  useLiveData(`projects/${idFromRecordIdentity(dataStore, project)}`);
+  const url = `projects/${idFromRecordIdentity(dataStore, project)}`;
+  useLiveData(url);
 
   const claimOwnership = async () => {
     try {

--- a/source/SIL.AppBuilder.Portal.Frontend/src/ui/routes/projects/show/display.tsx
+++ b/source/SIL.AppBuilder.Portal.Frontend/src/ui/routes/projects/show/display.tsx
@@ -9,7 +9,6 @@ import { useCurrentUser } from '@data/containers/with-current-user';
 import { useDataActions } from '@data/containers/resources/project/with-data-actions';
 import { useTranslations } from '@lib/i18n';
 import * as toast from '@lib/toast';
-import { get as authenticatedGet } from '@lib/fetch';
 
 import Overview from './overview';
 import Header from './header';

--- a/source/SIL.AppBuilder.Portal.Frontend/src/ui/routes/projects/show/overview/products/index.tsx
+++ b/source/SIL.AppBuilder.Portal.Frontend/src/ui/routes/projects/show/overview/products/index.tsx
@@ -12,6 +12,8 @@ import ProductItem from './item';
 import './styles.scss';
 import { useLiveData } from '~/data/live';
 
+import { useConditionalPoll } from '~/lib/hooks';
+
 interface IProps {
   project: ProjectResource;
   isEmptyWorkflowProjectUrl: boolean;
@@ -38,6 +40,12 @@ export default function Products({ project }: IProps) {
   useLiveData(`projects/${idFromRecordIdentity(dataStore, project)}`);
   useLiveData(`products`);
   useLiveData(`user-tasks`);
+
+  // useConditionalPoll(async () => {
+  //   const result = await dataStore.cache.query((q) => q.findRelatedRecords(project, 'products'));
+
+  //   return ( result || [] ).length > 0;
+  // }, 3000);
 
   let productList;
 

--- a/source/SIL.AppBuilder.Portal.Frontend/src/ui/routes/projects/show/overview/products/index.tsx
+++ b/source/SIL.AppBuilder.Portal.Frontend/src/ui/routes/projects/show/overview/products/index.tsx
@@ -12,8 +12,6 @@ import ProductItem from './item';
 import './styles.scss';
 import { useLiveData } from '~/data/live';
 
-import { useConditionalPoll } from '~/lib/hooks';
-
 interface IProps {
   project: ProjectResource;
   isEmptyWorkflowProjectUrl: boolean;
@@ -40,12 +38,6 @@ export default function Products({ project }: IProps) {
   useLiveData(`projects/${idFromRecordIdentity(dataStore, project)}`);
   useLiveData(`products`);
   useLiveData(`user-tasks`);
-
-  // useConditionalPoll(async () => {
-  //   const result = await dataStore.cache.query((q) => q.findRelatedRecords(project, 'products'));
-
-  //   return ( result || [] ).length > 0;
-  // }, 3000);
 
   let productList;
 

--- a/source/SIL.AppBuilder.Portal.Frontend/src/ui/routes/projects/show/overview/products/selection-manager/product-selection.tsx
+++ b/source/SIL.AppBuilder.Portal.Frontend/src/ui/routes/projects/show/overview/products/selection-manager/product-selection.tsx
@@ -31,7 +31,6 @@ export default function ProductSelector(props: IProps & i18nProps) {
   // this happens because the repository location URL
   // is added async, and not part of the request.
   const pollCallback = useCallback(async () => {
-    console.log('passed in', project);
     if (workflowProjectUrl) {
       return true;
     }

--- a/source/SIL.AppBuilder.Portal.Frontend/yarn.lock
+++ b/source/SIL.AppBuilder.Portal.Frontend/yarn.lock
@@ -9902,6 +9902,11 @@ react-transition-group@^2.2.1, react-transition-group@^2.4.0:
     prop-types "^15.6.2"
     react-lifecycles-compat "^3.0.4"
 
+react-useinterval@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/react-useinterval/-/react-useinterval-1.0.1.tgz#4bb90349d18b0fc04d6567edacf476d515b5cf49"
+  integrity sha512-+UxgKd7p7D3cBS6/o2uwBStsFcoKIagRdN21so/ud1k1e6r4WDCHsSjY36aT3n6WvVgpZPk3JtbN4IFfxt69Pg==
+
 react@^15.6.2, react@^16.8.0:
   version "16.8.3"
   resolved "https://registry.yarnpkg.com/react/-/react-16.8.3.tgz#c6f988a2ce895375de216edcfaedd6b9a76451d9"


### PR DESCRIPTION
add polling to add or remove products button for the case that the backend finishes its work after the initial POST to create the project, but before the UI has loaded the next route that subscribes to updates to the project. Maybe as a general behavior design note: maybe all the subscriptions need to live on the same context, and useLiveData just adds/removes subscriptions from that context.