### PR TITLE
Add Active Projects

### DIFF
--- a/source/OptimaJet.DWKit.StarterApplication/Migrations/20190813145314_AddProjectActive.Designer.cs
+++ b/source/OptimaJet.DWKit.StarterApplication/Migrations/20190813145314_AddProjectActive.Designer.cs
@@ -2,6 +2,7 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using OptimaJet.DWKit.StarterApplication.Data;
@@ -10,9 +11,10 @@ using OptimaJet.DWKit.StarterApplication.Models;
 namespace OptimaJet.DWKit.StarterApplication.Migrations
 {
     [DbContext(typeof(AppDbContext))]
-    partial class AppDbContextModelSnapshot : ModelSnapshot
+    [Migration("20190813145314_AddProjectActive")]
+    partial class AddProjectActive
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/source/OptimaJet.DWKit.StarterApplication/Migrations/20190813145314_AddProjectActive.cs
+++ b/source/OptimaJet.DWKit.StarterApplication/Migrations/20190813145314_AddProjectActive.cs
@@ -1,0 +1,23 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+namespace OptimaJet.DWKit.StarterApplication.Migrations
+{
+    public partial class AddProjectActive : Migration
+    {
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<DateTime>(
+                name: "DateActive",
+                table: "Projects",
+                nullable: true);
+        }
+
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "DateActive",
+                table: "Projects");
+        }
+    }
+}

--- a/source/OptimaJet.DWKit.StarterApplication/Models/Project.cs
+++ b/source/OptimaJet.DWKit.StarterApplication/Models/Project.cs
@@ -63,14 +63,14 @@ namespace OptimaJet.DWKit.StarterApplication.Models
 
         [HasMany("products", Link.None)]
         public virtual List<Product> Products { get; set; }
-    
+
         [Attr("workflow-project-url")]
         public String WorkflowProjectUrl { get; set; }
 
         [Attr("workflow-app-project-url")]
         public String WorkflowAppProjectUrl { get; set; }
 
-        [NotMapped]
-        public bool? Active => Products?.Any(p => p.ProductWorkflow != null);
+        [Attr("date-active")]
+        public DateTime? DateActive { get; set; }
     }
 }

--- a/source/OptimaJet.DWKit.StarterApplication/Models/Project.cs
+++ b/source/OptimaJet.DWKit.StarterApplication/Models/Project.cs
@@ -1,6 +1,8 @@
 ﻿using System;
+using System.Linq;
 using System.Collections.Generic;
 using JsonApiDotNetCore.Models;
+using System.ComponentModel.DataAnnotations.Schema;
 
 namespace OptimaJet.DWKit.StarterApplication.Models
 {
@@ -67,5 +69,8 @@ namespace OptimaJet.DWKit.StarterApplication.Models
 
         [Attr("workflow-app-project-url")]
         public String WorkflowAppProjectUrl { get; set; }
+
+        [NotMapped]
+        public bool? Active => Products?.Any(p => p.ProductWorkflow != null);
     }
 }

--- a/source/OptimaJet.DWKit.StarterApplication/Services/ProductService.cs
+++ b/source/OptimaJet.DWKit.StarterApplication/Services/ProductService.cs
@@ -405,5 +405,41 @@ namespace OptimaJet.DWKit.StarterApplication.Services
 
             return artifact;
         }
+
+        public async Task UpdateProjectActive(int projectId)
+        {
+            var products = await ProductRepository.Get()
+                .Where(p => p.ProjectId == projectId)
+                .Include(p => p.ProductWorkflow)
+                .ToListAsync();
+
+            var project = await ProjectRepository.GetAsync(projectId);
+            var projectDateActive = project.DateActive;
+
+            var dateActive = DateTime.MinValue;
+            foreach (var product in products)
+            {
+                if (product.ProductWorkflow != null)
+                {
+                    if (product.DateUpdated.Value > dateActive)
+                    {
+                        dateActive = product.DateUpdated.Value;
+                    }
+                }
+            }
+
+            if (dateActive > DateTime.MinValue)
+            {
+                project.DateActive = dateActive;
+            } else
+            {
+                project.DateActive = null;
+            }
+
+            if (project.DateActive != projectDateActive)
+            {
+                await ProjectRepository.UpdateAsync(projectId, project);
+            }
+        }
     }
 }

--- a/source/SIL.AppBuilder.Portal.Frontend/src/data/models/project.ts
+++ b/source/SIL.AppBuilder.Portal.Frontend/src/data/models/project.ts
@@ -18,6 +18,7 @@ export interface ProjectAttributes extends AttributesObject {
   lastUpdatedAt?: string;
   isPublic: boolean;
   workflowProjectUrl?: string;
+  active?: boolean;
 }
 
 export type ProjectResource = ResourceObject<PROJECTS_TYPE, ProjectAttributes> & Record;

--- a/source/SIL.AppBuilder.Portal.Frontend/src/data/models/project.ts
+++ b/source/SIL.AppBuilder.Portal.Frontend/src/data/models/project.ts
@@ -18,7 +18,7 @@ export interface ProjectAttributes extends AttributesObject {
   lastUpdatedAt?: string;
   isPublic: boolean;
   workflowProjectUrl?: string;
-  active?: boolean;
+  dateActive?: string;
 }
 
 export type ProjectResource = ResourceObject<PROJECTS_TYPE, ProjectAttributes> & Record;

--- a/source/SIL.AppBuilder.Portal.Frontend/src/data/schema.ts
+++ b/source/SIL.AppBuilder.Portal.Frontend/src/data/schema.ts
@@ -125,7 +125,7 @@ const schemaDefinition: SchemaSettings = {
         location: { type: 'string' },
         isPublic: { type: 'boolean' },
         workflowProjectUrl: { type: 'string' },
-        dateActive: {type: 'date'},
+        dateActive: { type: 'date' },
         // filter keys
         ownerId: { type: 'string' },
       },

--- a/source/SIL.AppBuilder.Portal.Frontend/src/data/schema.ts
+++ b/source/SIL.AppBuilder.Portal.Frontend/src/data/schema.ts
@@ -125,6 +125,7 @@ const schemaDefinition: SchemaSettings = {
         location: { type: 'string' },
         isPublic: { type: 'boolean' },
         workflowProjectUrl: { type: 'string' },
+        active: {type: 'boolean'},
         // filter keys
         ownerId: { type: 'string' },
       },

--- a/source/SIL.AppBuilder.Portal.Frontend/src/data/schema.ts
+++ b/source/SIL.AppBuilder.Portal.Frontend/src/data/schema.ts
@@ -125,7 +125,7 @@ const schemaDefinition: SchemaSettings = {
         location: { type: 'string' },
         isPublic: { type: 'boolean' },
         workflowProjectUrl: { type: 'string' },
-        active: {type: 'boolean'},
+        dateActive: {type: 'date'},
         // filter keys
         ownerId: { type: 'string' },
       },

--- a/source/SIL.AppBuilder.Portal.Frontend/src/translations/locales/en-us.json
+++ b/source/SIL.AppBuilder.Portal.Frontend/src/translations/locales/en-us.json
@@ -75,6 +75,7 @@
   "sidebar": {
     "myTasks": "My Tasks {count, plural, =0 {} other {({ count })}}",
     "myProjects": "My Projects",
+    "activeProjects": "Active Projects",
     "organizationProjects": "Organization Projects",
     "users": "Users",
     "organizationSettings": "Organization Settings",
@@ -215,6 +216,7 @@
       "dropdown": {
         "orgProjects": "Organization Projects",
         "myProjects": "My Projects",
+	"activeProjects": "Active Projects",
         "archived": "Archived Projects",
         "all": "All Projects"
       }

--- a/source/SIL.AppBuilder.Portal.Frontend/src/translations/locales/en-us.json
+++ b/source/SIL.AppBuilder.Portal.Frontend/src/translations/locales/en-us.json
@@ -378,7 +378,8 @@
       "buildVersion": "Build Version",
       "buildDate": "Build Date",
       "createdOn": "Created On",
-      "updatedOn": "Updated On"
+      "updatedOn": "Updated On",
+      "activeSince": "Active Since"
     },
     "empty": "No projects found",
     "products": "Products",

--- a/source/SIL.AppBuilder.Portal.Frontend/src/ui/components/project-table/__tests__/page.ts
+++ b/source/SIL.AppBuilder.Portal.Frontend/src/ui/components/project-table/__tests__/page.ts
@@ -42,6 +42,7 @@ class ProjectTable {
     text: text(),
   });
 
+  sortColumn = text('[data-test-project-table-sort-column');
   isSortingUp = isPresent('[data-test-up-arrow]');
   isSortingDown = isPresent('[data-test-down-arrow]');
 

--- a/source/SIL.AppBuilder.Portal.Frontend/src/ui/components/project-table/table/column-data.ts
+++ b/source/SIL.AppBuilder.Portal.Frontend/src/ui/components/project-table/table/column-data.ts
@@ -5,6 +5,7 @@ export enum COLUMN_KEY {
   PROJECT_LANGUAGE = 'language',
   PROJECT_GROUP = 'group',
   PROJECT_DATE_UPDATED = 'dateUpdated',
+  PROJECT_DATE_ACTIVE = 'dateActive',
 
   PRODUCT_BUILD_VERSION = 'buildVersion',
   PRODUCT_BUILD_DATE = 'buildDate',
@@ -40,6 +41,12 @@ export const possibleColumnsByType = {
       id: COLUMN_KEY.PROJECT_DATE_UPDATED,
       i18nKey: 'projectTable.columns.updatedOn',
       propertyPath: 'dateUpdated',
+      sortable: true,
+    },
+    [COLUMN_KEY.PROJECT_DATE_ACTIVE]: {
+      id: COLUMN_KEY.PROJECT_DATE_ACTIVE,
+      i18nKey: 'projectTable.columns.activeSince',
+      propertyPath: 'dateActive',
       sortable: true,
     },
   },

--- a/source/SIL.AppBuilder.Portal.Frontend/src/ui/components/project-table/table/header/index.tsx
+++ b/source/SIL.AppBuilder.Portal.Frontend/src/ui/components/project-table/table/header/index.tsx
@@ -54,7 +54,11 @@ class Header extends React.Component<IProps> {
     return (
       <Tag data-test-project-table-column {...columnProps}>
         {isSorting && (isAscending ? <UpArrow /> : <DownArrow />)}
-        {t(column.i18nKey)}
+        {isSorting ? (
+          <span data-test-project-table-sort-column>{t(column.i18nKey)}</span>
+        ) : (
+          t(column.i18nKey)
+        )}
       </Tag>
     );
   };

--- a/source/SIL.AppBuilder.Portal.Frontend/src/ui/components/project-table/table/row/index.tsx
+++ b/source/SIL.AppBuilder.Portal.Frontend/src/ui/components/project-table/table/row/index.tsx
@@ -49,7 +49,7 @@ class Row extends React.Component<IProps> {
       timezone,
     } = this.props;
 
-    const { language, dateUpdated } = attributesFor(project);
+    const { language, dateUpdated, dateActive } = attributesFor(project);
     const { name: orgName } = attributesFor(organization);
     const { givenName, familyName } = attributesFor(owner);
     const { name: groupName } = attributesFor(group);
@@ -72,6 +72,11 @@ class Row extends React.Component<IProps> {
           break;
         case COLUMN_KEY.PROJECT_DATE_UPDATED:
           column.value = moment(dateUpdated)
+            .tz(timezone)
+            .format('LLL');
+          break;
+        case COLUMN_KEY.PROJECT_DATE_ACTIVE:
+          column.value = moment(dateActive)
             .tz(timezone)
             .format('LLL');
           break;

--- a/source/SIL.AppBuilder.Portal.Frontend/src/ui/components/project-table/table/row/index.tsx
+++ b/source/SIL.AppBuilder.Portal.Frontend/src/ui/components/project-table/table/row/index.tsx
@@ -76,9 +76,13 @@ class Row extends React.Component<IProps> {
             .format('LLL');
           break;
         case COLUMN_KEY.PROJECT_DATE_ACTIVE:
-          column.value = moment(dateActive)
-            .tz(timezone)
-            .format('LLL');
+          if (dateActive) {
+            column.value = moment(dateActive)
+              .tz(timezone)
+              .format('LLL');
+          } else {
+            column.value = '-';
+          }
           break;
         default:
           column.value = 'active column not recognized';

--- a/source/SIL.AppBuilder.Portal.Frontend/src/ui/components/sidebar/navigation.tsx
+++ b/source/SIL.AppBuilder.Portal.Frontend/src/ui/components/sidebar/navigation.tsx
@@ -58,6 +58,13 @@ export default function Navigation({ closeSidebar }: IProps) {
         onClick={closeSidebar}
       />
 
+      <MenuItem
+        content={"Active Projects"}
+        to='/projects/active'
+        exact
+        onClick={closeSidebar}
+      />
+
       <RequireRole roleName={ROLE.OrganizationAdmin}>
         <MenuItem content={t('sidebar.users')} to='/users' onClick={closeSidebar} />
       </RequireRole>

--- a/source/SIL.AppBuilder.Portal.Frontend/src/ui/components/sidebar/navigation.tsx
+++ b/source/SIL.AppBuilder.Portal.Frontend/src/ui/components/sidebar/navigation.tsx
@@ -59,7 +59,7 @@ export default function Navigation({ closeSidebar }: IProps) {
       />
 
       <MenuItem
-        content={"Active Projects"}
+        content={t('sidebar.activeProjects')}
         to='/projects/active'
         exact
         onClick={closeSidebar}

--- a/source/SIL.AppBuilder.Portal.Frontend/src/ui/components/sidebar/navigation.tsx
+++ b/source/SIL.AppBuilder.Portal.Frontend/src/ui/components/sidebar/navigation.tsx
@@ -58,12 +58,14 @@ export default function Navigation({ closeSidebar }: IProps) {
         onClick={closeSidebar}
       />
 
-      <MenuItem
-        content={t('sidebar.activeProjects')}
-        to='/projects/active'
-        exact
-        onClick={closeSidebar}
-      />
+      <RequireRole roleName={ROLE.OrganizationAdmin}>
+        <MenuItem
+          content={t('sidebar.activeProjects')}
+          to='/projects/active'
+          exact
+          onClick={closeSidebar}
+        />
+      </RequireRole>
 
       <RequireRole roleName={ROLE.OrganizationAdmin}>
         <MenuItem content={t('sidebar.users')} to='/users' onClick={closeSidebar} />

--- a/source/SIL.AppBuilder.Portal.Frontend/src/ui/routes/projects/index.tsx
+++ b/source/SIL.AppBuilder.Portal.Frontend/src/ui/routes/projects/index.tsx
@@ -7,7 +7,7 @@ import { NotFound } from '@ui/routes/errors';
 
 import AllProjectsRoute, { pathName as allProjectPath } from './list/all';
 import MyProjectsRoute, { pathName as myProjectPath } from './list/my-projects';
-import ActiveProjectsRoute, {pathName as activeProjectPath } from './list/active-projects';
+import ActiveProjectsRoute, { pathName as activeProjectPath } from './list/active-projects';
 import OrganizationProjectsRoute, {
   pathName as organizationProjectPath,
 } from './list/organization-projects';

--- a/source/SIL.AppBuilder.Portal.Frontend/src/ui/routes/projects/index.tsx
+++ b/source/SIL.AppBuilder.Portal.Frontend/src/ui/routes/projects/index.tsx
@@ -7,6 +7,7 @@ import { NotFound } from '@ui/routes/errors';
 
 import AllProjectsRoute, { pathName as allProjectPath } from './list/all';
 import MyProjectsRoute, { pathName as myProjectPath } from './list/my-projects';
+import ActiveProjectsRoute, {pathName as activeProjectPath } from './list/active-projects';
 import OrganizationProjectsRoute, {
   pathName as organizationProjectPath,
 } from './list/organization-projects';
@@ -23,6 +24,7 @@ export default function ProjectsRoot() {
         <Route exact path={archivedProjectPath} component={ArchivedProjectsRoute} />
         <Route exact path={newProjectPath} component={NewProjectRoute} />
         <Route exact path={allProjectPath} component={AllProjectsRoute} />
+        <Route exact path={activeProjectPath} component={ActiveProjectsRoute} />
 
         <Route path={projectDetailPath} component={ProjectDetailRoute} />
 

--- a/source/SIL.AppBuilder.Portal.Frontend/src/ui/routes/projects/list/__tests__/-factory.ts
+++ b/source/SIL.AppBuilder.Portal.Frontend/src/ui/routes/projects/list/__tests__/-factory.ts
@@ -4,6 +4,7 @@ export const project = {
   attributes: {
     name: 'Dummy project',
     'date-archived': null,
+    'date-active': '2018-10-30T16:19:09.878193',
     language: 'English',
     'owner-id': 1,
   },

--- a/source/SIL.AppBuilder.Portal.Frontend/src/ui/routes/projects/list/__tests__/active-project-list-test.tsx
+++ b/source/SIL.AppBuilder.Portal.Frontend/src/ui/routes/projects/list/__tests__/active-project-list-test.tsx
@@ -1,0 +1,62 @@
+import { when } from '@bigtest/convergence';
+import { describe, it, beforeEach } from '@bigtest/mocha';
+import { visit, location } from '@bigtest/react';
+import { expect } from 'chai';
+import {
+  setupApplicationTest,
+  setupRequestInterceptor,
+  useFakeAuthentication,
+} from 'tests/helpers/index';
+
+import PageInteractor from './-page-interactor';
+import * as ProjectsFactory from './-factory';
+
+describe('Acceptance | Project Table | Active list', () => {
+  let pageInteractor;
+  useFakeAuthentication();
+  setupApplicationTest();
+
+  describe('Render active projects list page', () => {
+    beforeEach(function() {
+      this.mockGet(200, 'product-definitions', { data: [] });
+      this.mockGet(200, 'projects', { ...ProjectsFactory.projectsResponse });
+    });
+
+    describe('navigates to active projects page', () => {
+      beforeEach(async function() {
+        pageInteractor = new PageInteractor();
+        await visit('/projects/active');
+        await when(() => pageInteractor.isPresent);
+      });
+
+      it('is in active projects page', () => {
+        expect(location().pathname).to.equal('/projects/active');
+      });
+
+      it('empty text is not displayed when project list exist', () => {
+        expect(pageInteractor.projectTable.isEmptyTextPresent).to.be.false;
+      });
+
+      it('is sorted down by date-active', () => {
+        expect(pageInteractor.projectTable.isSortingDown).to.be.true;
+        expect(pageInteractor.projectTable.sortColumn).to.contain('Active Since');
+      });
+
+      it('default options are selected', () => {
+        const items = pageInteractor.projectTable.selectedItems();
+        const itemsText = items.map((i) => i.text);
+
+        expect(itemsText).to.contain('Owner');
+        expect(itemsText).to.contain('Group');
+        expect(itemsText).to.contain('Build Version');
+        expect(itemsText).to.contain('Build Date');
+        expect(itemsText).to.contain('Active Since');
+
+        expect(itemsText).to.not.contain('Updated On');
+        expect(itemsText).to.not.contain('Organization');
+        expect(itemsText).to.not.contain('Language');
+        expect(itemsText).to.not.contain('Created On');
+      });
+    });
+  });
+});

--- a/source/SIL.AppBuilder.Portal.Frontend/src/ui/routes/projects/list/__tests__/custom-table-acceptance-test.tsx
+++ b/source/SIL.AppBuilder.Portal.Frontend/src/ui/routes/projects/list/__tests__/custom-table-acceptance-test.tsx
@@ -50,6 +50,7 @@ describe('Acceptance | My Projects | Column selector', () => {
         expect(itemsText).to.not.contain('Language');
         expect(itemsText).to.not.contain('Build Date');
         expect(itemsText).to.not.contain('Created On');
+        expect(itemsText).to.not.contain('Active Since');
       });
 
       it('product fields are set', () => {

--- a/source/SIL.AppBuilder.Portal.Frontend/src/ui/routes/projects/list/active-projects.tsx
+++ b/source/SIL.AppBuilder.Portal.Frontend/src/ui/routes/projects/list/active-projects.tsx
@@ -18,7 +18,7 @@ export const pathName = '/projects/active';
 export default compose(
   withCurrentUserContext,
   withCurrentOrganization,
-  withSorting({ defaultSort: 'date-active' }),
+  withSorting({ defaultSort: '-date-active' }),
   withPagination(),
   withFiltering({
     requiredFilters: [{ attribute: 'date-active', value: 'isnotnull:' }],
@@ -35,7 +35,7 @@ export default compose(
       COLUMN_KEY.PROJECT_OWNER,
       COLUMN_KEY.PROJECT_GROUP,
       COLUMN_KEY.PRODUCT_BUILD_VERSION,
-      COLUMN_KEY.PRODUCT_UPDATED_ON,
+      COLUMN_KEY.PRODUCT_BUILD_DATE,
     ],
   }),
   withTableRows({

--- a/source/SIL.AppBuilder.Portal.Frontend/src/ui/routes/projects/list/active-projects.tsx
+++ b/source/SIL.AppBuilder.Portal.Frontend/src/ui/routes/projects/list/active-projects.tsx
@@ -18,19 +18,19 @@ export const pathName = '/projects/active';
 export default compose(
   withCurrentUserContext,
   withCurrentOrganization,
-  withSorting({ defaultSort: 'name' }),
+  withSorting({ defaultSort: 'date-active' }),
   withPagination(),
   withFiltering({
-    requiredFilters: [{ attribute: 'active', value: 'isnotnull:' }],
+    requiredFilters: [{ attribute: 'date-active', value: 'isnotnull:' }],
   }),
   withNetwork(),
   withLoader(({ error, projects }) => !error && !projects),
   withProps(({ projects }) => ({
-    tableName: 'organization',
+    tableName: 'active-projects',
     rowCount: projects ? projects.length : 0,
   })),
   withTableColumns({
-    tableName: 'organization',
+    tableName: 'active-projects',
     defaultColumns: [
       COLUMN_KEY.PROJECT_OWNER,
       COLUMN_KEY.PROJECT_GROUP,
@@ -39,6 +39,6 @@ export default compose(
     ],
   }),
   withTableRows({
-    tableName: 'organization',
+    tableName: 'active-projects',
   })
 )(Display);

--- a/source/SIL.AppBuilder.Portal.Frontend/src/ui/routes/projects/list/active-projects.tsx
+++ b/source/SIL.AppBuilder.Portal.Frontend/src/ui/routes/projects/list/active-projects.tsx
@@ -18,7 +18,7 @@ export const pathName = '/projects/active';
 export default compose(
   withCurrentUserContext,
   withCurrentOrganization,
-  withSorting({ defaultSort: '-date-active' }),
+  withSorting({ defaultSort: '-dateActive' }), // need dateActive (not date-active) for direction arrow
   withPagination(),
   withFiltering({
     requiredFilters: [{ attribute: 'date-active', value: 'isnotnull:' }],
@@ -36,6 +36,7 @@ export default compose(
       COLUMN_KEY.PROJECT_GROUP,
       COLUMN_KEY.PRODUCT_BUILD_VERSION,
       COLUMN_KEY.PRODUCT_BUILD_DATE,
+      COLUMN_KEY.PROJECT_DATE_ACTIVE,
     ],
   }),
   withTableRows({

--- a/source/SIL.AppBuilder.Portal.Frontend/src/ui/routes/projects/list/active-projects.tsx
+++ b/source/SIL.AppBuilder.Portal.Frontend/src/ui/routes/projects/list/active-projects.tsx
@@ -1,0 +1,44 @@
+import { compose, withProps } from 'recompose';
+import { withSorting } from '@data/containers/api/sorting';
+import { withPagination } from '@data/containers/api/pagination';
+import { withFiltering } from '@data/containers/api/with-filtering';
+import { withLoader } from '@data/containers/with-loader';
+import { withNetwork } from '@data/containers/resources/project/list';
+
+import { withCurrentUserContext } from '~/data/containers/with-current-user';
+
+import { withCurrentOrganization } from '@data/containers/with-current-organization';
+import { withTableColumns, withTableRows, COLUMN_KEY } from '@ui/components/project-table';
+import { TYPE_NAME as PROJECT } from '@data/models/project';
+
+import Display from './display';
+
+export const pathName = '/projects/active';
+
+export default compose(
+  withCurrentUserContext,
+  withCurrentOrganization,
+  withSorting({ defaultSort: 'name' }),
+  withPagination(),
+  withFiltering({
+    requiredFilters: [{ attribute: 'active', value: 'isnotnull:' }],
+  }),
+  withNetwork(),
+  withLoader(({ error, projects }) => !error && !projects),
+  withProps(({ projects }) => ({
+    tableName: 'organization',
+    rowCount: projects ? projects.length : 0,
+  })),
+  withTableColumns({
+    tableName: 'organization',
+    defaultColumns: [
+      COLUMN_KEY.PROJECT_OWNER,
+      COLUMN_KEY.PROJECT_GROUP,
+      COLUMN_KEY.PRODUCT_BUILD_VERSION,
+      COLUMN_KEY.PRODUCT_UPDATED_ON,
+    ],
+  }),
+  withTableRows({
+    tableName: 'organization',
+  })
+)(Display);

--- a/source/SIL.AppBuilder.Portal.Frontend/src/ui/routes/projects/list/header/dropdown.tsx
+++ b/source/SIL.AppBuilder.Portal.Frontend/src/ui/routes/projects/list/header/dropdown.tsx
@@ -13,7 +13,7 @@ export function ProjectFilterDropdown({ filter }) {
   const dropdownText = {
     'all-projects': t('projects.switcher.dropdown.all'),
     'my-projects': t('projects.switcher.dropdown.myProjects'),
-    'active-projects' : t('projects.switcher.dropdown.activeProjects'),
+    'active-projects': t('projects.switcher.dropdown.activeProjects'),
     organization: t('projects.switcher.dropdown.orgProjects'),
     archived: t('projects.switcher.dropdown.archived'),
   };

--- a/source/SIL.AppBuilder.Portal.Frontend/src/ui/routes/projects/list/header/dropdown.tsx
+++ b/source/SIL.AppBuilder.Portal.Frontend/src/ui/routes/projects/list/header/dropdown.tsx
@@ -13,6 +13,7 @@ export function ProjectFilterDropdown({ filter }) {
   const dropdownText = {
     'all-projects': t('projects.switcher.dropdown.all'),
     'my-projects': t('projects.switcher.dropdown.myProjects'),
+    'active-projects' : t('projects.switcher.dropdown.activeProjects'),
     organization: t('projects.switcher.dropdown.orgProjects'),
     archived: t('projects.switcher.dropdown.archived'),
   };
@@ -38,6 +39,13 @@ export function ProjectFilterDropdown({ filter }) {
           as={NavLink}
           to={PROJECT_ROUTES.OWN}
         />
+        <Dropdown.Item
+          text={t('projects.switcher.dropdown.activeProjects')}
+          className='m-l-md'
+          as={NavLink}
+          to={PROJECT_ROUTES.ACTIVE}
+        />
+
         <Dropdown.Item
           text={t('projects.switcher.dropdown.orgProjects')}
           className='m-l-md'

--- a/source/SIL.AppBuilder.Portal.Frontend/src/ui/routes/projects/list/header/dropdown.tsx
+++ b/source/SIL.AppBuilder.Portal.Frontend/src/ui/routes/projects/list/header/dropdown.tsx
@@ -2,6 +2,8 @@ import React from 'react';
 import CaretDown from '@material-ui/icons/KeyboardArrowDown';
 import { Dropdown } from 'semantic-ui-react';
 import { NavLink } from 'react-router-dom';
+import { ROLE } from '@data/models/role';
+import { RequireRole } from '@ui/components/authorization';
 
 import { useTranslations } from '~/lib/i18n';
 
@@ -40,18 +42,19 @@ export function ProjectFilterDropdown({ filter }) {
           to={PROJECT_ROUTES.OWN}
         />
         <Dropdown.Item
-          text={t('projects.switcher.dropdown.activeProjects')}
-          className='m-l-md'
-          as={NavLink}
-          to={PROJECT_ROUTES.ACTIVE}
-        />
-
-        <Dropdown.Item
           text={t('projects.switcher.dropdown.orgProjects')}
           className='m-l-md'
           as={NavLink}
           to={PROJECT_ROUTES.ORGANIZATION}
         />
+        <RequireRole roleName={ROLE.OrganizationAdmin}>
+          <Dropdown.Item
+            text={t('projects.switcher.dropdown.activeProjects')}
+            className='m-l-md'
+            as={NavLink}
+            to={PROJECT_ROUTES.ACTIVE}
+          />
+        </RequireRole>
         <Dropdown.Item
           text={t('projects.switcher.dropdown.archived')}
           className='m-l-lg'

--- a/source/SIL.AppBuilder.Portal.Frontend/src/ui/routes/projects/list/header/routes.ts
+++ b/source/SIL.AppBuilder.Portal.Frontend/src/ui/routes/projects/list/header/routes.ts
@@ -3,4 +3,5 @@ export enum PROJECT_ROUTES {
   ORGANIZATION = '/projects/organization',
   ARCHIVED = '/projects/archived',
   ALL = '/projects/all',
+  ACTIVE = '/projects/active',
 }


### PR DESCRIPTION
Add `Active Projects` to side navbar and projects drowndown.  Only display for Org Admin (and Super Admin). The list of projects is sorted by Project.DateActive. 

Project.DateActive is updated when a product workflow is started or removed.