### PR TITLE
Fix Workflow Admin Url being available

### DIFF
--- a/source/SIL.AppBuilder.Portal.Frontend/src/data/containers/resources/user-task/index.ts
+++ b/source/SIL.AppBuilder.Portal.Frontend/src/data/containers/resources/user-task/index.ts
@@ -28,18 +28,8 @@ export function useUserTaskHelpers() {
     return `/flow/${workflowBusinessFlow}/${id}`;
   };
 
-  const pathToWorkflowAdmin = (task: TaskResource) => {
-    if (!task) return null;
-
-    const [product] = relationsFromPath(dataStore, task, ['product']);
-    const id = idFromRecordIdentity(dataStore, product);
-
-    return `${env.dwkit.adminUrl}/Account/Login/?ReturnUrl=/admin%3Fapanel%3Dworkflowinstances%26aid%3D${id}`;
-  };
-
   return {
     pathToWorkflow,
-    pathToWorkflowAdmin,
     navigateToTaskWorkflow(task: TaskResource) {
       const path = pathToWorkflow(task);
 

--- a/source/SIL.AppBuilder.Portal.Frontend/src/ui/routes/projects/show/overview/products/item/tasks/index.tsx
+++ b/source/SIL.AppBuilder.Portal.Frontend/src/ui/routes/projects/show/overview/products/item/tasks/index.tsx
@@ -32,10 +32,11 @@ export default function ProductTasksForCurrentUser({ product }: IProps) {
   const { dataStore } = useOrbit();
   const productRemoteId = idFromRecordIdentity(product as any);
   const { relativeTimeAgo } = useTimezoneFormatters();
-  const { pathToWorkflow, pathToWorkflowAdmin } = useUserTaskHelpers();
+  const { pathToWorkflow } = useUserTaskHelpers();
   const [transition, setTransition] = useState(null);
   const { foundCurrentUser, workTask } = useCurrentUserTask({ product });
   const { isSuperAdmin } = useCurrentUser();
+  const workflowAdminUrl = `${env.dwkit.adminUrl}/Account/Login/?ReturnUrl=/admin%3Fapanel%3Dworkflowinstances%26aid%3D${productRemoteId}`;
   const getTransition = useCallback(async () => {
     let transition = null;
     let response = await authenticatedGet(`/api/products/${productRemoteId}/transitions/active`, {
@@ -108,11 +109,7 @@ export default function ProductTasksForCurrentUser({ product }: IProps) {
                     </Link>
                   )}
                   {isSuperAdmin && (
-                    <a
-                      className='m-l-md bold uppercase'
-                      target='_blank'
-                      href={pathToWorkflowAdmin(workTask)}
-                    >
+                    <a className='m-l-md bold uppercase' target='_blank' href={workflowAdminUrl}>
                       {t('common.workflow')}
                     </a>
                   )}


### PR DESCRIPTION
* The Workflow Admin Url was null when the task was not currently
  assigned to the user.  This simplifies how the Url is obtained.