### PR TITLE
Right Size Task Wait Control

### DIFF
--- a/source/SIL.AppBuilder.Portal.Frontend/src/data/async-waiter.tsx
+++ b/source/SIL.AppBuilder.Portal.Frontend/src/data/async-waiter.tsx
@@ -7,10 +7,12 @@ export function AsyncWaiter<Fn extends Function>({
   children,
   fn,
   loadingProps = {},
+  sizeClass,
 }: {
   children?: any;
   fn: Fn;
   loadingProps?: any;
+  sizeClass?: string;
 }) {
   if (!fn) {
     throw new Error(`Function passed to AsyncWaiter must not be falsey`);
@@ -26,7 +28,7 @@ export function AsyncWaiter<Fn extends Function>({
   if (loading) {
     return (
       <div {...loadingProps}>
-        <PageLoader />
+        <PageLoader sizeClass={sizeClass} />
       </div>
     );
   }

--- a/source/SIL.AppBuilder.Portal.Frontend/src/ui/components/loaders/page.tsx
+++ b/source/SIL.AppBuilder.Portal.Frontend/src/ui/components/loaders/page.tsx
@@ -4,15 +4,16 @@ import RectLoader from './rect-loader';
 
 interface IProps {
   loaderProps?: any;
+  sizeClass?: string;
 }
 
 export default class PageLoader extends React.PureComponent<IProps> {
   render() {
     const loaderProps = this.props.loaderProps || {};
-
+    const sizeClass = this.props.sizeClass || 'm-t-xxl m-b-xxl';
     return (
       <div className='flex-row flex-grow justify-content-center align-items-center'>
-        <RectLoader className='m-t-xxl m-b-xxl' {...loaderProps} />
+        <RectLoader className={sizeClass} {...loaderProps} />
       </div>
     );
   }

--- a/source/SIL.AppBuilder.Portal.Frontend/src/ui/routes/projects/show/overview/products/item/tasks/index.tsx
+++ b/source/SIL.AppBuilder.Portal.Frontend/src/ui/routes/projects/show/overview/products/item/tasks/index.tsx
@@ -85,7 +85,7 @@ export default function ProductTasksForCurrentUser({ product }: IProps) {
 
   return (
     <div className='w-100 p-sm p-b-md m-l-md fs-13'>
-      <AsyncWaiter fn={getTransition}>
+      <AsyncWaiter fn={getTransition} sizeClass='m-t-sm m-b-sm'>
         {({ value }) => {
           setTransition(value);
           let waitTime = '';


### PR DESCRIPTION

![Screen Shot 2019-09-20 at 1 46 42 PM](https://user-images.githubusercontent.com/6209188/65347510-2bab9100-dbad-11e9-86f6-0cc359f687b5.png)
The wait box that appears while the app tries to retrieve the
current task info is very large and then shrinks to one line
once the task is found.  This fix adjusts the size of the box
while it is finding the task info to something close to the final
size.