### PR TITLE
Support environment in Workflow/ProductDefinition Properties

### DIFF
--- a/scripts/DB/default_workflow.sql
+++ b/scripts/DB/default_workflow.sql
@@ -87,6 +87,7 @@ INSERT INTO "WorkflowScheme" ("Code", "Scheme") VALUES
   <Parameters>
     <Parameter Name="Comment" Type="String" Purpose="Temporary" />
     <Parameter Name="ShouldExecute" Type="String" Purpose="Persistence" />
+    <Parameter Name="environment" Type="String" Purpose="Persistence" />
   </Parameters>
   <Commands>
     <Command Name="Approve" />
@@ -703,6 +704,7 @@ INSERT INTO "WorkflowScheme" ("Code", "Scheme") VALUES
   <Parameters>
     <Parameter Name="Comment" Type="String" Purpose="Temporary" />
     <Parameter Name="ShouldExecute" Type="String" Purpose="Persistence" InitialValue="{&quot;Synchronize Data&quot;:false}" />
+    <Parameter Name="environment" Type="String" Purpose="Persistence" />
   </Parameters>
   <Commands>
     <Command Name="Approve" />
@@ -967,6 +969,7 @@ INSERT INTO "WorkflowScheme" ("Code", "Scheme") VALUES
   <Parameters>
     <Parameter Name="Comment" Type="String" Purpose="Temporary" />
     <Parameter Name="ShouldExecute" Type="String" Purpose="Persistence" InitialValue="{ &quot;Synchronize Data&quot; : false }" />
+    <Parameter Name="environment" Type="String" Purpose="Persistence" />
   </Parameters>
   <Commands>
     <Command Name="Approve" />
@@ -1233,6 +1236,7 @@ INSERT INTO "WorkflowScheme" ("Code", "Scheme") VALUES
   <Parameters>
     <Parameter Name="Comment" Type="String" Purpose="Temporary" />
     <Parameter Name="ShouldExecute" Type="String" Purpose="Persistence" />
+    <Parameter Name="environment" Type="String" Purpose="Persistence" />
   </Parameters>
   <Commands>
     <Command Name="Approve" />
@@ -1713,6 +1717,7 @@ INSERT INTO "WorkflowScheme" ("Code", "Scheme") VALUES
   <Parameters>
     <Parameter Name="Comment" Type="String" Purpose="Temporary" />
     <Parameter Name="ShouldExecute" Type="String" Purpose="Persistence" InitialValue="{ &quot;Synchronize Data&quot; : false }" />
+    <Parameter Name="environment" Type="String" Purpose="Persistence" />
   </Parameters>
   <Commands>
     <Command Name="Approve" />

--- a/source/OptimaJet.DWKit.StarterApplication/Migrations/20190923130727_AddProductDefinitionProperties.Designer.cs
+++ b/source/OptimaJet.DWKit.StarterApplication/Migrations/20190923130727_AddProductDefinitionProperties.Designer.cs
@@ -2,6 +2,7 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using OptimaJet.DWKit.StarterApplication.Data;
@@ -10,9 +11,10 @@ using OptimaJet.DWKit.StarterApplication.Models;
 namespace OptimaJet.DWKit.StarterApplication.Migrations
 {
     [DbContext(typeof(AppDbContext))]
-    partial class AppDbContextModelSnapshot : ModelSnapshot
+    [Migration("20190923130727_AddProductDefinitionProperties")]
+    partial class AddProductDefinitionProperties
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/source/OptimaJet.DWKit.StarterApplication/Migrations/20190923130727_AddProductDefinitionProperties.cs
+++ b/source/OptimaJet.DWKit.StarterApplication/Migrations/20190923130727_AddProductDefinitionProperties.cs
@@ -1,0 +1,22 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+namespace OptimaJet.DWKit.StarterApplication.Migrations
+{
+    public partial class AddProductDefinitionProperties : Migration
+    {
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<string>(
+                name: "Properties",
+                table: "ProductDefinitions",
+                nullable: true);
+        }
+
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "Properties",
+                table: "ProductDefinitions");
+        }
+    }
+}

--- a/source/OptimaJet.DWKit.StarterApplication/Models/ProductDefinition.cs
+++ b/source/OptimaJet.DWKit.StarterApplication/Models/ProductDefinition.cs
@@ -25,5 +25,8 @@ namespace OptimaJet.DWKit.StarterApplication.Models
         [HasOne("republish-workflow")]
         public virtual WorkflowDefinition RepublishWorkflow { get; set; }
         public int? RepublishWorkflowId { get; set; }
+
+        [Attr("properties")]
+        public string Properties { get; set; }
     }
 }

--- a/source/OptimaJet.DWKit.StarterApplication/Utility/JsonUtils.cs
+++ b/source/OptimaJet.DWKit.StarterApplication/Utility/JsonUtils.cs
@@ -1,0 +1,35 @@
+﻿using System;
+using System.Collections.Generic;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+
+namespace OptimaJet.DWKit.StarterApplication.Utility
+{
+    public static class JsonUtils
+    {
+        public static Dictionary<string, object> MergeProperties(Dictionary<string, object> baseProps, Dictionary<string, object> higherProps)
+        {
+            var result = new Dictionary<string, object>(baseProps);
+            foreach (var kv in higherProps)
+            {
+                if (!result.ContainsKey(kv.Key))
+                {
+                    result.Add(kv.Key, kv.Value);
+                }
+                else
+                {
+                    JObject baseObject = result[kv.Key] as JObject;
+                    JObject higherObject = kv.Value as JObject;
+                    baseObject.Merge(higherObject, new JsonMergeSettings { MergeArrayHandling = MergeArrayHandling.Union });
+                    result[kv.Key] = baseObject;
+                }
+            }
+            return result;
+        }
+
+        public static Dictionary<string, object> DeserializeProperties(string properties) =>
+            string.IsNullOrWhiteSpace(properties)
+                ? new Dictionary<string, object>()
+                : JsonConvert.DeserializeObject<Dictionary<string, object>>(properties);
+    }
+}

--- a/source/SIL.AppBuilder.Portal.Frontend/src/data/models/product-definition.ts
+++ b/source/SIL.AppBuilder.Portal.Frontend/src/data/models/product-definition.ts
@@ -6,6 +6,7 @@ export type PRODUCT_DEFINITIONS_TYPE = 'productDefinition';
 export interface ProductDefinitionAttributes extends AttributesObject {
   name: string;
   description: string;
+  properties: string;
 }
 
 export type ProductDefinitionResource = ResourceObject<

--- a/source/SIL.AppBuilder.Portal.Frontend/src/data/schema.ts
+++ b/source/SIL.AppBuilder.Portal.Frontend/src/data/schema.ts
@@ -235,6 +235,7 @@ const schemaDefinition: SchemaSettings = {
       attributes: {
         name: { type: 'string' },
         description: { type: 'string' },
+        properties: { type: 'string' },
       },
       relationships: {
         products: { type: 'hasMany', model: 'product', inverse: 'productDefinition' },

--- a/source/SIL.AppBuilder.Portal.Frontend/src/translations/locales/en-us.json
+++ b/source/SIL.AppBuilder.Portal.Frontend/src/translations/locales/en-us.json
@@ -485,6 +485,7 @@
         "add": "Add Product Definition",
         "edit": "Edit Product Definition",
         "description": "Description",
+        "properties": "Properties",
         "type": "Application Type",
         "workflow": "Workflow",
         "republishWorkflow": "Republish Workflow",

--- a/source/SIL.AppBuilder.Portal.Frontend/src/ui/routes/admin/settings/product-definitions/common/form.tsx
+++ b/source/SIL.AppBuilder.Portal.Frontend/src/ui/routes/admin/settings/product-definitions/common/form.tsx
@@ -34,6 +34,7 @@ interface IState {
   workflowError?: string;
   rebuildWorkflow?: WorkflowDefinitionResource;
   republishWorkflow?: WorkflowDefinitionResource;
+  properties?: string;
 }
 
 type IProps = i18nProps & IOwnProps;
@@ -47,7 +48,7 @@ class ProductDefinitionForm extends React.Component<IProps, IState> {
 
     const { productDefinition, type, workflow, rebuildWorkflow, republishWorkflow } = props;
 
-    const { name, description } = attributesFor(productDefinition);
+    const { name, description, properties } = attributesFor(productDefinition);
 
     this.mut = mutCreator(this);
     this.toggle = toggleCreator(this);
@@ -61,6 +62,7 @@ class ProductDefinitionForm extends React.Component<IProps, IState> {
       workflowError: '',
       rebuildWorkflow: rebuildWorkflow || null,
       republishWorkflow: republishWorkflow || null,
+      properties: properties || '',
     };
   }
 
@@ -87,7 +89,15 @@ class ProductDefinitionForm extends React.Component<IProps, IState> {
     e.preventDefault();
 
     const { onSubmit } = this.props;
-    const { name, description, type, workflow, rebuildWorkflow, republishWorkflow } = this.state;
+    const {
+      name,
+      description,
+      type,
+      workflow,
+      rebuildWorkflow,
+      republishWorkflow,
+      properties,
+    } = this.state;
     const relationships = { type, workflow };
     if (rebuildWorkflow) {
       Object.assign(relationships, { rebuildWorkflow });
@@ -101,6 +111,7 @@ class ProductDefinitionForm extends React.Component<IProps, IState> {
           {
             name,
             description,
+            properties,
           },
           relationships
         );
@@ -153,6 +164,7 @@ class ProductDefinitionForm extends React.Component<IProps, IState> {
       workflowError,
       rebuildWorkflow,
       republishWorkflow,
+      properties,
     } = this.state;
 
     const {
@@ -303,6 +315,16 @@ class ProductDefinitionForm extends React.Component<IProps, IState> {
                 data-test-pd-description
                 value={description}
                 onChange={mut('description')}
+              />
+            </div>
+
+            <div className='field m-b-xl'>
+              <label>{t('admin.settings.productDefinitions.properties')}</label>
+              <textarea
+                data-test-pd-properties
+                type='text'
+                value={properties}
+                onChange={mut('properties')}
               />
             </div>
 


### PR DESCRIPTION
* Add ProductDefinition Properties
* Merge ProductionDefinition/WorkflowDefinition Properties into ProcessProperties
* Merge ProcessProperties with ActionParameters so that environment can flow to BuildEngine
* explicitly declare environment parameter in default_workflow.sql

Note: Currently, only explicitly defined parameters in the workflow are persisted in WorkflowProcessSchemeInstance. I have contacted DWKit on the correct way to handle this generically.