### PR TITLE
New project group list is inconsistent

### DIFF
--- a/source/SIL.AppBuilder.Portal.Frontend/src/ui/components/inputs/group-select/index.tsx
+++ b/source/SIL.AppBuilder.Portal.Frontend/src/ui/components/inputs/group-select/index.tsx
@@ -5,6 +5,7 @@ import { attributesFor } from 'react-orbitjs/dist';
 import { OrganizationResource } from '~/data';
 
 import { compareVia } from '@lib/collection';
+import { RectLoader } from '@ui/components/loaders';
 
 import Display from './display';
 import { useScopeGroupData } from './with-data';
@@ -31,11 +32,13 @@ export default function GroupSelect({
   useEffect(() => {
     // Have to put in the odd or case because the organization name comes up as a group and initially doesn't
     // have a name attribute
-    groups.sort(compareVia((group) => (attributesFor(group).name || '').toLowerCase()));
-    if (!selected && groups && groups.length > 0) {
-      const firstId = groups[0].id;
+    if (groups) {
+      groups.sort(compareVia((group) => (attributesFor(group).name || '').toLowerCase()));
+      if (!selected && groups && groups.length > 0) {
+        const firstId = groups[0].id;
 
-      onChange(firstId);
+        onChange(firstId);
+      }
     }
   }, [selected, groups, onChange]);
 
@@ -52,6 +55,13 @@ export default function GroupSelect({
     [selected, onChange]
   );
 
+  if (!groups) {
+    return (
+      <div className='flex justify-content-center w-100'>
+        <RectLoader />
+      </div>
+    );
+  }
   groups.sort(compareVia((group) => (attributesFor(group).name || '').toLowerCase()));
   const groupOptions = (groups || [])
     .filter((group) => attributesFor(group).name)

--- a/source/SIL.AppBuilder.Portal.Frontend/src/ui/routes/projects/new/__tests__/acceptance-test.ts
+++ b/source/SIL.AppBuilder.Portal.Frontend/src/ui/routes/projects/new/__tests__/acceptance-test.ts
@@ -143,6 +143,34 @@ describe('Acceptance | New Project', () => {
 
       beforeEach(function() {
         this.mockGet(200, '/application-types', scenarios.applicationTypes());
+        this.mockGet(200, 'groups?include=owner', {
+          data: [
+            {
+              id: 1,
+              type: 'groups',
+              attributes: { name: 'Group 1' },
+              relationships: {
+                owner: { data: { id: 1, type: 'organizations' } },
+              },
+            },
+            {
+              id: 2,
+              type: 'groups',
+              attributes: { name: 'Group 2' },
+              relationships: {
+                owner: { data: { id: 1, type: 'organizations' } },
+              },
+            },
+          ],
+          included: [
+            {
+              id: 1,
+              type: 'organizations',
+              attributes: { name: 'Organization 1' },
+              relationships: {},
+            },
+          ],
+        });
         this.server.get('/assets/language/langtags.json').intercept((req, res) => {
           res.status(200);
           res.json([

--- a/source/SIL.AppBuilder.Portal.Frontend/src/ui/routes/projects/new/__tests__/org-switcher-changes-available-groups-test.ts
+++ b/source/SIL.AppBuilder.Portal.Frontend/src/ui/routes/projects/new/__tests__/org-switcher-changes-available-groups-test.ts
@@ -32,6 +32,26 @@ function setupMockData() {
   beforeEach(function() {
     this.mockGet(200, 'users', { data: [] });
     this.mockGet(200, 'application-types', { data: applicationTypesData });
+    this.mockGet(200, 'groups?include=owner', {
+      data: [
+        {
+          id: 1,
+          type: 'groups',
+          attributes: { name: 'Group 1' },
+          relationships: {
+            owner: { data: { id: 2, type: 'organizations' } },
+          },
+        },
+      ],
+      included: [
+        {
+          id: 2,
+          type: 'organizations',
+          attributes: { name: 'SIL' },
+          relationships: {},
+        },
+      ],
+    });
   });
 }
 

--- a/source/SIL.AppBuilder.Portal.Frontend/src/ui/routes/projects/show/__tests__/group-and-access-acceptance-test.ts
+++ b/source/SIL.AppBuilder.Portal.Frontend/src/ui/routes/projects/show/__tests__/group-and-access-acceptance-test.ts
@@ -40,6 +40,43 @@ function setupData() {
         { type: 'users', id: 2, attributes: { familyName: 'last', givenName: 'first' } },
       ],
     });
+
+    this.mockGet(200, 'groups?include=owner', {
+      data: [
+        {
+          id: 1,
+          type: 'groups',
+          attributes: { name: 'Group 1' },
+          relationships: {
+            owner: { data: { id: 1, type: 'organizations' } },
+          },
+        },
+        {
+          id: 2,
+          type: 'groups',
+          attributes: { name: 'Group 2' },
+          relationships: {
+            owner: { data: { id: 1, type: 'organizations' } },
+          },
+        },
+        {
+          id: 3,
+          type: 'groups',
+          attributes: { name: 'Group 3' },
+          relationships: {
+            owner: { data: { id: 1, type: 'organizations' } },
+          },
+        },
+      ],
+      included: [
+        {
+          id: 1,
+          type: 'organizations',
+          attributes: { name: 'Organization 1' },
+          relationships: {},
+        },
+      ],
+    });
   });
 }
 

--- a/source/SIL.AppBuilder.Portal.Frontend/src/ui/routes/projects/show/__tests__/owner-acceptance-test.ts
+++ b/source/SIL.AppBuilder.Portal.Frontend/src/ui/routes/projects/show/__tests__/owner-acceptance-test.ts
@@ -40,7 +40,7 @@ function setupMockData() {
           type: 'groups',
           attributes: { name: 'Group 1' },
           relationships: {
-            organization: { data: { id: 1, type: 'organizations' } },
+            owner: { data: { id: 1, type: 'organizations' } },
           },
         },
         {
@@ -48,7 +48,7 @@ function setupMockData() {
           type: 'groups',
           attributes: { name: 'Group 2' },
           relationships: {
-            organization: { data: { id: 1, type: 'organizations' } },
+            owner: { data: { id: 1, type: 'organizations' } },
           },
         },
       ],


### PR DESCRIPTION
Issues with accessing the cache for group.  This retrieves the
group information associated with the organization with a query.
All the subsequent accesses to the cache for that request then
retrieve the correct information.