### PR TITLE
Separate add/remove product button into two separate buttons

### DIFF
--- a/source/SIL.AppBuilder.Portal.Frontend/src/data/containers/resources/project/with-data-actions.tsx
+++ b/source/SIL.AppBuilder.Portal.Frontend/src/data/containers/resources/project/with-data-actions.tsx
@@ -151,7 +151,6 @@ export function withDataActions<T>(WrappedComponent) {
 
     productForProductDefinition = (productDefinition) => {
       const { products } = this.props;
-
       const matchingProduct = products.find((product) => {
         const { data } = relationshipFor(product, 'productDefinition');
         return data.id === productDefinition.id;
@@ -164,7 +163,6 @@ export function withDataActions<T>(WrappedComponent) {
       const { project, dataStore } = this.props;
 
       const productSelected = this.productForProductDefinition(productDefinition);
-
       if (productSelected) {
         return dataStore.update((q) => q.removeRecord(productSelected), defaultOptions());
       }
@@ -204,7 +202,7 @@ export function withDataActions<T>(WrappedComponent) {
       const { project } = passedProps;
 
       return {
-        products: (q) => q.findRelatedRecords(project, 'products'),
+        products: (q) => q.findRecords('product').filter({ relation: 'project', record: project }),
       };
     }),
     requireProps('project')

--- a/source/SIL.AppBuilder.Portal.Frontend/src/data/containers/resources/user-task/index.ts
+++ b/source/SIL.AppBuilder.Portal.Frontend/src/data/containers/resources/user-task/index.ts
@@ -20,6 +20,9 @@ export function useUserTaskHelpers() {
       'productDefinition',
       'workflow',
     ]);
+    if (!product || !workflow) {
+      return null;
+    }
     const id = idFromRecordIdentity(dataStore, product);
     const { workflowBusinessFlow } = attributesFor(workflow);
 

--- a/source/SIL.AppBuilder.Portal.Frontend/src/data/containers/with-relationship.tsx
+++ b/source/SIL.AppBuilder.Portal.Frontend/src/data/containers/with-relationship.tsx
@@ -117,7 +117,10 @@ export function relationsFromPath(
 
   for (let i = 0; i < relationshipPath.length; i++) {
     segment = relationshipPath[i];
-    assert(`can't access segment (${segment}) on falsey model.`, !!model);
+    if (!model) {
+      console.debug(`can't access segment (${segment}) on falsey model.`);
+      return models;
+    }
 
     model = dataStore.cache.query((q) => q.findRelatedRecord(model, segment));
     models.push(model);

--- a/source/SIL.AppBuilder.Portal.Frontend/src/translations/locales/en-us.json
+++ b/source/SIL.AppBuilder.Portal.Frontend/src/translations/locales/en-us.json
@@ -270,6 +270,8 @@
       "title": "Products",
       "empty": "You have no products for this project.",
       "addRemove": "Add or Remove Products",
+      "add": "Add Products",
+      "remove": "Remove Products",
       "popup": {
         "title": "Select Products",
         "done": "Done",

--- a/source/SIL.AppBuilder.Portal.Frontend/src/translations/locales/en-us.json
+++ b/source/SIL.AppBuilder.Portal.Frontend/src/translations/locales/en-us.json
@@ -273,7 +273,8 @@
       "add": "Add Products",
       "remove": "Remove Products",
       "popup": {
-        "title": "Select Products",
+        "addTitle": "Select Product to Add",
+        "removeTitle": "Select Product to Remove",
         "done": "Done",
         "empty": "No products available",
         "details": "Details"

--- a/source/SIL.AppBuilder.Portal.Frontend/src/ui/routes/projects/show/__tests__/page.ts
+++ b/source/SIL.AppBuilder.Portal.Frontend/src/ui/routes/projects/show/__tests__/page.ts
@@ -39,7 +39,8 @@ export class ProjectInteractor {
   isAutomaticRebuildChecked = isPresent('[data-test-project-settings-automatic-build].checked');
   isAllowDownloadChecked = isPresent('[data-test-project-settings-allow-download].checked');
   isPublic = isPresent('[data-test-project-settings-project-visibility].checked');
-  isProductModalPresent = isPresent('[data-test-project-product-popup]');
+  isProductAddModalPresent = isPresent('[data-test-project-product-add-popup]');
+  isProductRemoveModalPresent = isPresent('[data-test-project-product-remove-popup]');
   isMultiSelectPresent = isPresent('[data-test-multi-select]');
 
   hasUserSelect = isPresent('[data-test-user-select]');

--- a/source/SIL.AppBuilder.Portal.Frontend/src/ui/routes/projects/show/__tests__/products-acceptance-test.tsx
+++ b/source/SIL.AppBuilder.Portal.Frontend/src/ui/routes/projects/show/__tests__/products-acceptance-test.tsx
@@ -203,11 +203,6 @@ describe('Acceptance | Project View | Products', () => {
         expect(itemTexts).to.not.contain('android_amazon_app');
       });
 
-      it('existing project product is selected', () => {
-        const selector = page.productsList.removeModal.multiSelect;
-        expect(selector.itemNamed('android_s3').isChecked).to.equal(true);
-      });
-
       describe('remove an existing product', () => {
         beforeEach(async function() {
           await when(() => page.productsList.removeModal.isVisible);
@@ -235,12 +230,6 @@ describe('Acceptance | Project View | Products', () => {
         const itemTexts = items.map((item) => item.text);
         expect(itemTexts).to.not.contain('android_s3');
         expect(itemTexts).to.contain('android_amazon_app');
-      });
-
-      it('project product to be added is not selected', () => {
-        const selector = page.productsList.modal.multiSelect;
-
-        expect(selector.itemNamed('android_amazon_app').isChecked).to.equal(false);
       });
 
       describe('select a new product', () => {

--- a/source/SIL.AppBuilder.Portal.Frontend/src/ui/routes/projects/show/__tests__/products-acceptance-test.tsx
+++ b/source/SIL.AppBuilder.Portal.Frontend/src/ui/routes/projects/show/__tests__/products-acceptance-test.tsx
@@ -8,6 +8,7 @@ import {
   useFakeAuthentication,
   resetBrowser,
 } from 'tests/helpers/index';
+import { is } from '@bigtest/interactor';
 
 import page from './page';
 
@@ -188,24 +189,57 @@ describe('Acceptance | Project View | Products', () => {
       expect(productsText).to.contain('android_s3');
     });
 
-    describe('select products that do not require a store', () => {
+    describe('select remove products', () => {
       beforeEach(async function() {
         await new Convergence()
-          .do(() => page.productsInteractor.clickManageProductButton())
+          .do(() => page.productsInteractor.clickRemoveProductButton())
+          .when(() => page.productsInteractor.removeModal.isVisible);
+      });
+
+      it('has render existing product definitions to be removed', () => {
+        const items = page.productsInteractor.removeModal.multiSelectInteractor.itemsText();
+        const itemTexts = items.map((item) => item.text);
+        expect(itemTexts).to.contain('android_s3');
+        expect(itemTexts).to.not.contain('android_amazon_app');
+      });
+
+      it('existing project product is selected', () => {
+        const selector = page.productsList.removeModal.multiSelect;
+        expect(selector.itemNamed('android_s3').isChecked).to.equal(true);
+      });
+
+      describe('remove an existing product', () => {
+        beforeEach(async function() {
+          await when(() => page.productsList.removeModal.isVisible);
+          await page.productsList.removeModal.multiSelect.itemNamed('android_s3').toggle();
+        });
+
+        it('product is removed from list of existing products', () => {
+          expect(page.productsInteractor.removeModal.multiSelectInteractor.isListEmpty).to.be.true;
+          expect(page.productsInteractor.removeModal.multiSelectInteractor.emptyText).to.contain(
+            'No products available'
+          );
+        });
+      });
+    });
+
+    describe('select add products that do not require a store', () => {
+      beforeEach(async function() {
+        await new Convergence()
+          .do(() => page.productsInteractor.clickAddProductButton())
           .when(() => page.productsInteractor.modalInteractor.isVisible);
       });
 
-      it('has render product definitions', () => {
+      it('has render product definitions to be added', () => {
         const items = page.productsInteractor.modalInteractor.multiSelectInteractor.itemsText();
         const itemTexts = items.map((item) => item.text);
-        expect(itemTexts).to.contain('android_s3');
+        expect(itemTexts).to.not.contain('android_s3');
         expect(itemTexts).to.contain('android_amazon_app');
       });
 
-      it.always('project product is selected', () => {
+      it('project product to be added is not selected', () => {
         const selector = page.productsList.modal.multiSelect;
 
-        expect(selector.itemNamed('android_s3').isChecked).to.equal(true);
         expect(selector.itemNamed('android_amazon_app').isChecked).to.equal(false);
       });
 
@@ -213,82 +247,14 @@ describe('Acceptance | Project View | Products', () => {
         beforeEach(async function() {
           await when(() => page.productsList.modal.isVisible);
           await page.productsList.modal.multiSelect.itemNamed('android_amazon_app').toggle();
-          await when(() => page.productsList.products().length === 2);
         });
 
-        it('product is added to product list', () => {
-          const productList = page.productsList.itemsText();
-          const productsText = productList.map((item) => item.text);
-
-          expect(productsText).to.contain('android_s3');
-          expect(productsText).to.contain('android_amazon_app');
-        }).timeout(2000);
-
-        it('project product is selected', () => {
-          const selector = page.productsList.modal.multiSelect;
-
-          expect(selector.itemNamed('android_s3').isChecked).to.equal(true);
-          expect(selector.itemNamed('android_amazon_app').isChecked).to.equal(true);
-        }).timeout(2000);
-      });
-
-      describe('ignores requests until previous request has completed.', () => {
-        let requestCount;
-        beforeEach(async function() {
-          requestCount = 0;
-
-          customizer = async (server, req, resp) => {
-            if (
-              req.method === 'POST' ||
-              (req.method === 'DELETE' && /\/api\/products/.test(req.pathname))
-            ) {
-              ++requestCount;
-              await server.timeout(1000);
-            }
-          };
-
-          await page.productsList.modal.multiSelect.itemNamed('android_amazon_app').toggle();
-          await page.productsList.modal.multiSelect.itemNamed('android_amazon_app').toggle();
-          await page.productsList.modal.multiSelect.itemNamed('android_amazon_app').toggle();
-        });
-
-        it('is only requested once.', () => {
-          expect(requestCount).to.equal(1);
-        }).timeout(4000);
-
-        it('product is added to product list', () => {
-          const productList = page.productsInteractor.itemsText();
-          const productsText = productList.map((item) => item.text);
-
-          expect(productsText).to.contain('android_s3');
-          expect(productsText).to.contain('android_amazon_app');
-        }).timeout(4000);
-
-        it('project product is selected', () => {
-          const selector = page.productsList.modal.multiSelect;
-
-          expect(selector.itemNamed('android_s3').isChecked).to.equal(true);
-          expect(selector.itemNamed('android_amazon_app').isChecked).to.equal(true);
-        }).timeout(4000);
-
-        describe('and on deselect', () => {
-          beforeEach(async () => {
-            await new Convergence()
-              .when(
-                () => page.productsList.modal.multiSelect.itemNamed('android_amazon_app').isChecked
-              )
-              .do(async () => {
-                await page.productsList.modal.multiSelect.itemNamed('android_amazon_app').toggle();
-                await page.productsList.modal.multiSelect.itemNamed('android_amazon_app').toggle();
-                await page.productsList.modal.multiSelect.itemNamed('android_amazon_app').toggle();
-              });
-            await when(
-              () => page.productsList.modal.multiSelect.itemNamed('android_amazon_app').isChecked
-            );
-          });
-          it('is only requested one additional time.', () => {
-            expect(requestCount).to.equal(2);
-          }).timeout(4000);
+        it('product is removed from list of available products', () => {
+          expect(page.productsInteractor.modalInteractor.multiSelectInteractor.isListEmpty).to.be
+            .true;
+          expect(
+            page.productsInteractor.modalInteractor.multiSelectInteractor.emptyText
+          ).to.contain('No products available');
         });
       });
     });
@@ -396,11 +362,11 @@ describe('Acceptance | Project View | Products', () => {
 
     describe('try to add a product to the list', () => {
       beforeEach(async function() {
-        await page.productsInteractor.clickManageProductButton();
+        await page.productsInteractor.clickAddProductButton();
       });
 
       it('popup is not visible', () => {
-        expect(page.isProductModalPresent).to.be.false;
+        expect(page.isProductAddModalPresent).to.be.false;
       });
     });
   });

--- a/source/SIL.AppBuilder.Portal.Frontend/src/ui/routes/projects/show/__tests__/products-with-stores-acceptance-test.tsx
+++ b/source/SIL.AppBuilder.Portal.Frontend/src/ui/routes/projects/show/__tests__/products-with-stores-acceptance-test.tsx
@@ -12,6 +12,8 @@ import { MultiSelectInteractor } from '~/ui/components/inputs/multi-select/-page
 
 import { ProductsInteractor } from '~/ui/routes/projects/show/overview/products/-page.ts';
 
+import { ProductMultiSelectInteractor } from '~/ui/routes/projects/show/overview/products/-multi';
+
 import i18n from '@translations';
 
 describe('Acceptance | Project View | Products With Stores', () => {
@@ -212,14 +214,15 @@ describe('Acceptance | Project View | Products With Stores', () => {
       await page.clickAddProductButton();
       await when(() => page.modal.isVisible);
 
-      products = new MultiSelectInteractor('[data-test-project-product-add-popup]');
+      products = new ProductMultiSelectInteractor('[data-test-project-product-add-popup]');
       stores = new MultiSelectInteractor('[data-test-project-product-store-select-modal]');
     });
 
     it('no products are selected', () => {
-      const selected = products.checkedItems();
-
-      expect(selected.length).to.equal(0);
+      const items = products.itemsText();
+      const itemTexts = items.map((item) => item.text);
+      expect(itemTexts).to.contain('android_s3');
+      expect(itemTexts).to.contain('android_google');
     });
 
     describe('the user clicks a product that requires a store...', () => {
@@ -234,7 +237,6 @@ describe('Acceptance | Project View | Products With Stores', () => {
           const itemTexts = items.map((item) => item.text);
           expect(itemTexts).to.contain('android_s3');
           expect(itemTexts).to.contain('android_google');
-          expect(products.itemNamed('android_s3').isChecked).to.equal(false);
         });
 
         it('shows a message saying to contact the org admin', () => {

--- a/source/SIL.AppBuilder.Portal.Frontend/src/ui/routes/projects/show/__tests__/products-with-stores-acceptance-test.tsx
+++ b/source/SIL.AppBuilder.Portal.Frontend/src/ui/routes/projects/show/__tests__/products-with-stores-acceptance-test.tsx
@@ -209,10 +209,10 @@ describe('Acceptance | Project View | Products With Stores', () => {
     let stores;
 
     beforeEach(async function() {
-      await page.clickManageProductButton();
+      await page.clickAddProductButton();
       await when(() => page.modal.isVisible);
 
-      products = new MultiSelectInteractor('[data-test-project-product-popup]');
+      products = new MultiSelectInteractor('[data-test-project-product-add-popup]');
       stores = new MultiSelectInteractor('[data-test-project-product-store-select-modal]');
     });
 
@@ -230,6 +230,10 @@ describe('Acceptance | Project View | Products With Stores', () => {
         });
 
         it('does not yet "check" the product', () => {
+          const items = products.itemsText();
+          const itemTexts = items.map((item) => item.text);
+          expect(itemTexts).to.contain('android_s3');
+          expect(itemTexts).to.contain('android_google');
           expect(products.itemNamed('android_s3').isChecked).to.equal(false);
         });
 
@@ -282,15 +286,18 @@ describe('Acceptance | Project View | Products With Stores', () => {
             await when(() =>
               assert(stores.isOverlayLoaderVisible, 'expected overlay loader to briefly be visible')
             );
-            await when(() => products.checkedItems().length > 0);
+            await when(() => products.itemNamed('android_s3').isVisible);
           });
 
           it('closed the stores modal', () => {
             expect(page.isStoreModalVisible).to.equal(false);
           });
 
-          it('the product is created, and now in the list of products', () => {
-            expect(products.checkedItems().length).to.equal(1);
+          it('the product is created, and not in list of products to add', () => {
+            const items = products.itemsText();
+            const itemTexts = items.map((item) => item.text);
+            expect(itemTexts).to.contain('android_s3');
+            expect(itemTexts).to.not.contain('android_google');
           });
         });
       });

--- a/source/SIL.AppBuilder.Portal.Frontend/src/ui/routes/projects/show/overview/products/-modal.ts
+++ b/source/SIL.AppBuilder.Portal.Frontend/src/ui/routes/projects/show/overview/products/-modal.ts
@@ -10,9 +10,13 @@ class ProductModal {
   multiSelect = MultiSelectInteractor;
 }
 
-export const ProductModalInteractor = interactor(ProductModal);
+export const AddProductModalInteractor = interactor(ProductModal);
+export const RemoveProductModalInteractor = interactor(ProductModal);
 export type TInteractor = ProductModal & Interactor;
 
-export default new (ProductModalInteractor as any)(
-  '[data-test-project-product-popup]'
+export const RemoveProductModal = new (RemoveProductModalInteractor as any)(
+  '[data-test-project-product-remove-popup'
+) as TInteractor;
+export default new (AddProductModalInteractor as any)(
+  '[data-test-project-product-add-popup]'
 ) as TInteractor;

--- a/source/SIL.AppBuilder.Portal.Frontend/src/ui/routes/projects/show/overview/products/-modal.ts
+++ b/source/SIL.AppBuilder.Portal.Frontend/src/ui/routes/projects/show/overview/products/-modal.ts
@@ -1,13 +1,14 @@
 import { interactor, Interactor, clickable, hasClass } from '@bigtest/interactor';
-import MultiSelectInteractor from '@ui/components/inputs/multi-select/-page';
+
+import ProductMultiSelectInteractor from './-multi';
 
 class ProductModal {
   isVisible = hasClass('visible');
   closePopup = clickable('[data-test-project-product-close-button]');
 
   // TODO: don't use interactor in the name, it's an implementation detail
-  multiSelectInteractor = MultiSelectInteractor;
-  multiSelect = MultiSelectInteractor;
+  multiSelectInteractor = ProductMultiSelectInteractor;
+  multiSelect = ProductMultiSelectInteractor;
 }
 
 export const AddProductModalInteractor = interactor(ProductModal);

--- a/source/SIL.AppBuilder.Portal.Frontend/src/ui/routes/projects/show/overview/products/-multi.ts
+++ b/source/SIL.AppBuilder.Portal.Frontend/src/ui/routes/projects/show/overview/products/-multi.ts
@@ -1,0 +1,40 @@
+import {
+  isPresent,
+  text,
+  collection,
+  clickable,
+  Interactor,
+  interactor,
+} from '@bigtest/interactor';
+
+class ProductMultiSelect {
+  items = collection('[data-test-item]', {
+    text: text(),
+
+    toggle: clickable('[data-test-item-text]'),
+  });
+
+  itemNamed(named: string) {
+    const item = this.items().find((p) => p.text.includes(named));
+
+    if (!item) {
+      throw new Error(`cannot find multi-select item named: ${named}`);
+    }
+
+    return item;
+  }
+
+  toggleItem(named: string) {
+    return this.when(() => this.itemNamed(named)).do((item) => item.toggle());
+  }
+
+  itemsText = collection('[data-test-item-text]');
+  isListEmpty = isPresent('[data-test-empty-list]');
+  emptyText = text('[data-test-empty-list]');
+  isOverlayLoaderVisible = isPresent('[data-test-overlay-loader]');
+}
+
+export type TInteractor = ProductMultiSelect & Interactor;
+export const ProductMultiSelectInteractor = interactor(ProductMultiSelect) as TInteractor;
+
+export default new (ProductMultiSelectInteractor as any)('[data-test-multi-select]') as TInteractor;

--- a/source/SIL.AppBuilder.Portal.Frontend/src/ui/routes/projects/show/overview/products/-page.ts
+++ b/source/SIL.AppBuilder.Portal.Frontend/src/ui/routes/projects/show/overview/products/-page.ts
@@ -11,13 +11,16 @@ import {
 import { MultiSelectInteractor } from '@ui/components/inputs/multi-select/-page';
 import TransitionDetailsModalInteractor from '@ui/components/product-transitions/-modal';
 
-import ProductModalInteractor from './-modal';
+import AddProductModalInteractor from './-modal';
+import { RemoveProductModal } from './-modal';
 
 class Products {
-  clickManageProductButton = clickable('[data-test-project-products-manage-button]');
+  clickAddProductButton = clickable('[data-test-project-products-add-button]');
+  clickRemoveProductButton = clickable('[data-test-project-products-remove-button]');
   itemsText = collection('[data-test-project-product-name]');
   emptyLabel = text('[data-test-project-product-empty-text]');
-  isModalVisible = isPresent('[data-test-project-product-popup]');
+  isAddModalVisible = isPresent('[data-test-project-product-add-popup]');
+  isRemoveModalVisible = isPresent('[data-test-project-product-remove-popup]');
 
   products = collection('[data-test-project-product-item]', {
     name: text('[data-test-project-product-name]'),
@@ -37,8 +40,9 @@ class Products {
   }
 
   // TODO: don't use interactor in the name, it's an implementation detail
-  modalInteractor = ProductModalInteractor;
-  modal = ProductModalInteractor;
+  modalInteractor = AddProductModalInteractor;
+  modal = AddProductModalInteractor;
+  removeModal = RemoveProductModal;
 
   isStoreModalVisible = isPresent('[data-test-project-product-store-select-modal]');
   storeModal = scoped('[data-test-project-product-store-select-modal]', {

--- a/source/SIL.AppBuilder.Portal.Frontend/src/ui/routes/projects/show/overview/products/index.tsx
+++ b/source/SIL.AppBuilder.Portal.Frontend/src/ui/routes/projects/show/overview/products/index.tsx
@@ -28,7 +28,7 @@ export default function Products({ project }: IProps) {
     dataStore,
     subscriptions: { products, organization },
   } = useOrbit<ISubscriptions>({
-    products: (q) => q.findRelatedRecords(project, 'products'),
+    products: (q) => q.findRecords('product').filter({ relation: 'project', record: project }),
     organization: (q) => q.findRelatedRecord(project, 'organization'),
     // cache busters
     userTasks: (q) => q.findRecords('userTask'),

--- a/source/SIL.AppBuilder.Portal.Frontend/src/ui/routes/projects/show/overview/products/item/index.tsx
+++ b/source/SIL.AppBuilder.Portal.Frontend/src/ui/routes/projects/show/overview/products/item/index.tsx
@@ -23,7 +23,7 @@ interface IOwnProps {
 
 type IProps = IOwnProps;
 
-export default function ProductItem({ product, includeHeader }) {
+export default function ProductItem({ product }) {
   const { t } = useTranslations();
   const { dataStore } = useOrbit();
 

--- a/source/SIL.AppBuilder.Portal.Frontend/src/ui/routes/projects/show/overview/products/item/tasks/index.tsx
+++ b/source/SIL.AppBuilder.Portal.Frontend/src/ui/routes/projects/show/overview/products/item/tasks/index.tsx
@@ -82,7 +82,6 @@ export default function ProductTasksForCurrentUser({ product }: IProps) {
     }
     return allowedNames;
   };
-
   return (
     <div className='w-100 p-sm p-b-md m-l-md fs-13'>
       <AsyncWaiter fn={getTransition} sizeClass='m-t-sm m-b-sm'>

--- a/source/SIL.AppBuilder.Portal.Frontend/src/ui/routes/projects/show/overview/products/selection-manager/index.tsx
+++ b/source/SIL.AppBuilder.Portal.Frontend/src/ui/routes/projects/show/overview/products/selection-manager/index.tsx
@@ -1,11 +1,12 @@
 import * as React from 'react';
 import { compose, withProps } from 'recompose';
 import { withTranslations, i18nProps } from '@lib/i18n';
-import { isEmpty } from '@lib/collection';
+import { isEmpty, compareVia } from '@lib/collection';
 import {
   withDataActions,
   IProvidedProps as IDataActionsProps,
 } from '@data/containers/resources/project/with-data-actions';
+import { withRelationships } from '@data/containers/with-relationship';
 
 import {
   ProductDefinitionResource,
@@ -30,15 +31,22 @@ interface INeededProps {
 
 interface IOwnProps {
   isEmptyWorkflowProjectUrl: boolean;
+  list: ProductDefinitionResource[];
 }
 
 type IProps = IOwnProps & INeededProps & i18nProps & IDataActionsProps & IProductSelectionState;
 
 export default compose<IProps, INeededProps>(
   withTranslations,
-  withProps(({ project }) => {
+  withRelationships(({ organization }: INeededProps) => {
+    return {
+      list: [organization, 'organizationProductDefinitions', 'productDefinition'],
+    };
+  }),
+  withProps(({ project, list }) => {
     return {
       isEmptyWorkflowProjectUrl: isEmpty(attributesFor(project).workflowProjectUrl),
+      list: list.sort(compareVia((pd) => attributesFor(pd).name)),
     };
   }),
   withDataActions,
@@ -51,14 +59,13 @@ export default compose<IProps, INeededProps>(
         onStoreSelect,
         cancelStore: closeStoreModal,
       } = this.props.productSelection;
-
       await onStoreSelect(storeNeededFor, store);
 
       closeStoreModal();
     };
 
     render() {
-      const { productSelection, t, selected, organization, project } = this.props;
+      const { productSelection, t, selected, organization, project, list } = this.props;
 
       const { storeNeededFor, cancelStore, storeType } = productSelection;
 
@@ -80,6 +87,7 @@ export default compose<IProps, INeededProps>(
               selected,
               organization,
               project,
+              list,
               ...productSelection,
             }}
           />

--- a/source/SIL.AppBuilder.Portal.Frontend/src/ui/routes/projects/show/overview/products/selection-manager/multi-select-entry.tsx
+++ b/source/SIL.AppBuilder.Portal.Frontend/src/ui/routes/projects/show/overview/products/selection-manager/multi-select-entry.tsx
@@ -16,12 +16,12 @@ interface IOwnProps<T> {
   onChange: (el: T) => void;
   emptyListLabel?: string;
   displayProductIcon?: boolean;
-  readOnly?: boolean;
+  selectedOnly?: boolean;
 }
 
 type IProps<T> = IOwnProps<T> & i18nProps & IAttributeProps;
 
-export class MultiSelect<T extends ResourceObject> extends React.Component<IProps<T>> {
+export class MultiSelectEntry<T extends ResourceObject> extends React.Component<IProps<T>> {
   onChange = (element) => (e) => {
     e.preventDefault();
     this.props.onChange(element);
@@ -38,11 +38,27 @@ export class MultiSelect<T extends ResourceObject> extends React.Component<IProp
     return el !== undefined;
   };
 
-  render() {
-    const { list, emptyListLabel, displayProductIcon, t, readOnly } = this.props;
-    const emptyLabel = emptyListLabel || t('common.noResults');
+  filterList = () => {
+    const { list, selectedOnly } = this.props;
+    let filteredList = [];
+    let filteredIndex = 0;
+    if (!isEmpty(list)) {
+      list.map((element) => {
+        const isSelected = this.inSelectedList(element);
+        if ((selectedOnly && isSelected) || (!selectedOnly && !isSelected)) {
+          filteredList[filteredIndex] = element;
+          filteredIndex++;
+        }
+      });
+    }
+    return filteredList;
+  };
 
-    if (isEmpty(list)) {
+  render() {
+    const { emptyListLabel, displayProductIcon, t } = this.props;
+    const emptyLabel = emptyListLabel || t('common.noResults');
+    const filteredList = this.filterList();
+    if (isEmpty(filteredList)) {
       return (
         <div data-test-multi-select>
           <div data-test-empty-list className='empty-list'>
@@ -54,15 +70,12 @@ export class MultiSelect<T extends ResourceObject> extends React.Component<IProp
 
     return (
       <div data-test-multi-select>
-        {list.map((element, index) => {
-          const isSelected = this.inSelectedList(element);
-
+        {filteredList.map((element) => {
           return (
             <div
               key={element.id}
               className={`flex flex-column align-items-center
-              w-100 m-b-sm round-border-4 light-gray-text pointer
-              ${isSelected ? 'blue-light-border' : 'thin-border'}`}
+              w-100 m-b-sm round-border-4 light-gray-text pointer blue-light-border`}
               data-test-item
               onClick={this.onChange(element)}
             >
@@ -70,17 +83,8 @@ export class MultiSelect<T extends ResourceObject> extends React.Component<IProp
                 className={`flex flex-row align-items-center
                 w-100 p-sm bg-lightest-gray fs-14 round-border-4 thin-bottom-border`}
               >
-                <Checkbox
-                  data-test-item-checkbox
-                  className='m-r-sm'
-                  value={element.id}
-                  readOnly={readOnly}
-                  checked={isSelected}
-                />
-                {displayProductIcon && (
-                  <ProductIcon product={element} selected={isSelected} size={19} />
-                )}
-                <span data-test-item-text className={`p-l-xs-xs ${isSelected && 'black-text'}`}>
+                {displayProductIcon && <ProductIcon product={element} selected={true} size={19} />}
+                <span data-test-item-text className={`p-l-xs-xs black-text`}>
                   {attributesFor(element).name}
                 </span>
               </div>

--- a/source/SIL.AppBuilder.Portal.Frontend/src/ui/routes/projects/show/overview/products/selection-manager/multi-select-entry.tsx
+++ b/source/SIL.AppBuilder.Portal.Frontend/src/ui/routes/projects/show/overview/products/selection-manager/multi-select-entry.tsx
@@ -3,7 +3,6 @@ import { ResourceObject } from 'jsonapi-typescript';
 
 import { attributesFor, relationshipFor } from '@data';
 
-import { Checkbox } from 'semantic-ui-react';
 import ProductIcon from '@ui/components/product-icon';
 import { i18nProps } from '@lib/i18n';
 import { isEmpty } from '@lib/collection';

--- a/source/SIL.AppBuilder.Portal.Frontend/src/ui/routes/projects/show/overview/products/selection-manager/multi-select.tsx
+++ b/source/SIL.AppBuilder.Portal.Frontend/src/ui/routes/projects/show/overview/products/selection-manager/multi-select.tsx
@@ -5,20 +5,22 @@ import {
   OrganizationResource,
   ProductDefinitionResource,
   ProjectResource,
+  ProductResource,
   attributesFor,
 } from '@data';
 
 import { withTranslations, i18nProps } from '@lib/i18n';
-import { compareVia } from '@lib/collection';
 import { MultiSelect } from '@ui/components/inputs/multi-select';
-import { withRelationships } from '@data/containers/with-relationship';
 import { withOrbit } from 'react-orbitjs';
 
 interface INeededProps {
   organization: OrganizationResource;
-  selected?: ProductDefinitionResource[];
+  selected?: ProductResource[];
   project: ProjectResource;
+  list: ProductDefinitionResource[];
   onChangeSelection: (definition: ProductDefinitionResource) => Promise<void>;
+  selectedOnly?: boolean;
+  unselectedOnly?: boolean;
 }
 
 interface IPendingUpdates {
@@ -29,7 +31,6 @@ interface IComposedProps {
   selectedItemJoinsWith: string;
   emptyListLabel: string;
   displayProductIcon: boolean;
-  list: ProductDefinitionResource[];
 }
 
 type IProps = INeededProps & i18nProps & IComposedProps;
@@ -37,17 +38,11 @@ type IProps = INeededProps & i18nProps & IComposedProps;
 export default compose<IProps, INeededProps>(
   withTranslations,
   withOrbit(),
-  withRelationships(({ organization }: INeededProps) => {
-    return {
-      list: [organization, 'organizationProductDefinitions', 'productDefinition'],
-    };
-  }),
-  withProps(({ t, list }: IProps) => {
+  withProps(({ t }: IProps) => {
     return {
       selectedItemJoinsWith: 'productDefinition',
       emptyListLabel: t('project.products.popup.empty'),
       displayProductIcon: true,
-      list: list.sort(compareVia((pd) => attributesFor(pd).name)),
     };
   })
 )(
@@ -76,6 +71,8 @@ export default compose<IProps, INeededProps>(
         selectedItemJoinsWith,
         emptyListLabel,
         displayProductIcon,
+        selectedOnly,
+        unselectedOnly,
       } = this.props;
 
       const selectProps = {
@@ -86,6 +83,8 @@ export default compose<IProps, INeededProps>(
         selected,
         t,
         onChange: this.onSelectionChange,
+        selectedOnly,
+        unselectedOnly,
       };
 
       return <MultiSelect {...selectProps} />;

--- a/source/SIL.AppBuilder.Portal.Frontend/src/ui/routes/projects/show/overview/products/selection-manager/multi-select.tsx
+++ b/source/SIL.AppBuilder.Portal.Frontend/src/ui/routes/projects/show/overview/products/selection-manager/multi-select.tsx
@@ -6,7 +6,6 @@ import {
   ProductDefinitionResource,
   ProjectResource,
   ProductResource,
-  attributesFor,
 } from '@data';
 
 import { withTranslations, i18nProps } from '@lib/i18n';

--- a/source/SIL.AppBuilder.Portal.Frontend/src/ui/routes/projects/show/overview/products/selection-manager/multi-select.tsx
+++ b/source/SIL.AppBuilder.Portal.Frontend/src/ui/routes/projects/show/overview/products/selection-manager/multi-select.tsx
@@ -9,8 +9,9 @@ import {
 } from '@data';
 
 import { withTranslations, i18nProps } from '@lib/i18n';
-import { MultiSelect } from '@ui/components/inputs/multi-select';
 import { withOrbit } from 'react-orbitjs';
+
+import { MultiSelectEntry } from './multi-select-entry';
 
 interface INeededProps {
   organization: OrganizationResource;
@@ -19,7 +20,6 @@ interface INeededProps {
   list: ProductDefinitionResource[];
   onChangeSelection: (definition: ProductDefinitionResource) => Promise<void>;
   selectedOnly?: boolean;
-  unselectedOnly?: boolean;
 }
 
 interface IPendingUpdates {
@@ -71,7 +71,6 @@ export default compose<IProps, INeededProps>(
         emptyListLabel,
         displayProductIcon,
         selectedOnly,
-        unselectedOnly,
       } = this.props;
 
       const selectProps = {
@@ -83,10 +82,9 @@ export default compose<IProps, INeededProps>(
         t,
         onChange: this.onSelectionChange,
         selectedOnly,
-        unselectedOnly,
       };
 
-      return <MultiSelect {...selectProps} />;
+      return <MultiSelectEntry {...selectProps} />;
     }
   }
 );

--- a/source/SIL.AppBuilder.Portal.Frontend/src/ui/routes/projects/show/overview/products/selection-manager/product-selection.tsx
+++ b/source/SIL.AppBuilder.Portal.Frontend/src/ui/routes/projects/show/overview/products/selection-manager/product-selection.tsx
@@ -119,7 +119,7 @@ export default function ProductSelector(props: IProps & i18nProps) {
         closeIcon={<CloseIcon className='close-modal' />}
         onClose={toggleAddModal}
       >
-        <Modal.Header>{t('project.products.popup.title')}</Modal.Header>
+        <Modal.Header>{t('project.products.popup.addTitle')}</Modal.Header>
 
         <Modal.Content>
           <ProductDefinitionMultiSelect
@@ -128,19 +128,9 @@ export default function ProductSelector(props: IProps & i18nProps) {
             project={project}
             list={list}
             onChangeSelection={onChangeSelection}
-            unselectedOnly={true}
+            selectedOnly={false}
           />
         </Modal.Content>
-
-        <Modal.Actions>
-          <button
-            data-test-project-product-close-button
-            className='ui button huge'
-            onClick={toggleAddModal}
-          >
-            {t('project.products.popup.done')}
-          </button>
-        </Modal.Actions>
       </Modal>
       <Modal
         data-test-project-product-remove-popup
@@ -161,7 +151,7 @@ export default function ProductSelector(props: IProps & i18nProps) {
         closeIcon={<CloseIcon className='close-modal' />}
         onClose={toggleDeleteModal}
       >
-        <Modal.Header>{t('project.products.popup.title')}</Modal.Header>
+        <Modal.Header>{t('project.products.popup.removeTitle')}</Modal.Header>
 
         <Modal.Content>
           <ProductDefinitionMultiSelect
@@ -173,16 +163,6 @@ export default function ProductSelector(props: IProps & i18nProps) {
             selectedOnly={true}
           />
         </Modal.Content>
-
-        <Modal.Actions>
-          <button
-            data-test-project-product-close-button
-            className='ui button huge'
-            onClick={toggleDeleteModal}
-          >
-            {t('project.products.popup.done')}
-          </button>
-        </Modal.Actions>
       </Modal>
     </div>
   );

--- a/source/SIL.AppBuilder.Portal.Frontend/src/ui/routes/projects/show/overview/products/selection-manager/with-product-selection-state.tsx
+++ b/source/SIL.AppBuilder.Portal.Frontend/src/ui/routes/projects/show/overview/products/selection-manager/with-product-selection-state.tsx
@@ -17,8 +17,10 @@ interface INeededProps {
 
 export interface IProvidedProps {
   productSelection: {
-    isModalOpen: boolean;
-    toggleModal: () => void;
+    isAddModalOpen: boolean;
+    isDeleteModalOpen: boolean;
+    toggleAddModal: () => void;
+    toggleDeleteModal: () => void;
     storeNeededFor: ProductDefinitionResource;
     cancelStore: () => void;
     onChangeSelection: (definition: ProductDefinitionResource) => Promise<void>;
@@ -30,16 +32,23 @@ export interface IProvidedProps {
 type IProps = INeededProps & i18nProps & IDataActionsProps & WithDataProps;
 
 interface IState {
-  isModalOpen: boolean;
+  isAddModalOpen: boolean;
+  isDeleteModalOpen: boolean;
   storeNeededFor?: ProductDefinitionResource;
   storeType?: StoreTypeResource;
 }
 
 export function withProductSelectionState<TWrappedProps>(WrappedComponent) {
   return class extends React.Component<IProps & TWrappedProps, IState> {
-    state = { isModalOpen: false, storeNeededFor: undefined, storeType: undefined };
+    state = {
+      isAddModalOpen: false,
+      isDeleteModalOpen: false,
+      storeNeededFor: undefined,
+      storeType: undefined,
+    };
 
-    toggleModal = () => this.setState({ isModalOpen: !this.state.isModalOpen });
+    toggleAddModal = () => this.setState({ isAddModalOpen: !this.state.isAddModalOpen });
+    toggleDeleteModal = () => this.setState({ isDeleteModalOpen: !this.state.isDeleteModalOpen });
     showToast = () => toast.warning(this.props.t('project.products.creationInProgress'));
 
     handleProductAdd = async (definition: ProductDefinitionResource) => {
@@ -57,7 +66,6 @@ export function withProductSelectionState<TWrappedProps>(WrappedComponent) {
       if (!storeType) {
         return await this.updateProduct(definition);
       }
-
       this.setState({ storeNeededFor: definition, storeType });
     };
 
@@ -77,11 +85,9 @@ export function withProductSelectionState<TWrappedProps>(WrappedComponent) {
       const { productForProductDefinition } = this.props;
 
       const product = productForProductDefinition(definition);
-
       if (product) {
         return await this.updateProduct(definition);
       }
-
       return await this.handleProductAdd(definition);
     };
 
@@ -90,13 +96,15 @@ export function withProductSelectionState<TWrappedProps>(WrappedComponent) {
     };
 
     render() {
-      const { isModalOpen, storeNeededFor, storeType } = this.state;
+      const { isAddModalOpen, isDeleteModalOpen, storeNeededFor, storeType } = this.state;
 
       const props = {
         ...this.props,
         productSelection: {
-          isModalOpen,
-          toggleModal: this.toggleModal,
+          isAddModalOpen,
+          isDeleteModalOpen,
+          toggleAddModal: this.toggleAddModal,
+          toggleDeleteModal: this.toggleDeleteModal,
           onChangeSelection: this.onChangeSelection,
           storeNeededFor,
           onStoreSelect: this.updateProduct,


### PR DESCRIPTION
This pull request separates the add remove product button into two separate add and remove buttons.  Pressing add shows only the products to be added which are removed from the list as they are added.  Pressing remove shows only the existing products and removes them from the list as they are deselected.  This PR also fixes issues where the underlying list on the project screen was not updated when products were added and deleted.
Project screen:
<img width="1182" alt="Screen Shot 2020-01-10 at 10 46 12 AM" src="https://user-images.githubusercontent.com/6209188/72166246-e3e88980-3396-11ea-8db7-9bf0327d7a2b.png">
Remove product popup:
<img width="917" alt="Screen Shot 2020-01-10 at 10 46 51 AM" src="https://user-images.githubusercontent.com/6209188/72166315-fcf13a80-3396-11ea-9752-4a3114d5ac6f.png">
Add product popup:
<img width="883" alt="Screen Shot 2020-01-10 at 10 46 40 AM" src="https://user-images.githubusercontent.com/6209188/72166251-e77c1080-3396-11ea-930e-ec8fcb8dd819.png">

