### PR TITLE
Subscribe to product transitions instead of user tasks

### DIFF
--- a/source/SIL.AppBuilder.Portal.Frontend/src/data/schema.ts
+++ b/source/SIL.AppBuilder.Portal.Frontend/src/data/schema.ts
@@ -200,6 +200,25 @@ const schemaDefinition: SchemaSettings = {
         productActions: { type: 'hasOne', model: 'productAction', inverse: 'products' },
         productWorkflow: { type: 'hasOne', model: 'productWorkflow', inverse: 'products' },
         productPublications: { type: 'hasMany', model: 'productPublication', inverse: 'product' },
+        productTransitions: { type: 'hasMany', model: 'productTransition', inverse: 'product' },
+      },
+    },
+    productTransition: {
+      keys: { remoteId: {} },
+      attributes: {
+        allowedUserNames: { type: 'string' },
+        command: { type: 'string' },
+        comment: { type: 'string' },
+        dateStarted: { type: 'string' },
+        dateTransition: { type: 'string' },
+        destinationState: { type: 'string' },
+        initialState: { type: 'string' },
+        transitionType: { type: 'number' },
+        workflowType: { type: 'string' },
+        workflowUserId: { type: 'string' },
+      },
+      relationships: {
+        product: { type: 'hasOne', model: 'product', inverse: 'productTransitions' },
       },
     },
     productAction: {

--- a/source/SIL.AppBuilder.Portal.Frontend/src/ui/routes/projects/show/overview/products/item/tasks/with-data.tsx
+++ b/source/SIL.AppBuilder.Portal.Frontend/src/ui/routes/projects/show/overview/products/item/tasks/with-data.tsx
@@ -1,8 +1,6 @@
-import { useState, useCallback } from 'react';
-import { useOrbit } from 'react-orbitjs';
-import { uniqBy } from 'lodash';
+import { useOrbit, useCache } from 'react-orbitjs';
 
-import { ProductResource, TaskResource, idFromRecordIdentity } from '~/data';
+import { ProductResource, TaskResource } from '~/data';
 
 import { useCurrentUser } from '~/data/containers/with-current-user';
 
@@ -17,54 +15,17 @@ interface INeededProps {
 export function useCurrentUserTask({ product }: INeededProps): IProvidedDataProps {
   const { currentUser } = useCurrentUser();
   const { dataStore } = useOrbit();
-  const [foundCurrentUser, setFoundCurrentUser] = useState();
-  const [workTask, setWorkTask] = useState();
 
-  // Get current user task is a hook function called by UseMemo
-  const getCurrentUserTask = useCallback(() => {
-    let tasks = [];
-    try {
-      let localWorkTask = null;
-      let localFoundCurrentUser = false;
-      tasks = dataStore.cache.query((q) =>
-        q.findRecords('userTask').filter({ relation: 'product', record: product })
-      );
-      // for some reason the backend is sending task creations to the frontend qucik
-      // enough where the key-checking mechanisms hasn't yet added the first task,
-      // so a subsequent task will become a duplicate because both received tasks
-      // have yet to be added to the local cache.
-      tasks = uniqBy(tasks, (task) => (task.keys || {}).remoteId);
-      {
-        tasks.map((task) => {
-          const user = dataStore.cache.query((q) => q.findRelatedRecord(task, 'user'));
-          const taskUserId = idFromRecordIdentity(user as any);
-          const currentUserId = idFromRecordIdentity(currentUser as any);
-          if (taskUserId === currentUserId) {
-            localFoundCurrentUser = true;
-            localWorkTask = task;
-          } else if (!localWorkTask) {
-            // If there isn't a return task set, set it to this entry so that an elapsed time
-            // can be calculated, even if there isn't one for the current user.
-            localWorkTask = task;
-          }
-        });
-      }
-      if (localFoundCurrentUser != foundCurrentUser) {
-        setFoundCurrentUser(localFoundCurrentUser);
-      }
-      if (localWorkTask != workTask) {
-        setWorkTask(localWorkTask);
-      }
-    } catch (e) {
-      console.debug(
-        'error occurred',
-        e,
-        'we probably need to PR to orbit.js, as this is a race condition scenario that causes the error',
-        'variables that are in use that may be related to this error: ',
-        ['product: ', product, 'currentUser: ', currentUser]
-      );
-    }
-  }, [dataStore.cache, product, currentUser, workTask]);
-  getCurrentUserTask();
-  return { foundCurrentUser, workTask };
+  const {
+    subscriptions: { tasks },
+  } = useCache({
+    tasks: (q) => q.findRelatedRecords({ type: 'product', id: product.id }, 'tasks'),
+  });
+
+  const foundCurrentUser = tasks.some((task) => {
+    const user = dataStore.cache.query((q) => q.findRelatedRecord(task, 'user'));
+    return user.id === currentUser.id;
+  });
+
+  return { foundCurrentUser, workTask: tasks.slice(-1)[0] };
 }


### PR DESCRIPTION
Subscribing to the transitions ensures we're always showing the correct transition, however there are still some unnecessary refreshes when a new transition comes through that doesn't actually update the display. The `continue` button also needs to be fixed.
![scrot](https://user-images.githubusercontent.com/3629343/101189520-cbbbd180-361c-11eb-8f72-98eff22118dd.gif)
