### PR TITLE
Fix error when rendering task without product

### DIFF
--- a/source/SIL.AppBuilder.Portal.Frontend/src/ui/routes/tasks/row.tsx
+++ b/source/SIL.AppBuilder.Portal.Frontend/src/ui/routes/tasks/row.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { compose } from 'recompose';
+import { compose, branch, renderNothing } from 'recompose';
 import { withRouter, RouteComponentProps } from 'react-router-dom';
 import { Label } from 'semantic-ui-react';
 import { withData as withOrbit } from 'react-orbitjs';
@@ -114,12 +114,11 @@ class TaskRow extends React.Component<IProps> {
 export default compose<INeededProps, IProps>(
   withTranslations,
   withRouter,
-  withOrbit(({ userTask }) => {
-    return {
-      product: (q) => q.findRelatedRecord(userTask, 'product'),
-      assignedTo: (q) => q.findRelatedRecord(userTask, 'user'),
-    };
-  }),
+  withOrbit(({ userTask }) => ({
+    product: (q) => q.findRelatedRecord(userTask, 'product'),
+    assignedTo: (q) => q.findRelatedRecord(userTask, 'user'),
+  })),
+  branch(({ product }) => !product, renderNothing),
   withOrbit(({ product }) => ({
     project: (q) => q.findRelatedRecord(product, 'project'),
     productDefinition: (q) => q.findRelatedRecord(product, 'productDefinition'),


### PR DESCRIPTION
Prevent the task row from rendering if the task is missing a product
in order to avoid `Cannot read property 'type' of null` error being
thrown by Orbit queries.

It looks like a task removal event isn't being sent by the server in addition to the product removal event, and it's nontrivial to cascade the product removal to remove related tasks as well.

![scrot](https://user-images.githubusercontent.com/3629343/101391975-bd72ed00-388a-11eb-9e4f-b94bc54f9adc.gif)

Previous error:
![image](https://user-images.githubusercontent.com/3629343/101391686-50f7ee00-388a-11eb-92fc-19ad9692ec65.png)
