### PR TITLE
Fix project ownership change subscription

### DIFF
--- a/source/SIL.AppBuilder.Portal.Frontend/src/ui/routes/projects/show/with-data.tsx
+++ b/source/SIL.AppBuilder.Portal.Frontend/src/ui/routes/projects/show/with-data.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { useQuery } from 'react-orbitjs';
+import { useQuery, useCache } from 'react-orbitjs';
 
 import { buildFindRecord, buildOptions } from '@data';
 
@@ -8,6 +8,8 @@ import { PageLoader } from '~/ui/components/loaders';
 import { PageError } from '~/ui/components/errors';
 
 import { useRouter } from '~/lib/hooks';
+
+import { keyMap } from '~/data/schema';
 
 export function withData(WrappedComponent) {
   return function ProjectDataFetcher(props) {
@@ -41,6 +43,16 @@ export function withData(WrappedComponent) {
           ],
         }),
       ],
+    });
+
+    useCache({
+      ...(project && {
+        project: (q) =>
+          q.findRecord({
+            type: 'project',
+            id: keyMap.keyToId('project', 'remoteId', id),
+          }),
+      }),
     });
 
     if (error) return <PageError error={error} />;


### PR DESCRIPTION
This will cause the `useQuery` hook to always have the latest data that's in the Orbit cache.

Claiming Ownership
![claim-ownership](https://user-images.githubusercontent.com/3629343/101548950-67797480-3972-11eb-8780-26e8013166cd.gif)

Changing Ownership
![change-ownership](https://user-images.githubusercontent.com/3629343/101548955-68120b00-3972-11eb-886c-0c7dd1b96bb4.gif)