### PR TITLE
fix error when product no longer exists

### DIFF
--- a/source/SIL.AppBuilder.Portal.Frontend/src/data/containers/resources/project/with-data-actions.tsx
+++ b/source/SIL.AppBuilder.Portal.Frontend/src/data/containers/resources/project/with-data-actions.tsx
@@ -212,13 +212,27 @@ export function withDataActions<T>(WrappedComponent) {
   }
 
   return compose(
-    withOrbit((passedProps) => {
-      const { project } = passedProps;
-
-      return {
-        products: (q) => q.findRecords('product').filter({ relation: 'project', record: project }),
-      };
-    }),
+    withOrbit((passedProps) => ({
+      products: (q) => q.findRecords('product'),
+    })),
+    (component) => (props) => {
+      return component({
+        ...props,
+        products: props.products.filter((product) => {
+          if (
+            product.relationships.project &&
+            'data' in product.relationships.project &&
+            product.relationships.project.data &&
+            'id' in product.relationships.project.data &&
+            product.relationships.project.data.id === props.project.id
+          ) {
+            return true;
+          } else {
+            return false;
+          }
+        }),
+      });
+    },
     requireProps('project')
   )(ProjectDataActionWrapper);
 }

--- a/source/SIL.AppBuilder.Portal.Frontend/src/ui/routes/projects/show/overview/products/index.tsx
+++ b/source/SIL.AppBuilder.Portal.Frontend/src/ui/routes/projects/show/overview/products/index.tsx
@@ -18,7 +18,7 @@ interface IProps {
 }
 
 interface ISubscriptions {
-  products: ProductResource[];
+  _products: ProductResource[];
   organization: OrganizationResource;
 }
 
@@ -26,13 +26,27 @@ export default function Products({ project }: IProps) {
   const { t } = useTranslations();
   const {
     dataStore,
-    subscriptions: { products, organization },
+    subscriptions: { _products, organization },
   } = useOrbit<ISubscriptions>({
-    products: (q) => q.findRecords('product').filter({ relation: 'project', record: project }),
+    _products: (q) => q.findRecords('product'),
     organization: (q) => q.findRelatedRecord(project, 'organization'),
     // cache busters
     userTasks: (q) => q.findRecords('userTask'),
     project: (q) => q.findRecord(project),
+  });
+
+  const products = _products.filter((product) => {
+    if (
+      product.relationships.project &&
+      'data' in product.relationships.project &&
+      product.relationships.project.data &&
+      'id' in product.relationships.project.data &&
+      product.relationships.project.data.id === project.id
+    ) {
+      return true;
+    } else {
+      return false;
+    }
   });
 
   useLiveData(`projects/${idFromRecordIdentity(dataStore, project)}`);

--- a/source/SIL.AppBuilder.Portal.Frontend/src/ui/routes/projects/show/overview/products/item/tasks/index.tsx
+++ b/source/SIL.AppBuilder.Portal.Frontend/src/ui/routes/projects/show/overview/products/item/tasks/index.tsx
@@ -58,6 +58,10 @@ export default function ProductTasksForCurrentUser({ product }: IProps) {
           Expires: 0,
         },
       });
+      if (response.status === 404) {
+        setTransition(null);
+        return;
+      }
       try {
         let json = await handleResponse(response, t);
         setTransition(json.data);

--- a/source/SIL.AppBuilder.Portal.Frontend/src/ui/routes/tasks/row.tsx
+++ b/source/SIL.AppBuilder.Portal.Frontend/src/ui/routes/tasks/row.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { compose } from 'recompose';
+import { compose, branch, renderNothing } from 'recompose';
 import { withRouter, RouteComponentProps } from 'react-router-dom';
 import { Label } from 'semantic-ui-react';
 import { withData as withOrbit } from 'react-orbitjs';
@@ -114,16 +114,16 @@ class TaskRow extends React.Component<IProps> {
 export default compose<INeededProps, IProps>(
   withTranslations,
   withRouter,
-  withOrbit(({ userTask }) => {
-    return {
-      product: (q) => q.findRelatedRecord(userTask, 'product'),
-      assignedTo: (q) => q.findRelatedRecord(userTask, 'user'),
-    };
-  }),
+  withOrbit(({ userTask }) => ({
+    product: (q) => q.findRelatedRecord(userTask, 'product'),
+    assignedTo: (q) => q.findRelatedRecord(userTask, 'user'),
+  })),
+  branch(({ product }) => !product, renderNothing),
   withOrbit(({ product }) => ({
     project: (q) => q.findRelatedRecord(product, 'project'),
     productDefinition: (q) => q.findRelatedRecord(product, 'productDefinition'),
   })),
+  branch(({ project }) => !project, renderNothing),
   withOrbit(({ productDefinition }) => ({
     workflow: (q) => q.findRelatedRecord(productDefinition, 'workflow'),
   }))


### PR DESCRIPTION
This PR resolves errors (`Cannot read property 'type' of null` specifically) when a product is deleted from the database without being removed from the Orbit cache. This was tested manually be deleting the product from the `Products` table manually, however I believe it occurs in the wild due to websocket failures which result in the product removal not being sent to the client.

Due to a bug in OrbitJS, the project display screen would request the project as well as its associated products. Because the product no longer exists, it would update (not delete) the product entity which no longer exists in the database to have a relationship to a project of `null` which would result in the error. This is bypassed filtering the products outside of Orbit.

Once the product has been deleted, there are several requests that will 404 and fail to parse as JSON. These 404 responses will now gracefully fail without a JSON parse error.