### PR TITLE
Fix UserSelect when user not in group or org

### DIFF
--- a/source/SIL.AppBuilder.Portal.Frontend/src/ui/components/inputs/user-select/with-data.tsx
+++ b/source/SIL.AppBuilder.Portal.Frontend/src/ui/components/inputs/user-select/with-data.tsx
@@ -66,7 +66,7 @@ export function withData(WrappedComponent) {
     const isOwnerInList = filtered.find((user) => user.id === selected);
 
     if (!isOwnerInList) {
-      const owner = filtered.find((user) => user.id === selected);
+      const owner = users.find((user) => user.id === selected);
 
       if (owner) {
         filtered.push(owner);


### PR DESCRIPTION
There was code in the UserSelect so that if the user was somehow not in
the group or organization, the user would still be listed so that it
could be changed.