### PR TITLE
Fix scrolling issues on group, project and author dropdowns and on sidebar

### DIFF
--- a/source/SIL.AppBuilder.Portal.Frontend/src/ui/components/inputs/author-select/display.tsx
+++ b/source/SIL.AppBuilder.Portal.Frontend/src/ui/components/inputs/author-select/display.tsx
@@ -38,6 +38,7 @@ export default class AuthorSelectDisplay extends React.Component<IProps> {
       <Dropdown
         data-test-user-select
         disabled={disableSelection || false}
+        scrolling
         options={userOptions}
         value={selected}
         onChange={this.onSelect}

--- a/source/SIL.AppBuilder.Portal.Frontend/src/ui/components/inputs/group-select/display.tsx
+++ b/source/SIL.AppBuilder.Portal.Frontend/src/ui/components/inputs/group-select/display.tsx
@@ -32,6 +32,7 @@ export default function GroupSelectDisplay({
     <Dropdown
       data-test-group-select
       disabled={disableSelection || false}
+      scrolling
       options={groupOptions}
       value={selected}
       onChange={onSelect}

--- a/source/SIL.AppBuilder.Portal.Frontend/src/ui/components/inputs/user-select/display.tsx
+++ b/source/SIL.AppBuilder.Portal.Frontend/src/ui/components/inputs/user-select/display.tsx
@@ -38,6 +38,7 @@ export default class UserSelectDisplay extends React.Component<IProps> {
       <Dropdown
         data-test-user-select
         disabled={disableSelection || false}
+        scrolling
         options={userOptions}
         value={selected}
         onChange={this.onSelect}

--- a/source/SIL.AppBuilder.Portal.Frontend/src/ui/components/sidebar/index.tsx
+++ b/source/SIL.AppBuilder.Portal.Frontend/src/ui/components/sidebar/index.tsx
@@ -18,7 +18,7 @@ export default function Sidebar({ closeSidebar, className }: IProps) {
   return (
     <div
       data-test-sidebar
-      className={`sidebar bg-white border-right-dark border-top-dark ${className}`}
+      className={`sidebar bg-white border-right-dark overflows border-top-dark ${className}`}
     >
       <Header
         closeSidebar={closeSidebar}

--- a/source/SIL.AppBuilder.Portal.Frontend/src/ui/components/sidebar/org-switcher/display.tsx
+++ b/source/SIL.AppBuilder.Portal.Frontend/src/ui/components/sidebar/org-switcher/display.tsx
@@ -49,13 +49,7 @@ export default function OrgSwitcherDisplay(props: IProps) {
   const noResults = !results || results.length === 0;
 
   return (
-    <Menu
-      data-test-org-switcher
-      className='m-t-none no-borders h-100 overflows'
-      pointing
-      secondary
-      vertical
-    >
+    <Menu data-test-org-switcher className='m-t-none no-borders h-100' pointing secondary vertical>
       {showSearch && (
         <Menu.Item
           data-test-org-switcher-search


### PR DESCRIPTION
Scrolling option causes scrollbar to appear when the number of items in the dropdown requires it