### PR TITLE
Add Product Publishing Properties

### DIFF
--- a/source/OptimaJet.DWKit.StarterApplication/Migrations/20221031142542_AddProductProperties.Designer.cs
+++ b/source/OptimaJet.DWKit.StarterApplication/Migrations/20221031142542_AddProductProperties.Designer.cs
@@ -2,6 +2,7 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using OptimaJet.DWKit.StarterApplication.Data;
@@ -10,9 +11,10 @@ using OptimaJet.DWKit.StarterApplication.Models;
 namespace OptimaJet.DWKit.StarterApplication.Migrations
 {
     [DbContext(typeof(AppDbContext))]
-    partial class AppDbContextModelSnapshot : ModelSnapshot
+    [Migration("20221031142542_AddProductProperties")]
+    partial class AddProductProperties
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/source/OptimaJet.DWKit.StarterApplication/Migrations/20221031142542_AddProductProperties.cs
+++ b/source/OptimaJet.DWKit.StarterApplication/Migrations/20221031142542_AddProductProperties.cs
@@ -1,0 +1,22 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+namespace OptimaJet.DWKit.StarterApplication.Migrations
+{
+    public partial class AddProductProperties : Migration
+    {
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<string>(
+                name: "Properties",
+                table: "Products",
+                nullable: true);
+        }
+
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "Properties",
+                table: "Products");
+        }
+    }
+}

--- a/source/OptimaJet.DWKit.StarterApplication/Models/Product.cs
+++ b/source/OptimaJet.DWKit.StarterApplication/Models/Product.cs
@@ -64,5 +64,8 @@ namespace OptimaJet.DWKit.StarterApplication.Models
 
         [HasMany("product-publications", Link.None)]
         public virtual List<ProductPublication> ProductPublications { get; set; }
+
+        [Attr("properties")]
+        public string Properties { get; set; }
     }
 }

--- a/source/OptimaJet.DWKit.StarterApplication/Services/BuildEngine/BuildEngineServiceBase.cs
+++ b/source/OptimaJet.DWKit.StarterApplication/Services/BuildEngine/BuildEngineServiceBase.cs
@@ -6,6 +6,7 @@ using Microsoft.EntityFrameworkCore;
 using Newtonsoft.Json.Linq;
 using OptimaJet.DWKit.StarterApplication.Models;
 using OptimaJet.DWKit.StarterApplication.Repositories;
+using OptimaJet.DWKit.StarterApplication.Utility;
 using SIL.AppBuilder.BuildEngineApiClient;
 using static OptimaJet.DWKit.StarterApplication.Utility.EnvironmentHelpers;
 
@@ -131,6 +132,16 @@ namespace OptimaJet.DWKit.StarterApplication.Services.BuildEngine
             environment["PROJECT_ORGANIZATION"] = product.Project.Organization.Name;
             environment["PROJECT_OWNER_NAME"] = product.Project.Owner.Name;
             environment["PROJECT_OWNER_EMAIL"] = product.Project.Owner.Email;
+
+            if (!string.IsNullOrEmpty(product.Properties))
+            {
+                var productProperties = JsonUtils.DeserializeProperties(product.Properties);
+                var productEnv = GetEnvironment(productProperties);
+                foreach(var kv in productEnv)
+                {
+                    environment[kv.Key] = kv.Value;
+                }
+            }
 
         }
         protected static Dictionary<string, string> GetEnvironment(Dictionary<string, object> paramsDict)

--- a/source/SIL.AppBuilder.Portal.Frontend/src/data/containers/resources/product/with-data-action.tsx
+++ b/source/SIL.AppBuilder.Portal.Frontend/src/data/containers/resources/product/with-data-action.tsx
@@ -1,6 +1,7 @@
 import { useOrbit } from 'react-orbitjs/dist';
 
 import { defaultOptions } from '@data';
+
 import { ProductAttributes } from '~/data/models/product';
 
 export function useDataActions(product) {

--- a/source/SIL.AppBuilder.Portal.Frontend/src/data/containers/resources/product/with-data-action.tsx
+++ b/source/SIL.AppBuilder.Portal.Frontend/src/data/containers/resources/product/with-data-action.tsx
@@ -1,0 +1,31 @@
+import { useOrbit } from 'react-orbitjs/dist';
+
+import { defaultOptions } from '@data';
+import { ProductAttributes } from '~/data/models/product';
+
+export function useDataActions(product) {
+  const { dataStore } = useOrbit();
+
+  const updateAttribute = async (attribute: string, value: any) => {
+    await dataStore.update((q) => q.replaceAttribute(product, attribute, value), defaultOptions());
+  };
+
+  const updateAttributes = async (attributes: ProductAttributes) => {
+    const { id, type } = product;
+
+    return dataStore.update(
+      (q) =>
+        q.replaceRecord({
+          id,
+          type,
+          attributes,
+        }),
+      defaultOptions()
+    );
+  };
+
+  return {
+    updateAttributes,
+    updateAttribute,
+  };
+}

--- a/source/SIL.AppBuilder.Portal.Frontend/src/data/models/product.ts
+++ b/source/SIL.AppBuilder.Portal.Frontend/src/data/models/product.ts
@@ -11,6 +11,7 @@ export interface ProductAttributes extends AttributesObject {
   dateBuilt: string;
   versionBuilt: string;
   publishLink: string;
+  properties: string;
 }
 
 export type ProductResource = ResourceObject<PRODUCTS_TYPE, ProductAttributes>;

--- a/source/SIL.AppBuilder.Portal.Frontend/src/data/schema.ts
+++ b/source/SIL.AppBuilder.Portal.Frontend/src/data/schema.ts
@@ -189,6 +189,7 @@ const schemaDefinition: SchemaSettings = {
         dateBuilt: { type: 'string' },
         versionBuilt: { type: 'string' },
         publishLink: { type: 'string' },
+        properties: { type: 'string' },
       },
       relationships: {
         project: { type: 'hasOne', model: 'project', inverse: 'products' },

--- a/source/SIL.AppBuilder.Portal.Frontend/src/translations/locales/en-us.json
+++ b/source/SIL.AppBuilder.Portal.Frontend/src/translations/locales/en-us.json
@@ -48,7 +48,8 @@
     "updated": "Updated",
     "continue": "Continue",
     "error": "Error",
-    "workflow": "Workflow"
+    "workflow": "Workflow",
+    "default": "Default"
   },
   "models": {
     "add": "Add {name}",
@@ -148,7 +149,8 @@
       "cancel": "Cancel",
       "noneAvailable": "No actions are currently available for this product.",
       "bulkNotAllAllowed": "Not all of the selected projects' products can have the {action} action(s) applied.",
-      "dispatched": "The {action} action has been dispatched."
+      "dispatched": "The {action} action has been dispatched.",
+      "properties": "Properties"
     }
   },
   "profile": {
@@ -291,7 +293,8 @@
         "removeTitle": "Select Product to Remove",
         "done": "Done",
         "empty": "No products available",
-        "details": "Details"
+        "details": "Details",
+        "properties": "Publishing Properties"
       },
       "publications": {
         "channel": "Channel",
@@ -321,6 +324,13 @@
           "4": "{workflowType} Workflow Cancelled",
           "5": "{workflowType} Project Access"
         }
+      },
+      "properties": {
+        "computeType": "Compute Type",
+        "selectComputeType": "Select compute type",
+        "small": "Small",
+        "medium": "Medium",
+        "title": "Product Publishing Properties"
       },
       "updated": "Updated",
       "size": "Size",
@@ -356,11 +366,11 @@
         "title": "Authors",
         "add": "add author",
         "close": "close",
-	"form": {
-	  "user": "user",
-	  "userError": "User cannot be empty",
-	  "submit": "Add Author"
-	}
+        "form": {
+          "user": "user",
+          "userError": "User cannot be empty",
+          "submit": "Add Author"
+        }
       },
       "reviewers": {
         "title": "Reviewers",
@@ -583,6 +593,6 @@
     "publish-failed": "Publish failed"
   },
   "downloads": {
-    "title" : "Downloads"
+    "title": "Downloads"
   }
 }

--- a/source/SIL.AppBuilder.Portal.Frontend/src/ui/components/product-artifact/actions.tsx
+++ b/source/SIL.AppBuilder.Portal.Frontend/src/ui/components/product-artifact/actions.tsx
@@ -10,12 +10,15 @@ import { useLiveData } from '~/data/live';
 import { handleResponse } from '~/data/containers/with-current-user/fetcher';
 
 import TransitionDetails from '@ui/components/product-transitions/details';
+import ProductProperties from '@ui/components/product-properties';
 
 import { put, get } from '~/lib/fetch';
 
 import * as toast from '~/lib/toast';
 
 import { preventDefault } from '~/lib/dom';
+import { ROLE } from '@data/models/role';
+import { RequireRole } from '@ui/components/authorization';
 
 export default function ItemActions({ product }) {
   const { t } = useTranslations();
@@ -96,6 +99,9 @@ export default function ItemActions({ product }) {
           );
         })}
         <TransitionDetails product={product} />
+        <RequireRole roleName={ROLE.OrganizationAdmin}>
+          <ProductProperties text='Foobar' product={product} />
+        </RequireRole>
       </Dropdown.Menu>
     </Dropdown>
   );

--- a/source/SIL.AppBuilder.Portal.Frontend/src/ui/components/product-artifact/actions.tsx
+++ b/source/SIL.AppBuilder.Portal.Frontend/src/ui/components/product-artifact/actions.tsx
@@ -100,7 +100,7 @@ export default function ItemActions({ product }) {
         })}
         <TransitionDetails product={product} />
         <RequireRole roleName={ROLE.OrganizationAdmin}>
-          <ProductProperties text='Foobar' product={product} />
+          <ProductProperties product={product} />
         </RequireRole>
       </Dropdown.Menu>
     </Dropdown>

--- a/source/SIL.AppBuilder.Portal.Frontend/src/ui/components/product-artifact/actions.tsx
+++ b/source/SIL.AppBuilder.Portal.Frontend/src/ui/components/product-artifact/actions.tsx
@@ -17,6 +17,7 @@ import { put, get } from '~/lib/fetch';
 import * as toast from '~/lib/toast';
 
 import { preventDefault } from '~/lib/dom';
+
 import { ROLE } from '@data/models/role';
 import { RequireRole } from '@ui/components/authorization';
 

--- a/source/SIL.AppBuilder.Portal.Frontend/src/ui/components/product-properties/index.tsx
+++ b/source/SIL.AppBuilder.Portal.Frontend/src/ui/components/product-properties/index.tsx
@@ -2,7 +2,9 @@ import React, { useCallback, useEffect, useState } from 'react';
 import { Dropdown, Modal, Form } from 'semantic-ui-react';
 
 import { ProductResource, attributesFor } from '~/data';
+
 import { useTranslations } from '~/lib/i18n';
+
 import CloseIcon from '@material-ui/icons/Close';
 import { useDataActions } from '@data/containers/resources/product/with-data-action';
 import * as toast from '@lib/toast';

--- a/source/SIL.AppBuilder.Portal.Frontend/src/ui/components/product-properties/index.tsx
+++ b/source/SIL.AppBuilder.Portal.Frontend/src/ui/components/product-properties/index.tsx
@@ -1,0 +1,150 @@
+import React, { useCallback, useEffect, useState } from 'react';
+import { Dropdown, Modal, Form } from 'semantic-ui-react';
+
+import { ProductResource, attributesFor } from '~/data';
+import { useTranslations } from '~/lib/i18n';
+import CloseIcon from '@material-ui/icons/Close';
+import { useDataActions } from '@data/containers/resources/product/with-data-action';
+import * as toast from '@lib/toast';
+
+export interface IProps {
+  product: ProductResource;
+}
+
+const defaultProperties = `{
+  "environment": {
+      "BUILD_COMPUTE_TYPE": "small",
+      "BUILD_IMAGE_TAG": "latest"
+  }
+}`;
+
+export default function ProductProperties({ product }: IProps) {
+  const { t } = useTranslations();
+  const { updateAttribute } = useDataActions(product);
+  const [properties, setProperties] = useState('');
+  const [computeType, setComputeType] = useState('');
+  const [open, setOpen] = useState(false);
+
+  function resetState() {
+    const attributes = attributesFor(product);
+    const currentProperties = attributes.properties;
+    setProperties(currentProperties);
+    setComputeType(getComputeTypeFromProperties(currentProperties));
+  }
+
+  useEffect(() => {
+    resetState();
+  }, []);
+
+  function getComputeTypeFromProperties(properties) {
+    let computeType = '';
+    if (properties) {
+      const json = JSON.parse(properties);
+      computeType = json['environment']['BUILD_COMPUTE_TYPE'];
+    }
+    return computeType;
+  }
+
+  function setDefaultProperties() {
+    setProperties(defaultProperties);
+  }
+
+  const onSubmit = useCallback(async () => {
+    try {
+      await updateAttribute('properties', properties);
+      setOpen(false);
+    } catch (e) {
+      toast.error(e);
+    }
+  }, [properties, updateAttribute]);
+
+  const onCancel = () => {
+    resetState();
+    setOpen(false);
+  };
+
+  const computeOptions = [
+    { key: 's', text: t('project.products.properties.small'), value: 'small' },
+    { key: 'm', text: t('project.products.properties.medium'), value: 'medium' },
+  ];
+
+  const changeCompute = useCallback(
+    (_, { value }) => {
+      setComputeType(value);
+      const newProperties = properties || defaultProperties;
+      const json = JSON.parse(newProperties);
+      json['environment']['BUILD_COMPUTE_TYPE'] = value;
+      setProperties(JSON.stringify(json, null, 4));
+    },
+    [properties]
+  );
+
+  function changeProperties(event) {
+    setProperties(event.target.value);
+  }
+
+  return (
+    <Modal
+      data-test-product-properties-modal
+      onClose={() => setOpen(false)}
+      onOpen={() => setOpen(true)}
+      open={open}
+      trigger={
+        <Dropdown.Item
+          data-test-product-properties-button
+          key='Properties'
+          text={t('project.products.popup.properties')}
+        />
+      }
+      closeIcon={<CloseIcon data-test-product-properties-close className='close-modal' />}
+      className='medium'
+    >
+      <Modal.Header>{t('project.products.properties.title')}</Modal.Header>
+      <Modal.Content>
+        <Form className='w-100'>
+          <Form.Select
+            fluid
+            data-test-
+            label={t('project.products.properties.computeType')}
+            placeholder={t('project.products.properties.selectComputeType')}
+            options={computeOptions}
+            value={computeType}
+            onChange={changeCompute}
+          />
+          <Form.Field className='flex-100'>
+            <textarea
+              data-test-properties
+              value={properties}
+              onChange={changeProperties}
+              className='flex-100'
+            ></textarea>
+          </Form.Field>
+        </Form>
+        <div className='m-b-xl'>
+          <button
+            data-test-pp-default
+            className='ui button p-t-md p-b-md p-l-lg p-r-lg'
+            onClick={setDefaultProperties}
+          >
+            {t('common.default')}
+          </button>
+          <button
+            data-test-wf-submit
+            className='ui button p-t-md p-b-md p-l-lg p-r-lg'
+            onClick={onSubmit}
+          >
+            {t('common.save')}
+          </button>
+
+          <button
+            data-test-wf-cancel
+            className='ui button p-t-md p-b-md p-l-lg p-r-lg'
+            onClick={onCancel}
+          >
+            {t('common.cancel')}
+          </button>
+        </div>
+      </Modal.Content>
+    </Modal>
+  );
+}


### PR DESCRIPTION
There are builds that use too much memory for the default compute type (small -- 3GB).  We need to override the compute type before the build begins.  So we need a publishing property that is set per product but not in the publishing properties that are in the project. We could have duplicated the ProductDefinition or WorkflowDefinition, but that would bring confusion to those definitions and we would have to remove a product and re-add it with a different definition. 

So we decided to be able to add publishing properties to a product in the list of products for a project. For now, the menu item is available for Org Admins and Super Admins.

![image](https://user-images.githubusercontent.com/517814/207416153-e011e189-e6d3-4b33-a5b2-ef53cb984145.png)

The new dialog has a dropdown for Compute Type

![image](https://user-images.githubusercontent.com/517814/207416465-de4c1a46-f104-4e5e-8c36-09b8e3717911.png)

 to make it easy for the Admin to enter the correct publishing property name and value.

![image](https://user-images.githubusercontent.com/517814/207416605-80f94558-f29e-4c40-aa01-22d6628789c6.png)

As part of this change, I also enabled the ability to set the image (version) to use with the build. We only support the number of docker images that we keep (currently 3).


