### PR TITLE
Add migration for handling DateCreated field

### DIFF
--- a/source/SIL.AppBuilder.Portal/common/prisma/migrations/2_prisma_auto_date/migration.sql
+++ b/source/SIL.AppBuilder.Portal/common/prisma/migrations/2_prisma_auto_date/migration.sql
@@ -1,0 +1,35 @@
+-- AlterTable
+ALTER TABLE "Notifications" ALTER COLUMN "DateCreated" SET DEFAULT CURRENT_TIMESTAMP;
+
+-- AlterTable
+ALTER TABLE "OrganizationInviteRequests" ALTER COLUMN "DateCreated" SET DEFAULT CURRENT_TIMESTAMP;
+
+-- AlterTable
+ALTER TABLE "OrganizationMembershipInvites" ALTER COLUMN "DateCreated" SET DEFAULT CURRENT_TIMESTAMP;
+
+-- AlterTable
+ALTER TABLE "ProductArtifacts" ALTER COLUMN "DateCreated" SET DEFAULT CURRENT_TIMESTAMP;
+
+-- AlterTable
+ALTER TABLE "ProductBuilds" ALTER COLUMN "DateCreated" SET DEFAULT CURRENT_TIMESTAMP;
+
+-- AlterTable
+ALTER TABLE "ProductPublications" ALTER COLUMN "DateCreated" SET DEFAULT CURRENT_TIMESTAMP;
+
+-- AlterTable
+ALTER TABLE "Products" ALTER COLUMN "DateCreated" SET DEFAULT CURRENT_TIMESTAMP;
+
+-- AlterTable
+ALTER TABLE "ProjectImports" ALTER COLUMN "DateCreated" SET DEFAULT CURRENT_TIMESTAMP;
+
+-- AlterTable
+ALTER TABLE "Projects" ALTER COLUMN "DateCreated" SET DEFAULT CURRENT_TIMESTAMP;
+
+-- AlterTable
+ALTER TABLE "SystemStatuses" ALTER COLUMN "DateCreated" SET DEFAULT CURRENT_TIMESTAMP;
+
+-- AlterTable
+ALTER TABLE "UserTasks" ALTER COLUMN "DateCreated" SET DEFAULT CURRENT_TIMESTAMP;
+
+-- AlterTable
+ALTER TABLE "Users" ALTER COLUMN "DateCreated" SET DEFAULT CURRENT_TIMESTAMP;


### PR DESCRIPTION
As it turns out, Prisma actually *did* need to create a migration for the changes to automatically handle the `DateCreated` field. However, it didn't try to create the migration until running `bootstrap` with a fresh DB. 

Note for the future: running `prisma generate` is insufficient after altering the schema. Also run `prisma migrate` just in case.