### PR TITLE
Refactor WorkflowInstances to split up stored data

### DIFF
--- a/source/SIL.AppBuilder.Portal/common/databaseProxy/Products.ts
+++ b/source/SIL.AppBuilder.Portal/common/databaseProxy/Products.ts
@@ -69,7 +69,7 @@ export async function update(
 function deleteProduct(productId: string) {
   // Delete all userTasks for this product, and delete the product
   return prisma.$transaction([
-    prisma.workflowInstances.delete({
+    prisma.workflowInstances.deleteMany({
       where: {
         ProductId: productId
       }

--- a/source/SIL.AppBuilder.Portal/common/prisma/migrations/4_workflow_instances_refactor/migration.sql
+++ b/source/SIL.AppBuilder.Portal/common/prisma/migrations/4_workflow_instances_refactor/migration.sql
@@ -1,0 +1,13 @@
+-- AlterTable
+ALTER TABLE "WorkflowInstances" DROP COLUMN "Snapshot",
+ADD COLUMN     "Context" TEXT NOT NULL,
+ADD COLUMN     "State" TEXT NOT NULL,
+ADD COLUMN     "WorkflowDefinitionId" INTEGER NOT NULL,
+ADD COLUMN     "DateCreated" TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+ADD COLUMN     "DateUpdated" TIMESTAMP;
+
+-- AddForeignKey
+ALTER TABLE "WorkflowInstances" ADD CONSTRAINT "FK_WorkflowInstances_WorkflowDefinitions_WorkflowDefinitionId" FOREIGN KEY ("WorkflowDefinitionId") REFERENCES "WorkflowDefinitions"("Id") ON DELETE NO ACTION ON UPDATE NO ACTION;
+
+-- DropIndex
+DROP INDEX "WorkflowInstances_ProductId_key";

--- a/source/SIL.AppBuilder.Portal/common/prisma/schema.prisma
+++ b/source/SIL.AppBuilder.Portal/common/prisma/schema.prisma
@@ -247,6 +247,9 @@ model ProductPublications {
 model ProductTransitions {
   Id               Int       @id(map: "PK_ProductTransitions") @default(autoincrement())
   ProductId        String    @db.Uuid
+  // TODO: remove when DWKit is replaced
+  // Could possibly be replaced with regular UserId, but probably shouldn't, because what if a User is deleted?
+  // Maybe replace with name? Or perhaps this would already be taken care of by populating AllowedUserNames with just the name of the user who caused the product transition...
   WorkflowUserId   String?   @db.Uuid
   AllowedUserNames String?
   InitialState     String?
@@ -453,7 +456,7 @@ model Users {
   ExternalId                    String?
   ProfileVisibility             Int                             @default(1)
   EmailNotification             Boolean?                        @default(true)
-  WorkflowUserId                String?                         @db.Uuid
+  WorkflowUserId                String?                         @db.Uuid // TODO: remove when DWKit is replaced
   DateCreated                   DateTime?                       @default(now()) @db.Timestamp
   DateUpdated                   DateTime?                       @updatedAt @db.Timestamp
   Authors                       Authors[]
@@ -475,8 +478,8 @@ model WorkflowDefinitions {
   Name                 String?
   Enabled              Boolean
   Description          String?
-  WorkflowScheme       String?
-  WorkflowBusinessFlow String?
+  WorkflowScheme       String? // TODO: remove when DWKit is replaced
+  WorkflowBusinessFlow String? // TODO: remove when DWKit is replaced
   StoreTypeId          Int?
   Type                 Int                  @default(1)
   Properties           String?

--- a/source/SIL.AppBuilder.Portal/common/prisma/schema.prisma
+++ b/source/SIL.AppBuilder.Portal/common/prisma/schema.prisma
@@ -287,7 +287,7 @@ model Products {
   StoreLanguage       StoreLanguages?       @relation(fields: [StoreLanguageId], references: [Id], onDelete: Restrict, onUpdate: NoAction, map: "FK_Products_StoreLanguages_StoreLanguageId")
   Store               Stores?               @relation(fields: [StoreId], references: [Id], onDelete: Restrict, onUpdate: NoAction, map: "FK_Products_Stores_StoreId")
   UserTasks           UserTasks[]
-  WorkflowInstance    WorkflowInstances?
+  WorkflowInstances   WorkflowInstances[]
 
   @@index([ProductDefinitionId], map: "IX_Products_ProductDefinitionId")
   @@index([ProjectId], map: "IX_Products_ProjectId")
@@ -486,6 +486,7 @@ model WorkflowDefinitions {
   StoreType            StoreTypes?          @relation(fields: [StoreTypeId], references: [Id], onDelete: Restrict, onUpdate: NoAction, map: "FK_WorkflowDefinitions_StoreTypes_StoreTypeId")
   ProductType          Int                  @default(0)
   AdminRequirements    Int[]                @default([0])
+  WorkflowInstances    WorkflowInstances[]
 
   @@index([StoreTypeId], map: "IX_WorkflowDefinitions_StoreTypeId")
 }
@@ -751,8 +752,13 @@ model dwUploadedFiles {
 }
 
 model WorkflowInstances {
-  Id        Int      @id(map: "PK_WorkflowInstances") @default(autoincrement())
-  Snapshot  String
-  ProductId String   @unique @db.Uuid
-  Product   Products @relation(fields: [ProductId], references: [Id], onDelete: NoAction, onUpdate: NoAction, map: "FK_WorkflowInstances_Products_ProductId")
+  Id           Int          @id(map: "PK_WorkflowInstances") @default(autoincrement())
+  State        String
+  Context      String
+  WorkflowDefinitionId Int
+  ProductId    String       @db.Uuid
+  DateCreated               DateTime? @default(now()) @db.Timestamp
+  DateUpdated               DateTime? @updatedAt @db.Timestamp
+  Product      Products     @relation(fields: [ProductId], references: [Id], onDelete: NoAction, onUpdate: NoAction, map: "FK_WorkflowInstances_Products_ProductId")
+  WorkflowDefinition   WorkflowDefinitions @relation(fields: [WorkflowDefinitionId], references: [Id], onDelete: NoAction, onUpdate: NoAction, map: "FK_WorkflowInstances_WorkflowDefinitions_WorkflowDefinitionId")
 }

--- a/source/SIL.AppBuilder.Portal/common/public/workflow.ts
+++ b/source/SIL.AppBuilder.Portal/common/public/workflow.ts
@@ -73,7 +73,7 @@ export enum WorkflowAction {
   Publish_Failed = 'Publish Failed'
 }
 
-export type WorkflowContext = {
+export type WorkflowContextBase = {
   instructions:
     | 'asset_package_verify_and_publish'
     | 'app_configuration'
@@ -103,14 +103,11 @@ export type WorkflowContext = {
   includeReviewers: boolean;
   includeArtifacts: 'apk' | 'aab' | boolean;
   start?: WorkflowState;
-  adminRequirements: WorkflowAdminRequirements[];
   // Not sure how this is used, but will figure out when integrating into backend
   environment: { [key: string]: any };
-  productType: ProductType;
-  productId: string;
-  hasAuthors: boolean;
-  hasReviewers: boolean;
 };
+
+export type WorkflowContext = WorkflowContextBase & WorkflowInput;
 
 export type WorkflowConfig = {
   adminRequirements: WorkflowAdminRequirements[];
@@ -246,6 +243,7 @@ export type StateNode = {
 };
 
 export type Snapshot = {
-  value: string;
-  context: Omit<WorkflowContext, 'productId' | 'hasAuthors' | 'hasReviewers'>;
+  state: string;
+  context: WorkflowContextBase;
+  config: WorkflowConfig;
 };

--- a/source/SIL.AppBuilder.Portal/src/routes/(authenticated)/admin/settings/workflow-instances/[product_id]/+page.server.ts
+++ b/source/SIL.AppBuilder.Portal/src/routes/(authenticated)/admin/settings/workflow-instances/[product_id]/+page.server.ts
@@ -13,43 +13,39 @@ const jumpStateSchema = v.object({
 
 export const load: PageServerLoad = async ({ params }) => {
   // route already protected by hooks.server.ts
-  const instance = await prisma.workflowInstances.findUnique({
+  const product = await prisma.products.findUnique({
     where: {
-      ProductId: params.product_id
+      Id: params.product_id
     },
     select: {
-      Product: {
+      Id: true,
+      Project: {
         select: {
-          Id: true,
-          Project: {
-            select: {
-              Name: true
-            }
-          },
-          ProductDefinition: {
-            select: {
-              Name: true
-            }
-          },
-          ProductTransitions: {
-            where: {
-              DateTransition: {
-                not: null
-              }
-            },
-            select: {
-              DateTransition: true,
-              InitialState: true,
-              Command: true
-            },
-            orderBy: [
-              {
-                DateTransition: 'desc'
-              }
-            ],
-            take: 1
-          }
+          Name: true
         }
+      },
+      ProductDefinition: {
+        select: {
+          Name: true
+        }
+      },
+      ProductTransitions: {
+        where: {
+          DateTransition: {
+            not: null
+          }
+        },
+        select: {
+          DateTransition: true,
+          InitialState: true,
+          Command: true
+        },
+        orderBy: [
+          {
+            DateTransition: 'desc'
+          }
+        ],
+        take: 1
       }
     }
   });
@@ -59,12 +55,12 @@ export const load: PageServerLoad = async ({ params }) => {
   const snap = await Workflow.getSnapshot(params.product_id);
 
   return {
-    instance: instance,
-    snapshot: { value: snap?.value ?? '' },
+    product: product,
+    snapshot: { value: snap?.state ?? '' },
     machine: snap ? flow.serializeForVisualization() : [],
     form: await superValidate(
       {
-        state: snap?.value
+        state: snap?.state
       },
       valibot(jumpStateSchema)
     )

--- a/source/SIL.AppBuilder.Portal/src/routes/(authenticated)/admin/settings/workflow-instances/[product_id]/+page@(authenticated).svelte
+++ b/source/SIL.AppBuilder.Portal/src/routes/(authenticated)/admin/settings/workflow-instances/[product_id]/+page@(authenticated).svelte
@@ -103,19 +103,19 @@
       </summary>
       <ul>
         <li>
-          {m.project_title()}: {data.instance?.Product.Project.Name}
+          {m.project_title()}: {data.product?.Project.Name}
         </li>
         <li>
-          {m.project_products_title()}: {data.instance?.Product.ProductDefinition.Name}
+          {m.project_products_title()}: {data.product?.ProductDefinition.Name}
         </li>
         <li>
-          Last Transition: {data.instance?.Product.ProductTransitions[0].InitialState}
-          {data.instance?.Product.ProductTransitions[0].Command
-            ? `(${data.instance?.Product.ProductTransitions[0].Command})`
+          Last Transition: {data.product?.ProductTransitions[0].InitialState}
+          {data.product?.ProductTransitions[0].Command
+            ? `(${data.product?.ProductTransitions[0].Command})`
             : ''}
         </li>
         <li>
-          {m.project_products_transitions_date()}: {data.instance?.Product.ProductTransitions[0].DateTransition?.toLocaleTimeString()}
+          {m.project_products_transitions_date()}: {data.product?.ProductTransitions[0].DateTransition?.toLocaleTimeString()}
         </li>
       </ul>
       <form method="POST" use:enhance>


### PR DESCRIPTION
This depends on PR #1026 and should not be merged until that PR has been merged and this one has been rebased.

PR #1026 added configuration data for the Workflow state machine directly to the `WorkflowDefinitions` table.
This change means that it is no longer necessary to store that data in `WorkflowInstances` and can instead be accessed through an associated `WorkflowDefinition`.
Pursuant to that, the `WorkflowInstances` table has been modified according to the following:
- `State` column to store the name of the current state of the instance
- `Context` column to store just the necessary parts of the workflow instance's context
- `WorkflowDefinitionId` to reference the associated `WorkflowDefinition`
- `DateCreated` and `DateUpdated`
- deleted `Snapshot` column, since it was split into `State`, `Context`, and the associated fields in `WorkflowDefinitions`

The relationship to `Products` was also changed to be one `Product` to many `WorkflowInstances` in anticipation of the future addition of republish/rebuild workflows, of which there can be many associated with one product.