### PR TITLE
Allow hamburger icon in navbar to close sidebar on mobile

### DIFF
--- a/source/SIL.AppBuilder.Portal/src/routes/(authenticated)/+layout.svelte
+++ b/source/SIL.AppBuilder.Portal/src/routes/(authenticated)/+layout.svelte
@@ -93,9 +93,9 @@
     <div class="h-full drawer-side shrink-0 z-10">
       <label for="primary-content-drawer" class="drawer-overlay" />
       <div
-        class="h-full overflow-hidden w-full lg:w-72 lg:border-r min-[480px]:w-1/2 min-[720px]:w-1/3"
+        class="h-full mt-16 lg:mt-0 overflow-hidden w-full lg:w-72 lg:border-r min-[480px]:w-1/2 min-[720px]:w-1/3"
       >
-        <ul class="menu menu-lg mt-16 lg:mt-0 p-0 w-full bg-base-100 text-base-content h-full">
+        <ul class="menu menu-lg p-0 w-full bg-base-100 text-base-content h-full">
           <li>
             <a
               class="rounded-none"


### PR DESCRIPTION
There was no good way to close the sidebar in mobile without choosing a navigation link in the sidebar, which is less than ideal UX.
I was able to fix this issue by moving the margin-top from the menu links within the sidebar to just the sidebar itself, so it would no longer be layered on top of the navbar and prevent clicks on the navbar from closing the sidebar.