### PR TITLE
Add documentation comment to Session.user.roles

### DIFF
--- a/source/SIL.AppBuilder.Portal/src/auth.ts
+++ b/source/SIL.AppBuilder.Portal/src/auth.ts
@@ -10,6 +10,7 @@ declare module '@auth/sveltekit' {
   interface Session {
     user: {
       userId: number;
+      /** [organizationId, RoleId][]*/
       roles: [number, number][];
     } & DefaultSession['user'];
   }


### PR DESCRIPTION
I added a JSDoc comment to Session.user.roles so I could remember which part of the 2D array was the organizationId and which was the RoleId just by hovering over it with my mouse.