### PR TITLE
Create object to filter WorkflowInstances by terminal states

### DIFF
--- a/source/SIL.AppBuilder.Portal/common/public/workflow.ts
+++ b/source/SIL.AppBuilder.Portal/common/public/workflow.ts
@@ -1,3 +1,4 @@
+import type { Prisma } from '@prisma/client';
 import type { RoleId } from './prisma.js';
 import { and, type TransitionConfig } from 'xstate';
 import type { GuardPredicate } from 'xstate/guards';
@@ -53,6 +54,10 @@ export enum WorkflowState {
   Make_It_Live = 'Make It Live',
   Published = 'Published'
 }
+
+export const TerminalStateFilter: Prisma.WorkflowInstancesWhereInput = {
+  State: { in: [WorkflowState.Terminated, WorkflowState.Published] }
+};
 
 export enum WorkflowAction {
   Default = 'Default',

--- a/source/SIL.AppBuilder.Portal/common/workflow/index.ts
+++ b/source/SIL.AppBuilder.Portal/common/workflow/index.ts
@@ -18,7 +18,8 @@ import {
   MetaFilter,
   WorkflowTransitionMeta,
   Snapshot,
-  WorkflowState
+  WorkflowState,
+  TerminalStateFilter
 } from '../public/workflow.js';
 import prisma from '../prisma.js';
 import { RoleId, ProductTransitionType, WorkflowType } from '../public/prisma.js';
@@ -111,7 +112,7 @@ export class Workflow {
     const snap = await prisma.workflowInstances.findFirst({
       where: {
         ProductId: productId,
-        State: { not: WorkflowState.Published }
+        NOT: TerminalStateFilter
       },
       select: {
         State: true,
@@ -244,7 +245,7 @@ export class Workflow {
     const instance = await prisma.workflowInstances.findFirst({
       where: {
         ProductId: this.productId,
-        State: { not: WorkflowState.Published }
+        NOT: TerminalStateFilter
       },
       select: {
         Id: true


### PR DESCRIPTION
In multiple scenarios it is useful to query `WorkflowInstances` from the database based on whether or not their state is in one of the defined terminal states of the state machine definition.

As this is used in multiple places, and it is always possible that the state machine definition could have another terminal state added in the future, a `const` object was created that can be used in the `where` clause of a query against the `WorkflowInstances` table. Any future additions of a terminal state can add to the object, rather than having to manually go through and change every query against the `WorkflowInstances` table.