### PR TITLE
DB Changes for refactoring workflow state/transition filtration

### DIFF
--- a/scripts/DB/default_workflow.sql
+++ b/scripts/DB/default_workflow.sql
@@ -1,4 +1,4 @@
-INSERT INTO "WorkflowDefinitions" ("Id", "Name", "Type", "Enabled", "Description", "WorkflowScheme", "WorkflowBusinessFlow", "StoreTypeId", "AdminRequirements") VALUES
+INSERT INTO "WorkflowDefinitions" ("Id", "Name", "Type", "Enabled", "Description", "WorkflowScheme", "WorkflowBusinessFlow", "StoreTypeId", "WorkflowOptions") VALUES
 (1,	'sil_android_google_play',	1,	'1',	'SIL Default Workflow for Publishing to Google Play',	'SIL_Default_AppBuilders_Android_GooglePlay',	'SIL_Default_AppBuilders_Android_GooglePlay_Flow',	1,  '{1, 2}')
 ON CONFLICT ("Id")
 DO UPDATE SET 
@@ -9,7 +9,7 @@ DO UPDATE SET
 	"WorkflowScheme" = excluded."WorkflowScheme",
 	"WorkflowBusinessFlow" = excluded."WorkflowBusinessFlow",
 	"StoreTypeId" = excluded."StoreTypeId",
-  "AdminRequirements" = excluded."AdminRequirements";
+  "WorkflowOptions" = excluded."WorkflowOptions";
 
 INSERT INTO "WorkflowDefinitions" ("Id", "Name", "Type", "Enabled", "Description", "WorkflowScheme", "WorkflowBusinessFlow", "StoreTypeId") VALUES
 (2,	'sil_android_google_play_rebuild',	2,	'1',	'SIL Default Workflow for Rebuilding to Google Play',	'SIL_Default_AppBuilders_Android_GooglePlay_Rebuild',	'SIL_Default_AppBuilders_Android_GooglePlay_Flow',	1)
@@ -34,7 +34,7 @@ DO UPDATE SET
 	"WorkflowBusinessFlow" = excluded."WorkflowBusinessFlow",
 	"StoreTypeId" = excluded."StoreTypeId";
 	
-INSERT INTO "WorkflowDefinitions" ("Id", "Name", "Type", "Enabled", "Description", "WorkflowScheme", "WorkflowBusinessFlow", "StoreTypeId", "ProductType", "AdminRequirements") VALUES
+INSERT INTO "WorkflowDefinitions" ("Id", "Name", "Type", "Enabled", "Description", "WorkflowScheme", "WorkflowBusinessFlow", "StoreTypeId", "ProductType", "WorkflowOptions") VALUES
 (4,	'sil_android_s3',	1,	'1',	'SIL Default Workflow for Publish to Amazon S3 Bucket',	'SIL_Default_AppBuilders_Android_S3',	'SIL_Default_AppBuilders_Android_S3_Flow',	2,  1,  '{2}')
 ON CONFLICT ("Id")
 DO UPDATE SET 
@@ -46,7 +46,7 @@ DO UPDATE SET
 	"WorkflowBusinessFlow" = excluded."WorkflowBusinessFlow",
 	"StoreTypeId" = excluded."StoreTypeId",
   "ProductType" = excluded."ProductType",
-  "AdminRequirements" = excluded."AdminRequirements";
+  "WorkflowOptions" = excluded."WorkflowOptions";
 
 INSERT INTO "WorkflowDefinitions" ("Id", "Name", "Type", "Enabled", "Description", "WorkflowScheme", "WorkflowBusinessFlow", "StoreTypeId", "ProductType") VALUES
 (5,	'sil_android_s3_rebuild',	2,	'1',	'SIL Default Workflow for Rebuilding to Amazon S3 Bucket',	'SIL_Default_AppBuilders_Android_S3_Rebuild',	'SIL_Default_AppBuilders_Android_S3_Flow',	2,  1)
@@ -61,7 +61,7 @@ DO UPDATE SET
 	"StoreTypeId" = excluded."StoreTypeId",
   "ProductType" = excluded."ProductType";
 	
-INSERT INTO "WorkflowDefinitions" ("Id", "Name", "Enabled", "Description", "WorkflowScheme", "WorkflowBusinessFlow", "StoreTypeId", "Type", "AdminRequirements") VALUES 
+INSERT INTO "WorkflowDefinitions" ("Id", "Name", "Enabled", "Description", "WorkflowScheme", "WorkflowBusinessFlow", "StoreTypeId", "Type", "WorkflowOptions") VALUES 
 (6, 'la_android_google_play', '1', 'Low Admin Workflow for Publishing to Google Play', 'SIL_LowAdmin_AppBuilders_Android_GooglePlay', 'SIL_Default_AppBuilders_Android_GooglePlay_Flow', 1, 1, '{1}')
 ON CONFLICT ("Id")
 DO UPDATE SET 
@@ -72,7 +72,7 @@ DO UPDATE SET
 	"WorkflowBusinessFlow" = excluded."WorkflowBusinessFlow",
 	"StoreTypeId" = excluded."StoreTypeId",
 	"Type" = excluded."Type",
-  "AdminRequirements" = excluded."AdminRequirements";
+  "WorkflowOptions" = excluded."WorkflowOptions";
 
 INSERT INTO "WorkflowDefinitions" ("Id", "Name", "Enabled", "Description", "WorkflowScheme", "WorkflowBusinessFlow", "StoreTypeId", "Type") VALUES 
 (7, 'oa_android_google_play', '1', 'Owner Admin Workflow for Publishing to Google Play', 'SIL_OwnerAdmin_AppBuilders_Android_GooglePlay', 'SIL_Default_AppBuilders_Android_GooglePlay_Flow', 1, 1)

--- a/source/SIL.AppBuilder.Portal/common/prisma/migrations/5_workflow_config_refactor/migration.sql
+++ b/source/SIL.AppBuilder.Portal/common/prisma/migrations/5_workflow_config_refactor/migration.sql
@@ -1,3 +1,3 @@
 -- AlterTable
 ALTER TABLE "WorkflowDefinitions" DROP COLUMN "AdminRequirements",
-ADD COLUMN     "WorkflowOptions" INTEGER[] DEFAULT ARRAY[0]::INTEGER[];
+ADD COLUMN     "WorkflowOptions" INTEGER[] DEFAULT ARRAY[]::INTEGER[];

--- a/source/SIL.AppBuilder.Portal/common/prisma/migrations/5_workflow_config_refactor/migration.sql
+++ b/source/SIL.AppBuilder.Portal/common/prisma/migrations/5_workflow_config_refactor/migration.sql
@@ -1,0 +1,3 @@
+-- AlterTable
+ALTER TABLE "WorkflowDefinitions" DROP COLUMN "AdminRequirements",
+ADD COLUMN     "WorkflowOptions" INTEGER[] DEFAULT ARRAY[0]::INTEGER[];

--- a/source/SIL.AppBuilder.Portal/common/prisma/schema.prisma
+++ b/source/SIL.AppBuilder.Portal/common/prisma/schema.prisma
@@ -488,7 +488,7 @@ model WorkflowDefinitions {
   Workflows            ProductDefinitions[] @relation("ProductDefinitions_WorkflowIdToWorkflowDefinitions")
   StoreType            StoreTypes?          @relation(fields: [StoreTypeId], references: [Id], onDelete: Restrict, onUpdate: NoAction, map: "FK_WorkflowDefinitions_StoreTypes_StoreTypeId")
   ProductType          Int                  @default(0)
-  AdminRequirements    Int[]                @default([0])
+  WorkflowOptions      Int[]                @default([0])
   WorkflowInstances    WorkflowInstances[]
 
   @@index([StoreTypeId], map: "IX_WorkflowDefinitions_StoreTypeId")

--- a/source/SIL.AppBuilder.Portal/common/workflow/index.ts
+++ b/source/SIL.AppBuilder.Portal/common/workflow/index.ts
@@ -120,7 +120,7 @@ export class Workflow {
         WorkflowDefinition: {
           select: {
             ProductType: true,
-            AdminRequirements: true
+            WorkflowOptions: true
           }
         }
       }
@@ -130,7 +130,7 @@ export class Workflow {
       context: JSON.parse(snap.Context) as WorkflowContextBase,
       config: {
         productType: snap.WorkflowDefinition.ProductType,
-        adminRequirements: snap.WorkflowDefinition.AdminRequirements
+        adminRequirements: snap.WorkflowDefinition.WorkflowOptions
       }
     };
   }

--- a/source/SIL.AppBuilder.Portal/src/routes/(authenticated)/projects/[id=idNumber]/+page.server.ts
+++ b/source/SIL.AppBuilder.Portal/src/routes/(authenticated)/projects/[id=idNumber]/+page.server.ts
@@ -197,7 +197,7 @@ export const actions = {
                 Id: true,
                 Type: true,
                 ProductType: true,
-                AdminRequirements: true
+                WorkflowOptions: true
               }
             }
           }
@@ -207,7 +207,7 @@ export const actions = {
       if (flow?.Type === WorkflowType.Startup) {
         Workflow.create(productId, {
           productType: flow.ProductType,
-          adminRequirements: flow.AdminRequirements
+          adminRequirements: flow.WorkflowOptions
         });
       }
     }


### PR DESCRIPTION
Changes:
- Renamed `AdminRequirements` to `WorkflowOptions` to add more meaningful flexibility in the future for extending the different parameters for the state machine.
- Switched default for `WorkflowOptions` from [WorkflowOptions.None] to [] (Factoring out WorkflowOptions.None completely)