### PR TITLE
Refactor filtration of workflow states/transitions

### DIFF
--- a/source/SIL.AppBuilder.Portal/common/public/workflow.ts
+++ b/source/SIL.AppBuilder.Portal/common/public/workflow.ts
@@ -146,7 +146,7 @@ export type WorkflowTransitionMeta = {
  *  - no conditions are specified
  *  - all specified conditions are met
  */
-export function filterMeta(config: WorkflowConfig, filter?: MetaFilter) {
+export function includeStateOrTransition(config: WorkflowConfig, filter?: MetaFilter) {
   let include = !!filter;
   if (!filter) {
     return true; // no conditions are specified

--- a/source/SIL.AppBuilder.Portal/common/public/workflow.ts
+++ b/source/SIL.AppBuilder.Portal/common/public/workflow.ts
@@ -13,17 +13,17 @@ export enum ActionType {
 /**
  * The administrative requirements of the workflow.
  * Examples:
- *  - If the flow has `WorkflowAdminRequirements.ApprovalProcess` it will include extra state to represent the organizational approval process
- *  - If the flow has `WorkflowAdminRequirements.StoreAccess` it will not include those states, but there are still some states that require action from an OrgAdmin to complete certain actions
- *  - If the flow has `WorkflowAdminRequirements.None` none of the states or actions for the workflow instance will require an OrgAdmin.
+ *  - If the flow has `WorkflowOptions.ApprovalProcess` it will include extra state to represent the organizational approval process
+ *  - If the flow has `WorkflowOptions.AdminStoreAccess` it will not include those states, but there are still some states that require action from an OrgAdmin to complete certain actions
+ *  - If the flow has `WorkflowOptions.None` none of the states or actions for the workflow instance will require an OrgAdmin.
  *
- * Any state or transition can have a list of specified `WorkflowAdminRequirements`s. What this means is that those states and transitions will be included in a workflow instance ONLY when the instance's `WorkflowAdminRequirements` is in the state's or transition's list.
+ * Any state or transition can have a list of specified `WorkflowOptions`s. What this means is that those states and transitions will be included in a workflow instance ONLY when the instance's `WorkflowOptions` is in the state's or transition's list.
  *
- * If a state or transition does not specify any `WorkflowAdminRequirements` it will be included (provided it passes other conditions not dependent on `WorkflowAdminRequirements`).
+ * If a state or transition does not specify any `WorkflowOptions` it will be included (provided it passes other conditions not dependent on `WorkflowOptions`).
  */
-export enum WorkflowAdminRequirements {
+export enum WorkflowOptions {
   None = 0,
-  StoreAccess,
+  AdminStoreAccess,
   ApprovalProcess
 }
 
@@ -115,7 +115,7 @@ export type WorkflowContextBase = {
 export type WorkflowContext = WorkflowContextBase & WorkflowInput;
 
 export type WorkflowConfig = {
-  adminRequirements: WorkflowAdminRequirements[];
+  options: WorkflowOptions[];
   productType: ProductType;
 };
 
@@ -127,7 +127,7 @@ export type WorkflowInput = WorkflowConfig & {
 
 /** Used for filtering based on AdminLevel and/or ProductType */
 export type MetaFilter = {
-  adminRequirements?: WorkflowAdminRequirements[];
+  options?: WorkflowOptions[];
   productTypes?: ProductType[];
 };
 

--- a/source/SIL.AppBuilder.Portal/common/public/workflow.ts
+++ b/source/SIL.AppBuilder.Portal/common/public/workflow.ts
@@ -131,11 +131,12 @@ export type MetaFilter = {
   productTypes?: ProductType[];
 };
 
-export type WorkflowStateMeta = MetaFilter;
+export type WorkflowStateMeta = { includeWhen?: MetaFilter };
 
-export type WorkflowTransitionMeta = MetaFilter & {
+export type WorkflowTransitionMeta = {
   type: ActionType;
   user?: RoleId;
+  includeWhen?: MetaFilter;
 };
 
 export type WorkflowEvent = {
@@ -147,8 +148,7 @@ export type WorkflowEvent = {
 
 export type JumpParams = {
   target: WorkflowState | string;
-  products?: ProductType[];
-  adminRequirements?: WorkflowAdminRequirements[];
+  filter?: MetaFilter;
 };
 
 /**
@@ -168,7 +168,7 @@ export function jump(
   any,
   never,
   WorkflowEvent,
-  MetaFilter | WorkflowTransitionMeta
+  WorkflowStateMeta | WorkflowTransitionMeta
 > {
   const j = {
     type: 'canJump',

--- a/source/SIL.AppBuilder.Portal/common/public/workflow.ts
+++ b/source/SIL.AppBuilder.Portal/common/public/workflow.ts
@@ -22,8 +22,7 @@ export enum ActionType {
  * If a state or transition does not specify any `WorkflowOptions` it will be included (provided it passes other conditions not dependent on `WorkflowOptions`).
  */
 export enum WorkflowOptions {
-  None = 0,
-  AdminStoreAccess,
+  AdminStoreAccess = 1,
   ApprovalProcess
 }
 
@@ -125,10 +124,16 @@ export type WorkflowInput = WorkflowConfig & {
   hasReviewers: boolean;
 };
 
-/** Used for filtering based on AdminLevel and/or ProductType */
+type ProductTypeSingleOrList = ProductType | { in: ProductType[] };
+
+/** Used for filtering based on specified WorkflowOptions and/or ProductType */
 export type MetaFilter = {
-  options?: WorkflowOptions[];
-  productTypes?: ProductType[];
+  options?:
+    | { has: WorkflowOptions }      // options contains the provided
+    | { any: WorkflowOptions[] }    // options contains any of the provided
+    | { all: WorkflowOptions[] }    // options contains all of the provided
+    | { none: WorkflowOptions[] };  // options contains none of the provided
+  productType?: ProductTypeSingleOrList | { not: ProductTypeSingleOrList };
 };
 
 export type WorkflowStateMeta = { includeWhen?: MetaFilter };

--- a/source/SIL.AppBuilder.Portal/common/public/workflow.ts
+++ b/source/SIL.AppBuilder.Portal/common/public/workflow.ts
@@ -29,7 +29,6 @@ export enum ProductType {
 
 export enum WorkflowState {
   Start = 'Start',
-  Readiness_Check = 'Readiness Check',
   Approval = 'Approval',
   Approval_Pending = 'Approval Pending',
   Terminated = 'Terminated',

--- a/source/SIL.AppBuilder.Portal/common/public/workflow.ts
+++ b/source/SIL.AppBuilder.Portal/common/public/workflow.ts
@@ -11,18 +11,12 @@ export enum ActionType {
 }
 
 /**
- * The administrative requirements of the workflow.
- * Examples:
- *  - If the flow has `WorkflowOptions.ApprovalProcess` it will include extra state to represent the organizational approval process
- *  - If the flow has `WorkflowOptions.AdminStoreAccess` it will not include those states, but there are still some states that require action from an OrgAdmin to complete certain actions
- *  - If the flow has `WorkflowOptions.None` none of the states or actions for the workflow instance will require an OrgAdmin.
- *
- * Any state or transition can have a list of specified `WorkflowOptions`s. What this means is that those states and transitions will be included in a workflow instance ONLY when the instance's `WorkflowOptions` is in the state's or transition's list.
- *
- * If a state or transition does not specify any `WorkflowOptions` it will be included (provided it passes other conditions not dependent on `WorkflowOptions`).
+ * Optional features of the workflow. Different states/transitions can be included based on provided options.
  */
 export enum WorkflowOptions {
+  /** Require an OrgAdmin to access the GooglePlay Developer Console */
   AdminStoreAccess = 1,
+  /** Require approval from an OrgAdmin before product can be created */
   ApprovalProcess
 }
 

--- a/source/SIL.AppBuilder.Portal/common/public/workflow.ts
+++ b/source/SIL.AppBuilder.Portal/common/public/workflow.ts
@@ -17,7 +17,9 @@ export enum WorkflowOptions {
   /** Require an OrgAdmin to access the GooglePlay Developer Console */
   AdminStoreAccess = 1,
   /** Require approval from an OrgAdmin before product can be created */
-  ApprovalProcess
+  ApprovalProcess,
+  /** Allow Owner to delegate actions to Authors */
+  AllowTransferToAuthors
 }
 
 export enum ProductType {

--- a/source/SIL.AppBuilder.Portal/common/public/workflow.ts
+++ b/source/SIL.AppBuilder.Portal/common/public/workflow.ts
@@ -144,6 +144,24 @@ export type WorkflowTransitionMeta = {
   includeWhen?: MetaFilter;
 };
 
+/**
+ * Include state/transition if:
+ *  - no conditions are specified
+ *  - OR
+ *    - One of the provided user role features matches the context
+ *    - AND
+ *    - One of the provided product types matches the context
+ */
+export function filterMeta(filter: WorkflowConfig, meta?: MetaFilter) {
+  return (
+    meta === undefined ||
+    ((meta.options !== undefined
+      ? meta.options.filter((urf) => filter.options.includes(urf)).length > 0
+      : true) &&
+      (meta.productType !== undefined ? meta.productType.includes(filter.productType) : true))
+  );
+}
+
 export type WorkflowEvent = {
   type: WorkflowAction;
   comment?: string;

--- a/source/SIL.AppBuilder.Portal/common/workflow/index.ts
+++ b/source/SIL.AppBuilder.Portal/common/workflow/index.ts
@@ -15,7 +15,7 @@ import {
   ActionType,
   StateNode,
   WorkflowEvent,
-  filterMeta,
+  includeStateOrTransition,
   WorkflowTransitionMeta,
   Snapshot,
   WorkflowState,
@@ -156,7 +156,7 @@ export class Workflow {
   public serializeForVisualization(): StateNode[] {
     const machine = StartupWorkflow;
     const states = Object.entries(machine.states).filter(([k, v]) =>
-      filterMeta(this.config, v.meta?.includeWhen)
+      includeStateOrTransition(this.config, v.meta?.includeWhen)
     );
     const lookup = states.map((s) => s[0]);
     const actions: StateNode[] = [];
@@ -301,8 +301,8 @@ export class Workflow {
     filter: WorkflowConfig
   ) {
     return Object.values(on)
-      .map((v) => v.filter((t) => filterMeta(filter, t.meta?.includeWhen)))
-      .filter((v) => v.length > 0 && filterMeta(filter, v[0].meta?.includeWhen));
+      .map((v) => v.filter((t) => includeStateOrTransition(filter, t.meta?.includeWhen)))
+      .filter((v) => v.length > 0 && includeStateOrTransition(filter, v[0].meta?.includeWhen));
   }
 
   /**

--- a/source/SIL.AppBuilder.Portal/common/workflow/index.ts
+++ b/source/SIL.AppBuilder.Portal/common/workflow/index.ts
@@ -15,7 +15,7 @@ import {
   ActionType,
   StateNode,
   WorkflowEvent,
-  MetaFilter,
+  filterMeta,
   WorkflowTransitionMeta,
   Snapshot,
   WorkflowState,
@@ -156,7 +156,7 @@ export class Workflow {
   public serializeForVisualization(): StateNode[] {
     const machine = StartupWorkflow;
     const states = Object.entries(machine.states).filter(([k, v]) =>
-      Workflow.filterMeta(this.config, v.meta?.includeWhen)
+      filterMeta(this.config, v.meta?.includeWhen)
     );
     const lookup = states.map((s) => s[0]);
     const actions: StateNode[] = [];
@@ -301,26 +301,8 @@ export class Workflow {
     filter: WorkflowConfig
   ) {
     return Object.values(on)
-      .map((v) => v.filter((t) => Workflow.filterMeta(filter, t.meta?.includeWhen)))
-      .filter((v) => v.length > 0 && Workflow.filterMeta(filter, v[0].meta?.includeWhen));
-  }
-
-  /**
-   * Include state/transition if:
-   *  - no conditions are specified
-   *  - OR
-   *    - One of the provided user role features matches the context
-   *    - AND
-   *    - One of the provided product types matches the context
-   */
-  public static filterMeta(filter: WorkflowConfig, meta?: MetaFilter) {
-    return (
-      meta === undefined ||
-      ((meta.options !== undefined
-        ? meta.options.filter((urf) => filter.options.includes(urf)).length > 0
-        : true) &&
-        (meta.productType !== undefined ? meta.productType.includes(filter.productType) : true))
-    );
+      .map((v) => v.filter((t) => filterMeta(filter, t.meta?.includeWhen)))
+      .filter((v) => v.length > 0 && filterMeta(filter, v[0].meta?.includeWhen));
   }
 
   /**

--- a/source/SIL.AppBuilder.Portal/common/workflow/index.ts
+++ b/source/SIL.AppBuilder.Portal/common/workflow/index.ts
@@ -156,7 +156,7 @@ export class Workflow {
   public serializeForVisualization(): StateNode[] {
     const machine = StartupWorkflow;
     const states = Object.entries(machine.states).filter(([k, v]) =>
-      Workflow.filterMeta(this.config, v.meta)
+      Workflow.filterMeta(this.config, v.meta?.includeWhen)
     );
     const lookup = states.map((s) => s[0]);
     const actions: StateNode[] = [];
@@ -301,8 +301,8 @@ export class Workflow {
     filter: WorkflowConfig
   ) {
     return Object.values(on)
-      .map((v) => v.filter((t) => Workflow.filterMeta(filter, t.meta)))
-      .filter((v) => v.length > 0 && Workflow.filterMeta(filter, v[0].meta));
+      .map((v) => v.filter((t) => Workflow.filterMeta(filter, t.meta?.includeWhen)))
+      .filter((v) => v.length > 0 && Workflow.filterMeta(filter, v[0].meta?.includeWhen));
   }
 
   /**

--- a/source/SIL.AppBuilder.Portal/common/workflow/index.ts
+++ b/source/SIL.AppBuilder.Portal/common/workflow/index.ts
@@ -130,7 +130,7 @@ export class Workflow {
       context: JSON.parse(snap.Context) as WorkflowContextBase,
       config: {
         productType: snap.WorkflowDefinition.ProductType,
-        adminRequirements: snap.WorkflowDefinition.WorkflowOptions
+        options: snap.WorkflowDefinition.WorkflowOptions
       }
     };
   }
@@ -258,7 +258,7 @@ export class Workflow {
       hasAuthors: undefined,
       hasReviewers: undefined,
       productType: undefined,
-      adminRequirements: undefined
+      options: undefined
     } as WorkflowContextBase;
     if (instance) {
       return DatabaseWrites.workflowInstances.update({
@@ -316,8 +316,8 @@ export class Workflow {
   public static filterMeta(filter: WorkflowConfig, meta?: MetaFilter) {
     return (
       meta === undefined ||
-      ((meta.adminRequirements !== undefined
-        ? meta.adminRequirements.filter((urf) => filter.adminRequirements.includes(urf)).length > 0
+      ((meta.options !== undefined
+        ? meta.options.filter((urf) => filter.options.includes(urf)).length > 0
         : true) &&
         (meta.productTypes !== undefined ? meta.productTypes.includes(filter.productType) : true))
     );

--- a/source/SIL.AppBuilder.Portal/common/workflow/index.ts
+++ b/source/SIL.AppBuilder.Portal/common/workflow/index.ts
@@ -319,7 +319,7 @@ export class Workflow {
       ((meta.options !== undefined
         ? meta.options.filter((urf) => filter.options.includes(urf)).length > 0
         : true) &&
-        (meta.productTypes !== undefined ? meta.productTypes.includes(filter.productType) : true))
+        (meta.productType !== undefined ? meta.productType.includes(filter.productType) : true))
     );
   }
 

--- a/source/SIL.AppBuilder.Portal/common/workflow/startup-workflow.ts
+++ b/source/SIL.AppBuilder.Portal/common/workflow/startup-workflow.ts
@@ -89,14 +89,32 @@ export const StartupWorkflow = setup({
         }),
         jump({ target: WorkflowState.Product_Creation }),
         jump({ target: WorkflowState.App_Builder_Configuration }),
-        //@ts-expect-error I couldn't figure out the TS magic to prevent this from complaining. It should work fine though.
-        jump({ target: WorkflowState.Author_Configuration }, [{ type: 'hasAuthors' }]),
+        jump(
+          {
+            target: WorkflowState.Author_Configuration,
+            filter: { options: { has: WorkflowOptions.AllowTransferToAuthors } }
+          },
+          //@ts-expect-error I couldn't figure out the TS magic to prevent this from complaining. It should work fine though.
+          [{ type: 'hasAuthors' }]
+        ),
         jump({ target: WorkflowState.Synchronize_Data }),
-        //@ts-expect-error
-        jump({ target: WorkflowState.Author_Download }, [{ type: 'hasAuthors' }]),
+        jump(
+          {
+            target: WorkflowState.Author_Download,
+            filter: { options: { has: WorkflowOptions.AllowTransferToAuthors } }
+          },
+          //@ts-expect-error
+          [{ type: 'hasAuthors' }]
+        ),
         //note: authors can upload at any time, this state is just to prompt an upload
-        //@ts-expect-error
-        jump({ target: WorkflowState.Author_Upload }, [{ type: 'hasAuthors' }]),
+        jump(
+          {
+            target: WorkflowState.Author_Upload,
+            filter: { options: { has: WorkflowOptions.AllowTransferToAuthors } }
+          },
+          //@ts-expect-error
+          [{ type: 'hasAuthors' }]
+        ),
         jump({ target: WorkflowState.Product_Build }),
         jump({
           target: WorkflowState.App_Store_Preview,
@@ -297,7 +315,10 @@ export const StartupWorkflow = setup({
         [WorkflowAction.Transfer_to_Authors]: {
           meta: {
             type: ActionType.User,
-            user: RoleId.AppBuilder
+            user: RoleId.AppBuilder,
+            includeWhen: {
+              options: { has: WorkflowOptions.AllowTransferToAuthors }
+            }
           },
           guard: { type: 'hasAuthors' },
           target: WorkflowState.Author_Configuration
@@ -305,6 +326,11 @@ export const StartupWorkflow = setup({
       }
     },
     [WorkflowState.Author_Configuration]: {
+      meta: {
+        includeWhen: {
+          options: { has: WorkflowOptions.AllowTransferToAuthors }
+        }
+      },
       entry: assign({
         instructions: 'app_configuration',
         includeFields: ['storeDescription', 'listingLanguageCode', 'projectURL']
@@ -342,7 +368,10 @@ export const StartupWorkflow = setup({
         [WorkflowAction.Transfer_to_Authors]: {
           meta: {
             type: ActionType.User,
-            user: RoleId.AppBuilder
+            user: RoleId.AppBuilder,
+            includeWhen: {
+              options: { has: WorkflowOptions.AllowTransferToAuthors }
+            }
           },
           guard: { type: 'hasAuthors' },
           target: WorkflowState.Author_Download
@@ -350,6 +379,11 @@ export const StartupWorkflow = setup({
       }
     },
     [WorkflowState.Author_Download]: {
+      meta: {
+        includeWhen: {
+          options: { has: WorkflowOptions.AllowTransferToAuthors }
+        }
+      },
       entry: assign({
         instructions: 'authors_download',
         includeFields: ['storeDescription', 'listingLanguageCode', 'projectURL']
@@ -372,6 +406,11 @@ export const StartupWorkflow = setup({
       }
     },
     [WorkflowState.Author_Upload]: {
+      meta: {
+        includeWhen: {
+          options: { has: WorkflowOptions.AllowTransferToAuthors }
+        }
+      },
       entry: assign({
         instructions: 'authors_upload',
         includeFields: ['storeDescription', 'listingLanguageCode']

--- a/source/SIL.AppBuilder.Portal/common/workflow/startup-workflow.ts
+++ b/source/SIL.AppBuilder.Portal/common/workflow/startup-workflow.ts
@@ -107,20 +107,20 @@ export const StartupWorkflow = setup({
         jump({
           target: WorkflowState.App_Store_Preview,
           filter: {
-            productType: ProductType.Android_GooglePlay
+            productType: { is: ProductType.Android_GooglePlay }
           }
         }),
         jump({
           target: WorkflowState.Create_App_Store_Entry,
           filter: {
-            productType: ProductType.Android_GooglePlay
+            productType: { is: ProductType.Android_GooglePlay }
           }
         }),
         jump({ target: WorkflowState.Verify_and_Publish }),
         jump({ target: WorkflowState.Product_Publish }),
         jump({
           target: WorkflowState.Make_It_Live,
-          filter: { productType: ProductType.Android_GooglePlay }
+          filter: { productType: { is: ProductType.Android_GooglePlay } }
         }),
         jump({ target: WorkflowState.Published }),
         {
@@ -289,7 +289,7 @@ export const StartupWorkflow = setup({
             type: ActionType.User,
             user: RoleId.AppBuilder,
             includeWhen: {
-              productType: ProductType.Android_GooglePlay
+              productType: { is: ProductType.Android_GooglePlay }
             }
           },
           target: WorkflowState.Product_Build
@@ -309,7 +309,7 @@ export const StartupWorkflow = setup({
             type: ActionType.User,
             user: RoleId.AppBuilder,
             includeWhen: {
-              productType: ProductType.Android_GooglePlay
+              productType: { is: ProductType.Android_GooglePlay }
             }
           },
           actions: assign({
@@ -435,7 +435,7 @@ export const StartupWorkflow = setup({
             meta: {
               type: ActionType.Auto,
               includeWhen: {
-                productType: ProductType.Android_GooglePlay
+                productType: { is: ProductType.Android_GooglePlay }
               }
             },
             guard: ({ context }) =>
@@ -461,7 +461,7 @@ export const StartupWorkflow = setup({
     [WorkflowState.App_Store_Preview]: {
       meta: {
         includeWhen: {
-          productType: ProductType.Android_GooglePlay
+          productType: { is: ProductType.Android_GooglePlay }
         }
       },
       entry: assign({
@@ -530,7 +530,7 @@ export const StartupWorkflow = setup({
     [WorkflowState.Create_App_Store_Entry]: {
       meta: {
         includeWhen: {
-          productType: ProductType.Android_GooglePlay
+          productType: { is: ProductType.Android_GooglePlay }
         }
       },
       entry: assign({
@@ -675,7 +675,7 @@ export const StartupWorkflow = setup({
             meta: {
               type: ActionType.Auto,
               includeWhen: {
-                productType: ProductType.Android_GooglePlay
+                productType: { is: ProductType.Android_GooglePlay }
               }
             },
             guard: ({ context }) =>
@@ -700,7 +700,7 @@ export const StartupWorkflow = setup({
     [WorkflowState.Make_It_Live]: {
       meta: {
         includeWhen: {
-          productType: ProductType.Android_GooglePlay
+          productType: { is: ProductType.Android_GooglePlay }
         }
       },
       entry: assign({

--- a/source/SIL.AppBuilder.Portal/common/workflow/startup-workflow.ts
+++ b/source/SIL.AppBuilder.Portal/common/workflow/startup-workflow.ts
@@ -72,25 +72,25 @@ export const StartupWorkflow = setup({
         jump({
           target: WorkflowState.Readiness_Check,
           filter: {
-            options: [WorkflowOptions.ApprovalProcess]
+            options: { has: WorkflowOptions.ApprovalProcess }
           }
         }),
         jump({
           target: WorkflowState.Approval,
           filter: {
-            options: [WorkflowOptions.ApprovalProcess]
+            options: { has: WorkflowOptions.ApprovalProcess }
           }
         }),
         jump({
           target: WorkflowState.Approval_Pending,
           filter: {
-            options: [WorkflowOptions.ApprovalProcess]
+            options: { has: WorkflowOptions.ApprovalProcess }
           }
         }),
         jump({
           target: WorkflowState.Terminated,
           filter: {
-            options: [WorkflowOptions.ApprovalProcess]
+            options: { has: WorkflowOptions.ApprovalProcess }
           }
         }),
         jump({ target: WorkflowState.Product_Creation }),
@@ -107,25 +107,24 @@ export const StartupWorkflow = setup({
         jump({
           target: WorkflowState.App_Store_Preview,
           filter: {
-            productTypes: [ProductType.Android_GooglePlay]
+            productType: ProductType.Android_GooglePlay
           }
         }),
         jump({
           target: WorkflowState.Create_App_Store_Entry,
           filter: {
-            productTypes: [ProductType.Android_GooglePlay]
+            productType: ProductType.Android_GooglePlay
           }
         }),
         jump({ target: WorkflowState.Verify_and_Publish }),
         jump({ target: WorkflowState.Product_Publish }),
         jump({
           target: WorkflowState.Make_It_Live,
-          filter: { productTypes: [ProductType.Android_GooglePlay] }
+          filter: { productType: ProductType.Android_GooglePlay }
         }),
         jump({ target: WorkflowState.Published }),
         {
-          guard: ({ context }) =>
-            context.options.includes(WorkflowOptions.ApprovalProcess),
+          guard: ({ context }) => context.options.includes(WorkflowOptions.ApprovalProcess),
           target: WorkflowState.Readiness_Check
         },
         {
@@ -140,7 +139,7 @@ export const StartupWorkflow = setup({
             meta: {
               type: ActionType.Auto,
               includeWhen: {
-                options: [WorkflowOptions.ApprovalProcess]
+                options: { has: WorkflowOptions.ApprovalProcess }
               }
             },
             target: WorkflowState.Readiness_Check
@@ -155,7 +154,7 @@ export const StartupWorkflow = setup({
     [WorkflowState.Readiness_Check]: {
       meta: {
         includeWhen: {
-          options: [WorkflowOptions.ApprovalProcess]
+          options: { has: WorkflowOptions.ApprovalProcess }
         }
       },
       entry: assign({
@@ -175,7 +174,7 @@ export const StartupWorkflow = setup({
     [WorkflowState.Approval]: {
       meta: {
         includeWhen: {
-          options: [WorkflowOptions.ApprovalProcess]
+          options: { has: WorkflowOptions.ApprovalProcess }
         }
       },
       entry: assign({
@@ -217,7 +216,7 @@ export const StartupWorkflow = setup({
     [WorkflowState.Approval_Pending]: {
       meta: {
         includeWhen: {
-          options: [WorkflowOptions.ApprovalProcess]
+          options: { has: WorkflowOptions.ApprovalProcess }
         }
       },
       entry: [
@@ -252,7 +251,7 @@ export const StartupWorkflow = setup({
     [WorkflowState.Terminated]: {
       meta: {
         includeWhen: {
-          options: [WorkflowOptions.ApprovalProcess]
+          options: { has: WorkflowOptions.ApprovalProcess }
         }
       },
       entry: assign({
@@ -290,7 +289,7 @@ export const StartupWorkflow = setup({
             type: ActionType.User,
             user: RoleId.AppBuilder,
             includeWhen: {
-              productTypes: [ProductType.Android_GooglePlay]
+              productType: ProductType.Android_GooglePlay
             }
           },
           target: WorkflowState.Product_Build
@@ -300,7 +299,7 @@ export const StartupWorkflow = setup({
             type: ActionType.User,
             user: RoleId.AppBuilder,
             includeWhen: {
-              productTypes: [ProductType.Android_S3, ProductType.AssetPackage, ProductType.Web]
+              productType: { not: ProductType.Android_GooglePlay }
             }
           },
           target: WorkflowState.Product_Build
@@ -310,7 +309,7 @@ export const StartupWorkflow = setup({
             type: ActionType.User,
             user: RoleId.AppBuilder,
             includeWhen: {
-              productTypes: [ProductType.Android_GooglePlay]
+              productType: ProductType.Android_GooglePlay
             }
           },
           actions: assign({
@@ -436,7 +435,7 @@ export const StartupWorkflow = setup({
             meta: {
               type: ActionType.Auto,
               includeWhen: {
-                productTypes: [ProductType.Android_GooglePlay]
+                productType: ProductType.Android_GooglePlay
               }
             },
             guard: ({ context }) =>
@@ -462,7 +461,7 @@ export const StartupWorkflow = setup({
     [WorkflowState.App_Store_Preview]: {
       meta: {
         includeWhen: {
-          productTypes: [ProductType.Android_GooglePlay]
+          productType: ProductType.Android_GooglePlay
         }
       },
       entry: assign({
@@ -486,10 +485,9 @@ export const StartupWorkflow = setup({
               type: ActionType.User,
               user: RoleId.OrgAdmin,
               includeWhen: {
-                options: [
-                  WorkflowOptions.ApprovalProcess,
-                  WorkflowOptions.AdminStoreAccess
-                ]
+                options: {
+                  has: WorkflowOptions.AdminStoreAccess
+                }
               }
             },
             target: WorkflowState.Create_App_Store_Entry
@@ -499,7 +497,7 @@ export const StartupWorkflow = setup({
               type: ActionType.User,
               user: RoleId.AppBuilder,
               includeWhen: {
-                options: [WorkflowOptions.None]
+                options: { none: [WorkflowOptions.AdminStoreAccess] }
               }
             },
             target: WorkflowState.Create_App_Store_Entry
@@ -511,10 +509,7 @@ export const StartupWorkflow = setup({
               type: ActionType.User,
               user: RoleId.OrgAdmin,
               includeWhen: {
-                options: [
-                  WorkflowOptions.ApprovalProcess,
-                  WorkflowOptions.AdminStoreAccess
-                ]
+                options: { has: WorkflowOptions.AdminStoreAccess }
               }
             },
             target: WorkflowState.Synchronize_Data
@@ -524,7 +519,7 @@ export const StartupWorkflow = setup({
               type: ActionType.User,
               user: RoleId.AppBuilder,
               includeWhen: {
-                options: [WorkflowOptions.None]
+                options: { none: [WorkflowOptions.AdminStoreAccess] }
               }
             },
             target: WorkflowState.Synchronize_Data
@@ -535,7 +530,7 @@ export const StartupWorkflow = setup({
     [WorkflowState.Create_App_Store_Entry]: {
       meta: {
         includeWhen: {
-          productTypes: [ProductType.Android_GooglePlay]
+          productType: ProductType.Android_GooglePlay
         }
       },
       entry: assign({
@@ -555,10 +550,7 @@ export const StartupWorkflow = setup({
               type: ActionType.User,
               user: RoleId.OrgAdmin,
               includeWhen: {
-                options: [
-                  WorkflowOptions.ApprovalProcess,
-                  WorkflowOptions.AdminStoreAccess
-                ]
+                options: { has: WorkflowOptions.AdminStoreAccess }
               }
             },
             actions: assign({
@@ -574,7 +566,7 @@ export const StartupWorkflow = setup({
               type: ActionType.User,
               user: RoleId.AppBuilder,
               includeWhen: {
-                options: [WorkflowOptions.None]
+                options: { none: [WorkflowOptions.AdminStoreAccess] }
               }
             },
             actions: assign({
@@ -592,10 +584,7 @@ export const StartupWorkflow = setup({
               type: ActionType.User,
               user: RoleId.OrgAdmin,
               includeWhen: {
-                options: [
-                  WorkflowOptions.ApprovalProcess,
-                  WorkflowOptions.AdminStoreAccess
-                ]
+                options: { has: WorkflowOptions.AdminStoreAccess }
               }
             },
             target: WorkflowState.Synchronize_Data
@@ -605,7 +594,7 @@ export const StartupWorkflow = setup({
               type: ActionType.User,
               user: RoleId.AppBuilder,
               includeWhen: {
-                options: [WorkflowOptions.None]
+                options: { none: [WorkflowOptions.AdminStoreAccess] }
               }
             },
             target: WorkflowState.Synchronize_Data
@@ -686,7 +675,7 @@ export const StartupWorkflow = setup({
             meta: {
               type: ActionType.Auto,
               includeWhen: {
-                productTypes: [ProductType.Android_GooglePlay]
+                productType: ProductType.Android_GooglePlay
               }
             },
             guard: ({ context }) =>
@@ -711,7 +700,7 @@ export const StartupWorkflow = setup({
     [WorkflowState.Make_It_Live]: {
       meta: {
         includeWhen: {
-          productTypes: [ProductType.Android_GooglePlay]
+          productType: ProductType.Android_GooglePlay
         }
       },
       entry: assign({
@@ -725,10 +714,7 @@ export const StartupWorkflow = setup({
               type: ActionType.User,
               user: RoleId.OrgAdmin,
               includeWhen: {
-                options: [
-                  WorkflowOptions.ApprovalProcess,
-                  WorkflowOptions.AdminStoreAccess
-                ]
+                options: { has: WorkflowOptions.AdminStoreAccess }
               }
             },
             target: WorkflowState.Published
@@ -738,7 +724,7 @@ export const StartupWorkflow = setup({
               type: ActionType.User,
               user: RoleId.AppBuilder,
               includeWhen: {
-                options: [WorkflowOptions.None]
+                options: { none: [WorkflowOptions.AdminStoreAccess] }
               }
             },
             target: WorkflowState.Published
@@ -750,10 +736,7 @@ export const StartupWorkflow = setup({
               type: ActionType.User,
               user: RoleId.OrgAdmin,
               includeWhen: {
-                options: [
-                  WorkflowOptions.ApprovalProcess,
-                  WorkflowOptions.AdminStoreAccess
-                ]
+                options: { has: WorkflowOptions.AdminStoreAccess }
               }
             },
             target: WorkflowState.Synchronize_Data
@@ -763,7 +746,7 @@ export const StartupWorkflow = setup({
               type: ActionType.User,
               user: RoleId.AppBuilder,
               includeWhen: {
-                options: [WorkflowOptions.None]
+                options: { none: [WorkflowOptions.AdminStoreAccess] }
               }
             },
             target: WorkflowState.Synchronize_Data

--- a/source/SIL.AppBuilder.Portal/common/workflow/startup-workflow.ts
+++ b/source/SIL.AppBuilder.Portal/common/workflow/startup-workflow.ts
@@ -11,10 +11,10 @@ import {
   WorkflowAction,
   WorkflowEvent,
   JumpParams,
-  jump
+  jump,
+  filterMeta
 } from '../public/workflow.js';
 import { RoleId } from '../public/prisma.js';
-import { Workflow } from './index.js';
 
 /**
  * IMPORTANT: READ THIS BEFORE EDITING A STATE MACHINE!
@@ -39,7 +39,7 @@ export const StartupWorkflow = setup({
   },
   guards: {
     canJump: ({ context }, params: JumpParams) => {
-      return context.start === params.target && Workflow.filterMeta(context, params.filter);
+      return context.start === params.target && filterMeta(context, params.filter);
     },
     hasAuthors: ({ context }) => {
       return context.hasAuthors;

--- a/source/SIL.AppBuilder.Portal/common/workflow/startup-workflow.ts
+++ b/source/SIL.AppBuilder.Portal/common/workflow/startup-workflow.ts
@@ -70,12 +70,6 @@ export const StartupWorkflow = setup({
     [WorkflowState.Start]: {
       always: [
         jump({
-          target: WorkflowState.Readiness_Check,
-          filter: {
-            options: { has: WorkflowOptions.ApprovalProcess }
-          }
-        }),
-        jump({
           target: WorkflowState.Approval,
           filter: {
             options: { has: WorkflowOptions.ApprovalProcess }
@@ -125,7 +119,7 @@ export const StartupWorkflow = setup({
         jump({ target: WorkflowState.Published }),
         {
           guard: ({ context }) => context.options.includes(WorkflowOptions.ApprovalProcess),
-          target: WorkflowState.Readiness_Check
+          target: WorkflowState.Approval
         },
         {
           target: WorkflowState.Product_Creation
@@ -142,33 +136,13 @@ export const StartupWorkflow = setup({
                 options: { has: WorkflowOptions.ApprovalProcess }
               }
             },
-            target: WorkflowState.Readiness_Check
+            target: WorkflowState.Approval
           },
           {
             meta: { type: ActionType.Auto },
             target: WorkflowState.Product_Creation
           }
         ]
-      }
-    },
-    [WorkflowState.Readiness_Check]: {
-      meta: {
-        includeWhen: {
-          options: { has: WorkflowOptions.ApprovalProcess }
-        }
-      },
-      entry: assign({
-        instructions: 'readiness_check',
-        includeFields: ['storeDescription', 'listingLanguageCode']
-      }),
-      on: {
-        [WorkflowAction.Continue]: {
-          meta: {
-            type: ActionType.User,
-            user: RoleId.AppBuilder
-          },
-          target: WorkflowState.Approval
-        }
       }
     },
     [WorkflowState.Approval]: {

--- a/source/SIL.AppBuilder.Portal/common/workflow/startup-workflow.ts
+++ b/source/SIL.AppBuilder.Portal/common/workflow/startup-workflow.ts
@@ -12,7 +12,7 @@ import {
   WorkflowEvent,
   JumpParams,
   jump,
-  filterMeta
+  includeStateOrTransition
 } from '../public/workflow.js';
 import { RoleId } from '../public/prisma.js';
 
@@ -39,7 +39,7 @@ export const StartupWorkflow = setup({
   },
   guards: {
     canJump: ({ context }, params: JumpParams) => {
-      return context.start === params.target && filterMeta(context, params.filter);
+      return context.start === params.target && includeStateOrTransition(context, params.filter);
     },
     hasAuthors: ({ context }) => {
       return context.hasAuthors;

--- a/source/SIL.AppBuilder.Portal/common/workflow/startup-workflow.ts
+++ b/source/SIL.AppBuilder.Portal/common/workflow/startup-workflow.ts
@@ -4,7 +4,7 @@ import {
   WorkflowInput,
   WorkflowStateMeta,
   WorkflowTransitionMeta,
-  WorkflowAdminRequirements,
+  WorkflowOptions,
   ProductType,
   ActionType,
   WorkflowState,
@@ -61,7 +61,7 @@ export const StartupWorkflow = setup({
     includeArtifacts: false,
     environment: {},
     productType: input.productType,
-    adminRequirements: input.adminRequirements,
+    options: input.options,
     productId: input.productId,
     hasAuthors: input.hasAuthors,
     hasReviewers: input.hasReviewers
@@ -72,25 +72,25 @@ export const StartupWorkflow = setup({
         jump({
           target: WorkflowState.Readiness_Check,
           filter: {
-            adminRequirements: [WorkflowAdminRequirements.ApprovalProcess]
+            options: [WorkflowOptions.ApprovalProcess]
           }
         }),
         jump({
           target: WorkflowState.Approval,
           filter: {
-            adminRequirements: [WorkflowAdminRequirements.ApprovalProcess]
+            options: [WorkflowOptions.ApprovalProcess]
           }
         }),
         jump({
           target: WorkflowState.Approval_Pending,
           filter: {
-            adminRequirements: [WorkflowAdminRequirements.ApprovalProcess]
+            options: [WorkflowOptions.ApprovalProcess]
           }
         }),
         jump({
           target: WorkflowState.Terminated,
           filter: {
-            adminRequirements: [WorkflowAdminRequirements.ApprovalProcess]
+            options: [WorkflowOptions.ApprovalProcess]
           }
         }),
         jump({ target: WorkflowState.Product_Creation }),
@@ -125,7 +125,7 @@ export const StartupWorkflow = setup({
         jump({ target: WorkflowState.Published }),
         {
           guard: ({ context }) =>
-            context.adminRequirements.includes(WorkflowAdminRequirements.ApprovalProcess),
+            context.options.includes(WorkflowOptions.ApprovalProcess),
           target: WorkflowState.Readiness_Check
         },
         {
@@ -140,7 +140,7 @@ export const StartupWorkflow = setup({
             meta: {
               type: ActionType.Auto,
               includeWhen: {
-                adminRequirements: [WorkflowAdminRequirements.ApprovalProcess]
+                options: [WorkflowOptions.ApprovalProcess]
               }
             },
             target: WorkflowState.Readiness_Check
@@ -155,7 +155,7 @@ export const StartupWorkflow = setup({
     [WorkflowState.Readiness_Check]: {
       meta: {
         includeWhen: {
-          adminRequirements: [WorkflowAdminRequirements.ApprovalProcess]
+          options: [WorkflowOptions.ApprovalProcess]
         }
       },
       entry: assign({
@@ -175,7 +175,7 @@ export const StartupWorkflow = setup({
     [WorkflowState.Approval]: {
       meta: {
         includeWhen: {
-          adminRequirements: [WorkflowAdminRequirements.ApprovalProcess]
+          options: [WorkflowOptions.ApprovalProcess]
         }
       },
       entry: assign({
@@ -217,7 +217,7 @@ export const StartupWorkflow = setup({
     [WorkflowState.Approval_Pending]: {
       meta: {
         includeWhen: {
-          adminRequirements: [WorkflowAdminRequirements.ApprovalProcess]
+          options: [WorkflowOptions.ApprovalProcess]
         }
       },
       entry: [
@@ -252,7 +252,7 @@ export const StartupWorkflow = setup({
     [WorkflowState.Terminated]: {
       meta: {
         includeWhen: {
-          adminRequirements: [WorkflowAdminRequirements.ApprovalProcess]
+          options: [WorkflowOptions.ApprovalProcess]
         }
       },
       entry: assign({
@@ -486,9 +486,9 @@ export const StartupWorkflow = setup({
               type: ActionType.User,
               user: RoleId.OrgAdmin,
               includeWhen: {
-                adminRequirements: [
-                  WorkflowAdminRequirements.ApprovalProcess,
-                  WorkflowAdminRequirements.StoreAccess
+                options: [
+                  WorkflowOptions.ApprovalProcess,
+                  WorkflowOptions.AdminStoreAccess
                 ]
               }
             },
@@ -499,7 +499,7 @@ export const StartupWorkflow = setup({
               type: ActionType.User,
               user: RoleId.AppBuilder,
               includeWhen: {
-                adminRequirements: [WorkflowAdminRequirements.None]
+                options: [WorkflowOptions.None]
               }
             },
             target: WorkflowState.Create_App_Store_Entry
@@ -511,9 +511,9 @@ export const StartupWorkflow = setup({
               type: ActionType.User,
               user: RoleId.OrgAdmin,
               includeWhen: {
-                adminRequirements: [
-                  WorkflowAdminRequirements.ApprovalProcess,
-                  WorkflowAdminRequirements.StoreAccess
+                options: [
+                  WorkflowOptions.ApprovalProcess,
+                  WorkflowOptions.AdminStoreAccess
                 ]
               }
             },
@@ -524,7 +524,7 @@ export const StartupWorkflow = setup({
               type: ActionType.User,
               user: RoleId.AppBuilder,
               includeWhen: {
-                adminRequirements: [WorkflowAdminRequirements.None]
+                options: [WorkflowOptions.None]
               }
             },
             target: WorkflowState.Synchronize_Data
@@ -555,9 +555,9 @@ export const StartupWorkflow = setup({
               type: ActionType.User,
               user: RoleId.OrgAdmin,
               includeWhen: {
-                adminRequirements: [
-                  WorkflowAdminRequirements.ApprovalProcess,
-                  WorkflowAdminRequirements.StoreAccess
+                options: [
+                  WorkflowOptions.ApprovalProcess,
+                  WorkflowOptions.AdminStoreAccess
                 ]
               }
             },
@@ -574,7 +574,7 @@ export const StartupWorkflow = setup({
               type: ActionType.User,
               user: RoleId.AppBuilder,
               includeWhen: {
-                adminRequirements: [WorkflowAdminRequirements.None]
+                options: [WorkflowOptions.None]
               }
             },
             actions: assign({
@@ -592,9 +592,9 @@ export const StartupWorkflow = setup({
               type: ActionType.User,
               user: RoleId.OrgAdmin,
               includeWhen: {
-                adminRequirements: [
-                  WorkflowAdminRequirements.ApprovalProcess,
-                  WorkflowAdminRequirements.StoreAccess
+                options: [
+                  WorkflowOptions.ApprovalProcess,
+                  WorkflowOptions.AdminStoreAccess
                 ]
               }
             },
@@ -605,7 +605,7 @@ export const StartupWorkflow = setup({
               type: ActionType.User,
               user: RoleId.AppBuilder,
               includeWhen: {
-                adminRequirements: [WorkflowAdminRequirements.None]
+                options: [WorkflowOptions.None]
               }
             },
             target: WorkflowState.Synchronize_Data
@@ -725,9 +725,9 @@ export const StartupWorkflow = setup({
               type: ActionType.User,
               user: RoleId.OrgAdmin,
               includeWhen: {
-                adminRequirements: [
-                  WorkflowAdminRequirements.ApprovalProcess,
-                  WorkflowAdminRequirements.StoreAccess
+                options: [
+                  WorkflowOptions.ApprovalProcess,
+                  WorkflowOptions.AdminStoreAccess
                 ]
               }
             },
@@ -738,7 +738,7 @@ export const StartupWorkflow = setup({
               type: ActionType.User,
               user: RoleId.AppBuilder,
               includeWhen: {
-                adminRequirements: [WorkflowAdminRequirements.None]
+                options: [WorkflowOptions.None]
               }
             },
             target: WorkflowState.Published
@@ -750,9 +750,9 @@ export const StartupWorkflow = setup({
               type: ActionType.User,
               user: RoleId.OrgAdmin,
               includeWhen: {
-                adminRequirements: [
-                  WorkflowAdminRequirements.ApprovalProcess,
-                  WorkflowAdminRequirements.StoreAccess
+                options: [
+                  WorkflowOptions.ApprovalProcess,
+                  WorkflowOptions.AdminStoreAccess
                 ]
               }
             },
@@ -763,7 +763,7 @@ export const StartupWorkflow = setup({
               type: ActionType.User,
               user: RoleId.AppBuilder,
               includeWhen: {
-                adminRequirements: [WorkflowAdminRequirements.None]
+                options: [WorkflowOptions.None]
               }
             },
             target: WorkflowState.Synchronize_Data

--- a/source/SIL.AppBuilder.Portal/src/routes/(authenticated)/projects/[id=idNumber]/+page.server.ts
+++ b/source/SIL.AppBuilder.Portal/src/routes/(authenticated)/projects/[id=idNumber]/+page.server.ts
@@ -207,7 +207,7 @@ export const actions = {
       if (flow?.Type === WorkflowType.Startup) {
         Workflow.create(productId, {
           productType: flow.ProductType,
-          adminRequirements: flow.WorkflowOptions
+          options: flow.WorkflowOptions
         });
       }
     }


### PR DESCRIPTION
Builds on changes made in PR #1033.

Changes:
- Renamed `WorkflowAdminRequirements` to `WorkflowOptions` (future expandability)
- Wrap the filtering object in the `includeWhen` prop of the state/transition meta (readability)
- Refactored the filtration interface to be both more flexible and readable (albeit less performant, which could potentially be improved by updating the backend to a version of NodeJS that supports Set operations).
- Renamed `Workflow.filterMeta` to `includeStateOrTransition` and moved out of `Workflow` class.
- Removed `ReadinessCheck` as a state. (requested)
- Added `AllowTransferToAuthors` as another configuration option in `WorkflowOptions`. (requested)
  - This option is disabled by default across the provided workflow definitions in the seed script, meaning that it has to explicitly be enabled in a workflow definition to allow the `Transfer to Authors` action.