### PR TITLE
Paginate projects/filter route

### DIFF
--- a/source/SIL.AppBuilder.Portal/src/lib/projects/common.ts
+++ b/source/SIL.AppBuilder.Portal/src/lib/projects/common.ts
@@ -1,4 +1,7 @@
 import type { Prisma } from '@prisma/client';
+import * as v from 'valibot';
+import { idSchema } from '$lib/valibot';
+import { paginateSchema } from '$lib/table';
 
 export function pruneProjects(
   projects: Prisma.ProjectsGetPayload<{
@@ -46,3 +49,12 @@ export function pruneProjects(
 }
 
 export type PrunedProject = ReturnType<typeof pruneProjects>[0];
+
+export const projectSearchSchema = v.object({
+  organizationId: v.nullable(idSchema),
+  langCode: v.string(),
+  productDefinitionId: v.nullable(idSchema),
+  dateUpdatedRange: v.nullable(v.tuple([v.date(), v.nullable(v.date())])),
+  page: paginateSchema,
+  search: v.string()
+});

--- a/source/SIL.AppBuilder.Portal/src/routes/(authenticated)/projects/[filter=projectSelector]/[id]/+page.server.ts
+++ b/source/SIL.AppBuilder.Portal/src/routes/(authenticated)/projects/[filter=projectSelector]/[id]/+page.server.ts
@@ -1,8 +1,51 @@
 import type { Prisma } from '@prisma/client';
-import { redirect } from '@sveltejs/kit';
+import { redirect, error, type Actions } from '@sveltejs/kit';
 import { prisma } from 'sil.appbuilder.portal.common';
-import { pruneProjects } from '$lib/projects/common';
+import { projectSearchSchema, pruneProjects } from '$lib/projects/common';
+import { projectFilter } from '$lib/projects/common.server';
 import type { PageServerLoad } from './$types';
+import { superValidate, fail } from 'sveltekit-superforms';
+import { valibot } from 'sveltekit-superforms/adapters';
+
+function whereStatements(
+  filter: string,
+  orgId: number,
+  userId?: number
+): Prisma.ProjectsWhereInput {
+  const selector = filter as 'organization' | 'active' | 'archived' | 'all' | 'own';
+  switch (selector) {
+    case 'organization':
+      return {
+        OrganizationId: orgId,
+        DateArchived: null
+      };
+    case 'active':
+      return {
+        OrganizationId: orgId,
+        DateActive: {
+          not: null
+        },
+        DateArchived: null
+      };
+    case 'archived':
+      return {
+        OrganizationId: orgId,
+        DateArchived: {
+          not: null
+        }
+      };
+    case 'all':
+      return {
+        OrganizationId: orgId
+      };
+    case 'own':
+      return {
+        OrganizationId: orgId,
+        OwnerId: userId,
+        DateArchived: null
+      };
+  }
+}
 
 export const load = (async ({ params, url, locals }) => {
   const userId = (await locals.auth())?.user.userId;
@@ -11,36 +54,8 @@ export const load = (async ({ params, url, locals }) => {
     const paths = url.pathname.split('/');
     return redirect(302, paths.slice(0, paths.length - 1).join('/'));
   }
-  const selector = params.filter as 'organization' | 'active' | 'archived' | 'all' | 'own';
-  const whereStatements: Record<typeof selector, Prisma.ProjectsWhereInput> = {
-    organization: {
-      OrganizationId: orgId,
-      DateArchived: null
-    },
-    active: {
-      OrganizationId: orgId,
-      DateActive: {
-        not: null
-      },
-      DateArchived: null
-    },
-    archived: {
-      OrganizationId: orgId,
-      DateArchived: {
-        not: null
-      }
-    },
-    all: {
-      OrganizationId: orgId
-    },
-    own: {
-      OrganizationId: orgId,
-      OwnerId: userId,
-      DateArchived: null
-    }
-  };
   const projects = await prisma.projects.findMany({
-    where: whereStatements[selector],
+    where: whereStatements(params.filter, orgId, userId),
     include: {
       Products: {
         include: {
@@ -50,8 +65,57 @@ export const load = (async ({ params, url, locals }) => {
       Owner: true,
       Group: true,
       Organization: true
-    }
+    },
+    take: 10
   });
-  // TODO: Likely need to paginate
-  return { projects: pruneProjects(projects) };
+  return {
+    projects: pruneProjects(projects),
+    form: await superValidate(
+      {
+        page: {
+          page: 0,
+          size: 10
+        },
+        organizationId: orgId
+      },
+      valibot(projectSearchSchema)
+    ),
+    count: await prisma.projects.count({ where: whereStatements(params.filter, orgId, userId) }),
+    productDefinitions: await prisma.productDefinitions.findMany()
+  };
 }) satisfies PageServerLoad;
+
+export const actions: Actions = {
+  page: async function ({ params, request, locals }) {
+    const userId = (await locals.auth())?.user.userId;
+    if (!userId) return error(400);
+
+    const form = await superValidate(request, valibot(projectSearchSchema));
+    if (!form.valid) return fail(400, { form, ok: false });
+
+    const where: Prisma.ProjectsWhereInput = {
+      ...projectFilter(form.data),
+      ...whereStatements(params.filter!, parseInt(params.id!), userId)
+    };
+
+    const projects = await prisma.projects.findMany({
+      where: where,
+      include: {
+        Products: {
+          include: {
+            ProductDefinition: true
+          }
+        },
+        Owner: true,
+        Group: true,
+        Organization: true
+      },
+      skip: form.data.page.size * form.data.page.page,
+      take: form.data.page.size
+    });
+
+    const count = await prisma.projects.count({ where: where });
+
+    return { form, ok: true, query: { data: pruneProjects(projects), count } };
+  }
+};

--- a/source/SIL.AppBuilder.Portal/src/routes/(authenticated)/projects/[filter=projectSelector]/[id]/+page.svelte
+++ b/source/SIL.AppBuilder.Portal/src/routes/(authenticated)/projects/[filter=projectSelector]/[id]/+page.svelte
@@ -80,7 +80,7 @@
       </div>
     </div>
   </form>
-  <div class="w-full flex flex-row flex-wrap place-content-between p-4 pb-0 px-6 gap-4">
+  <div class="w-full flex flex-row flex-wrap place-content-between gap-1 mt-4">
     <div class="flex flex-row flex-wrap mobile-sizing gap-1 mx-4">
       <button
         class="action"

--- a/source/SIL.AppBuilder.Portal/src/routes/(authenticated)/projects/[filter=projectSelector]/[id]/+page.svelte
+++ b/source/SIL.AppBuilder.Portal/src/routes/(authenticated)/projects/[filter=projectSelector]/[id]/+page.svelte
@@ -1,52 +1,86 @@
 <script lang="ts">
   import type { PageData } from './$types';
-  import { goto } from '$app/navigation';
-  import { page } from '$app/stores';
+  import { goto, afterNavigate } from '$app/navigation';
   import SearchBar from '$lib/components/SearchBar.svelte';
   import * as m from '$lib/paraglide/messages';
+  import type { PrunedProject } from '$lib/projects/common';
   import ProjectFilterSelector from '$lib/projects/components/ProjectFilterSelector.svelte';
+  import { superForm } from 'sveltekit-superforms';
+  import type { FormResult } from 'sveltekit-superforms';
+  import { writable } from 'svelte/store';
   import ProjectCard from '$lib/projects/components/ProjectCard.svelte';
-  import { languageTag } from '$lib/paraglide/runtime';
+  import Pagination from '$lib/components/Pagination.svelte';
 
   export let data: PageData;
 
   let selectedProjects: number[] = [];
-  let selectedOrg = parseInt($page.params.id);
-  let searchTerm: string = '';
 
-  $: filteredProjects = data.projects.filter((project) => {
-    const searchTermLower = searchTerm.toLowerCase();
-    return [
-      project.Name,
-      project.Language,
-      project.OwnerName,
-      project.OrganizationName,
-      project.GroupName
-    ].some((field) => field?.toLowerCase().includes(searchTermLower));
+  const projects = writable(data.projects);
+  const count = writable(data.count);
+
+  const { form, enhance, submit } = superForm(data.form, {
+    dataType: 'json',
+    resetForm: false,
+    onChange(event) {
+      if (
+        !(
+          event.paths.includes('page.size') ||
+          event.paths.includes('langCode') ||
+          event.paths.includes('search')
+        )
+      ) {
+        submit();
+      }
+    },
+    onUpdate(event) {
+      const data = event.result.data as FormResult<{
+        query: { data: PrunedProject[]; count: number };
+      }>;
+      if (event.form.valid && data.query) {
+        projects.set(data.query.data);
+        count.set(data.query.count);
+      }
+    }
+  });
+
+  afterNavigate((navigation) => {
+    projects.set(data.projects);
+    count.set(data.count);
+    $form.organizationId = data.form.data.organizationId;
   });
 </script>
 
 <div class="w-full max-w-6xl mx-auto relative px-2">
-  <div class="flex flex-row place-content-between w-full pt-4 flex-wrap">
-    <div class="inline-block">
-      <ProjectFilterSelector />
+  <!-- svelte-ignore a11y-no-noninteractive-element-interactions -->
+  <form
+    method="POST"
+    action="?/page"
+    use:enhance
+    on:keydown={(event) => {
+      if (event.key === 'Enter') submit();
+    }}
+  >
+    <div class="flex flex-row place-content-between w-full pt-4 flex-wrap">
+      <div class="inline-block">
+        <ProjectFilterSelector />
+      </div>
+      <div class="flex flex-row flex-wrap md:flex-nowrap place-content-end items-center mx-4 mobile-sizing gap-1">
+        <select
+          class="select select-bordered mobile-sizing"
+          bind:value={$form.organizationId}
+          on:change={() => goto($form.organizationId + '')}
+        >
+          {#each data.organizations as organization}
+            <option value={organization.Id} selected={$form.organizationId === organization.Id}>
+              {organization.Name}
+            </option>
+          {/each}
+        </select>
+        <SearchBar bind:value={$form.search} className="w-full max-w-xs md:w-auto md:max-w-none" />
+      </div>
     </div>
-    <div
-      class="flex flex-row flex-wrap md:flex-nowrap place-content-end items-center mx-4 mobile-sizing gap-1"
-    >
-      <select
-        class="select select-bordered mobile-sizing"
-        bind:value={selectedOrg}
-        on:change={() => goto(selectedOrg + '')}
-      >
-        {#each data.organizations as organization}
-          <option value={organization.Id}>{organization.Name}</option>
-        {/each}
-      </select>
-      <SearchBar bind:value={searchTerm} className="w-full max-w-xs md:w-auto md:max-w-none" />
-    </div>
-  </div>
-  <div class="w-full flex flex-row flex-wrap place-content-between gap-1 mt-4">
+  </form>
+  <div class="w-full flex flex-row flex-wrap place-content-between p-4 pb-0 px-6 gap-4">
     <div class="flex flex-row flex-wrap mobile-sizing gap-1 mx-4">
       <button
         class="action"
@@ -68,9 +102,9 @@
       </button>
     </div>
   </div>
-  {#if filteredProjects.length > 0}
+  {#if $projects.length > 0}
     <div class="w-full relative p-4">
-      {#each filteredProjects.sort( (a, b) => (a.Name ?? '').localeCompare(b.Name ?? '', languageTag()) ) as project}
+      {#each $projects as project}
         <ProjectCard {project}>
           <span slot="checkbox">
             <input
@@ -86,6 +120,19 @@
   {:else}
     <p class="m-8">{m.projectTable_empty()}</p>
   {/if}
+  <!-- svelte-ignore a11y-no-noninteractive-element-interactions -->
+  <form
+    method="POST"
+    action="?/page"
+    use:enhance
+    on:keydown={(event) => {
+      if (event.key === 'Enter') submit();
+    }}
+  >
+    <div class="w-full flex flex-row place-content-start p-4 space-between-4 flex-wrap gap-1">
+      <Pagination bind:size={$form.page.size} total={$count} bind:page={$form.page.page} />
+    </div>
+  </form>
 </div>
 
 <style lang="postcss">

--- a/source/SIL.AppBuilder.Portal/src/routes/(authenticated)/projects/[id=idNumber]/+page.svelte
+++ b/source/SIL.AppBuilder.Portal/src/routes/(authenticated)/projects/[id=idNumber]/+page.svelte
@@ -221,7 +221,7 @@
                   )
                 })}
                 {m.tasks_forNames({
-                  allowedNames: product.ActiveTransition?.AllowedUserNames ?? 'Scriptoria',
+                  allowedNames: product.ActiveTransition?.AllowedUserNames || m.appName(),
                   activityName: product.ActiveTransition?.InitialState ?? ''
                 })}
                 {#if product.UserTasks.slice(-1)[0]?.UserId === $page.data.session?.user.userId}


### PR DESCRIPTION
Added server-side pagination, searching, and sorting to the `/projects/[filter=projectSelector]/[id]` route.

The only UI change was adding the pagination component to the bottom, so there is no before screenshot.

![image](https://github.com/user-attachments/assets/9157f0f6-4087-4e76-8ac5-b631b2ea20e5)
