### PR TITLE
Paginate /users

### DIFF
--- a/source/SIL.AppBuilder.Portal/src/routes/(authenticated)/+layout.server.ts
+++ b/source/SIL.AppBuilder.Portal/src/routes/(authenticated)/+layout.server.ts
@@ -15,23 +15,26 @@ export const load: LayoutServerLoad = async (event) => {
     },
     include: { UserRoles: true, Organizations: true }
   });
-  const organizations = user?.UserRoles.find((roleDef) => roleDef.RoleId === RoleId.SuperAdmin)
-    ? await prisma.organizations.findMany({
-      include: {
-        Owner: true
-      }
-    })
-    : await prisma.organizations.findMany({
-      where: {
-        OrganizationMemberships: {
-          every: {
-            UserId: userId
+  const organizations = await prisma.organizations.findMany({
+    where: user?.UserRoles.find((roleDef) => roleDef.RoleId === RoleId.SuperAdmin)
+      ? undefined
+      : {
+          OrganizationMemberships: {
+            every: {
+              UserId: userId
+            }
           }
+        },
+    select: {
+      Id: true,
+      Name: true,
+      LogoUrl: true,
+      Owner: {
+        select: {
+          Name: true
         }
-      },
-      include: {
-        Owner: true
       }
-    });
+    }
+  });
   return { organizations, numberOfTasks };
 };

--- a/source/SIL.AppBuilder.Portal/src/routes/(authenticated)/users/+page.server.ts
+++ b/source/SIL.AppBuilder.Portal/src/routes/(authenticated)/users/+page.server.ts
@@ -8,6 +8,7 @@ import { idSchema } from '$lib/valibot';
 import { superValidate } from 'sveltekit-superforms';
 import { valibot } from 'sveltekit-superforms/adapters';
 import { paginateSchema } from '$lib/table';
+import { minifyUser } from './common';
 
 const lockSchema = v.object({
   user: idSchema,
@@ -78,47 +79,6 @@ function adminOrDefaultWhere(isSuper: boolean, orgIds: number[]) {
         }
       };
 }
-
-type UserInfo = {
-  Id: number;
-  Name: string | null;
-  Email: string | null;
-  UserRoles: { OrganizationId: number; RoleId: number }[];
-  GroupMemberships: { Group: { Id: number; OwnerId: number } }[];
-  OrganizationMemberships: {
-    OrganizationId: number;
-  }[];
-  IsLocked: boolean;
-};
-// or by using smaller (or even minified) keys (eg N instead of Name, O instead of Organizations)
-// Done - Aidan
-function minifyUser(user: UserInfo) {
-  return {
-    /** User Id */
-    I: user.Id,
-    /** User Name */
-    N: user.Name,
-    /** User Email */
-    E: user.Email,
-    /** User OrganizationMemberships */
-    O: user.OrganizationMemberships.map((orgMem) => ({
-      /** Roles */
-      R: user.UserRoles.filter((ur) => ur.OrganizationId === orgMem.OrganizationId).map(
-        (r) => r.RoleId
-      ),
-      /** Organization Id */
-      I: orgMem.OrganizationId,
-      /** Group Ids */
-      G: user.GroupMemberships.filter(
-        (groupMem) => groupMem.Group.OwnerId === orgMem.OrganizationId
-      ).map((group) => group.Group.Id)
-    })),
-    /** User IsLocked */
-    A: !user.IsLocked
-  };
-}
-
-export type MinifiedUser = ReturnType<typeof minifyUser>;
 
 export const load = (async (event) => {
   const userInfo = (await event.locals.auth())?.user;

--- a/source/SIL.AppBuilder.Portal/src/routes/(authenticated)/users/+page.server.ts
+++ b/source/SIL.AppBuilder.Portal/src/routes/(authenticated)/users/+page.server.ts
@@ -1,68 +1,64 @@
 import { error, redirect } from '@sveltejs/kit';
 import { DatabaseWrites, prisma } from 'sil.appbuilder.portal.common';
 import { RoleId } from 'sil.appbuilder.portal.common/prisma';
+import type { Prisma } from '@prisma/client';
 import type { Actions, PageServerLoad } from './$types';
 import * as v from 'valibot';
 import { idSchema } from '$lib/valibot';
 import { superValidate } from 'sveltekit-superforms';
 import { valibot } from 'sveltekit-superforms/adapters';
+import { paginateSchema } from '$lib/table';
 
 const lockSchema = v.object({
   user: idSchema,
   active: v.boolean()
 });
 
-// Not used, just for reference
-// eslint-disable-next-line @typescript-eslint/no-unused-vars
-type UserInfo = {
-  Id: number;
-  Name: string;
-  FamilyName: string;
-  Organizations: {
-    Roles: number[];
-    Name: string;
-    Groups: string[];
-  }[];
-  IsLocked: boolean;
-};
+const userSchema = v.object({
+  page: paginateSchema,
+  search: v.string(),
+  organizationId: v.nullable(idSchema)
+});
 
-export const load = (async (event) => {
-  const userInfo = (await event.locals.auth())?.user;
-  const userId = userInfo?.userId;
-  if (!userId) return redirect(302, '/');
-
-  // If we are a superadmin, collect all users, otherwise
-  // collect every user in one of our organizations and deduplicate them
-  const include = {
+function select(orgIds?: number[]) {
+  return {
+    Id: true,
+    Name: true,
+    Email: true,
+    IsLocked: true,
     UserRoles: {
-      include: {
-        Organization: true
+      where: orgIds ? { OrganizationId: { in: orgIds } } : undefined,
+      select: {
+        RoleId: true,
+        OrganizationId: true
       }
     },
     GroupMemberships: {
-      include: {
-        Group: true
+      where: orgIds ? { Group: { OwnerId: { in: orgIds } } } : undefined,
+      select: {
+        Group: {
+          select: { Id: true, OwnerId: true }
+        }
       }
     },
     OrganizationMemberships: {
-      include: {
-        Organization: true
+      where: orgIds ? { OrganizationId: { in: orgIds } } : undefined,
+      select: {
+        OrganizationId: true
       }
     }
   };
+}
 
-  // Sacrificing perfect type safety for readibility
-  let users;
-  let organizations;
-
-  if (userInfo.roles.find((r) => r[1] === RoleId.SuperAdmin)) {
-    // Get all users that are locked or are a member of at least one organization
-    // (Users that are not in an organization and are not locked are not interesting
-    // because they can't login and behave essentially as locked users or as users
-    // who have never logged in before)
-    users = await prisma.users.findMany({
-      include,
-      where: {
+// If we are a superadmin, collect all users, otherwise
+// collect every user in one of our organizations
+function adminOrDefaultWhere(isSuper: boolean, orgIds: number[]) {
+  return isSuper
+    ? {
+        // Get all users that are locked or are a member of at least one organization
+        // (Users that are not in an organization and are not locked are not interesting
+        // because they can't login and behave essentially as locked users or as users
+        // who have never logged in before)
         OR: [
           {
             OrganizationMemberships: {
@@ -74,99 +70,94 @@ export const load = (async (event) => {
           }
         ]
       }
-    });
-    organizations = await prisma.organizations.findMany({
-      select: {
-        Id: true,
-        Name: true
-      }
-    });
-  } else {
-    // For each OrganizationMembership of the current user where they are an organization admin, include all
-    // users of that Organization. This creates duplicates for users that are in multiple of the same
-    // organizations as the current user so we put them in a map by user id to prune duplicates. There may
-    // be a better way to handle this with prisma itself
-
-    // Initially this gives a structure of
-    /**
-     * user: {
-     *  OrganizationMemberships: [{
-     *    Organization: {
-     *      OrganizationMemberships: [{
-     *        User: {}
-     *      }]
-     *    }
-     *  }]
-     * }
-     */
-    // so we flatMap it into an array of all of the OrganizationMemberships Users, and pass it to the Map indexed by user.Id
-    // finally, filter the organizations we return by the organizations the current user is an organizational admin for
-
-    users = [
-      ...[
-        ...new Map(
-          (await prisma.users.findUnique({
-            where: {
-              Id: userId
-            },
-            include: {
-              OrganizationMemberships: {
-                where: {
-                  Organization: {
-                    UserRoles: {
-                      some: {
-                        RoleId: RoleId.OrgAdmin,
-                        UserId: userId
-                      }
-                    }
-                  }
-                },
-                include: {
-                  Organization: {
-                    include: {
-                      OrganizationMemberships: {
-                        include: {
-                          User: {
-                            include
-                          }
-                        }
-                      }
-                    }
-                  }
-                }
-              }
-            }
-          }))!.OrganizationMemberships.flatMap((org) =>
-            org.Organization.OrganizationMemberships.flatMap((orgMem) => orgMem.User)
-          ).map((user) => [user.Id, user])
-        ).values()
-      ]
-    ];
-    organizations = await prisma.organizations.findMany({
-      where: {
-        UserRoles: {
+    : {
+        OrganizationMemberships: {
           some: {
-            RoleId: RoleId.OrgAdmin,
-            UserId: userId
+            OrganizationId: { in: orgIds }
           }
         }
-      },
-      select: {
-        Id: true,
-        Name: true,
-        UserRoles: true
-      }
-    });
-    const currentUserOrgAdmins = new Set(organizations.map((org) => org.Id));
-    users.forEach((user) => {
-      user.OrganizationMemberships = user.OrganizationMemberships.filter((mem) => {
-        return currentUserOrgAdmins.has(mem.OrganizationId);
-      });
-      user.GroupMemberships = user.GroupMemberships.filter((mem) => {
-        return currentUserOrgAdmins.has(mem.Group.OwnerId);
-      });
-    });
-  }
+      };
+}
+
+type UserInfo = {
+  Id: number;
+  Name: string | null;
+  Email: string | null;
+  UserRoles: { OrganizationId: number; RoleId: number }[];
+  GroupMemberships: { Group: { Id: number; OwnerId: number } }[];
+  OrganizationMemberships: {
+    OrganizationId: number;
+  }[];
+  IsLocked: boolean;
+};
+// or by using smaller (or even minified) keys (eg N instead of Name, O instead of Organizations)
+// Done - Aidan
+function minifyUser(user: UserInfo) {
+  return {
+    /** User Id */
+    I: user.Id,
+    /** User Name */
+    N: user.Name,
+    /** User Email */
+    E: user.Email,
+    /** User OrganizationMemberships */
+    O: user.OrganizationMemberships.map((orgMem) => ({
+      /** Roles */
+      R: user.UserRoles.filter((ur) => ur.OrganizationId === orgMem.OrganizationId).map(
+        (r) => r.RoleId
+      ),
+      /** Organization Id */
+      I: orgMem.OrganizationId,
+      /** Group Ids */
+      G: user.GroupMemberships.filter(
+        (groupMem) => groupMem.Group.OwnerId === orgMem.OrganizationId
+      ).map((group) => group.Group.Id)
+    })),
+    /** User IsLocked */
+    A: !user.IsLocked
+  };
+}
+
+export type MinifiedUser = ReturnType<typeof minifyUser>;
+
+export const load = (async (event) => {
+  const userInfo = (await event.locals.auth())?.user;
+  const userId = userInfo?.userId;
+  if (!userId) return redirect(302, '/');
+
+  const isSuper = !!userInfo.roles.find((r) => r[1] === RoleId.SuperAdmin);
+
+  const organizations = await prisma.organizations.findMany({
+    where: isSuper
+      ? undefined
+      : {
+          UserRoles: {
+            some: {
+              RoleId: RoleId.OrgAdmin,
+              UserId: userId
+            }
+          }
+        },
+    select: {
+      Id: true,
+      Name: true,
+      UserRoles: true
+    }
+  });
+
+  const orgIds = organizations.map((o) => o.Id);
+
+  const users = await prisma.users.findMany({
+    orderBy: {
+      FamilyName: 'asc'
+    },
+    select: select(isSuper ? undefined : orgIds),
+    where: adminOrDefaultWhere(isSuper, orgIds),
+    // More significantly, could paginate results to around 50 users/page = 10 KB
+    // Done - Aidan
+    take: 50
+  });
+
   return {
     // Only pass essential information to the client.
     // About 120 bytes per small user (with one organization and one group), and 240 for a larger user in several organizations.
@@ -174,44 +165,16 @@ export const load = (async (event) => {
     // The whole page is about 670 KB without this data.
     // Only superadmins would see this larger size, most users have organizations with much fewer users where it does not matter
 
+    users: users.map(minifyUser),
+    userCount: users.length,
     // Could be improved by putting group names into a referenced palette
     // (minimal returns if most users are in different organizations and groups)
     // I went ahead and did this too. My assumption is that there will generally be multiple users in each organization and group, so I think this should be a justifiable change. - Aidan
-
-    // or by using smaller (or even minified) keys (eg N instead of Name, O instead of Organizations)
-    // Done - Aidan
-
-    // More significantly, could paginate results to around 50 users/page = 10 KB
-    users: users.map((user) => ({
-      /** User Id */
-      I: user.Id,
-      /** User Name */
-      N: user.Name!,
-      /** User FamilyName */
-      F: user.FamilyName!,
-      /** User Email */
-      E: user.Email,
-      /** User OrganizationMemberships */
-      O: user.OrganizationMemberships.map((org) => ({
-        /** Roles */
-        R: user.UserRoles.filter((r) => r.OrganizationId === org.OrganizationId).map(
-          (r) => r.RoleId
-        ),
-        /** Organization Id */
-        I: org.OrganizationId,
-        /** Group Ids */
-        G: user.GroupMemberships.filter((group) => group.Group.OwnerId === org.OrganizationId).map(
-          (group) => group.Group.Id
-        )
-      })),
-      /** User IsLocked */
-      A: !user.IsLocked
-    })),
     groups: Object.fromEntries(
       (
         await prisma.groups.findMany({
           where: {
-            OwnerId: { in: organizations.map((o) => o.Id) },
+            OwnerId: { in: orgIds },
             GroupMemberships: {
               some: {}
             }
@@ -220,7 +183,17 @@ export const load = (async (event) => {
       ).map((g) => [g.Id, g.Name])
     ),
     organizations: Object.fromEntries(organizations?.map((org) => [org.Id, org.Name])),
-    organizationCount: organizations.length
+    organizationCount: organizations.length,
+    form: await superValidate(
+      {
+        organizationId: organizations.length > 1 ? null : organizations[0].Id,
+        page: {
+          page: 0,
+          size: 50
+        }
+      },
+      valibot(userSchema)
+    )
   };
 }) satisfies PageServerLoad;
 
@@ -240,5 +213,79 @@ export const actions: Actions = {
       }
     });
     return { form, ok: true };
+  },
+
+  async page(event) {
+    const session = await event.locals.auth();
+    if (!session) return error(403);
+    const form = await superValidate(event, valibot(userSchema));
+    if (!form.valid) return { form, ok: false };
+
+    const isSuper = !!session.user.roles.find((r) => r[1] === RoleId.SuperAdmin);
+
+    const organizations = await prisma.organizations.findMany({
+      where:
+        form.data.organizationId !== null
+          ? { Id: form.data.organizationId }
+          : isSuper
+          ? undefined
+          : {
+              UserRoles: {
+                some: {
+                  RoleId: RoleId.OrgAdmin,
+                  UserId: session.user.userId
+                }
+              }
+            },
+      select: {
+        Id: true,
+        Name: true,
+        UserRoles: true
+      }
+    });
+
+    const orgIds = organizations.map((o) => o.Id);
+
+    const where: Prisma.UsersWhereInput = {
+      AND: [
+        adminOrDefaultWhere(isSuper, orgIds),
+        {
+          OR: form.data.search
+            ? [
+                {
+                  Name: {
+                    contains: form.data.search,
+                    mode: 'insensitive'
+                  }
+                },
+                {
+                  Email: {
+                    contains: form.data.search,
+                    mode: 'insensitive'
+                  }
+                }
+              ]
+            : undefined
+        }
+      ]
+    };
+
+    const users = await prisma.users.findMany({
+      orderBy: {
+        FamilyName: 'asc'
+      },
+      select: select(isSuper ? undefined : orgIds),
+      where: where,
+      // More significantly, could paginate results to around 50 users/page = 10 KB
+      // Done - Aidan
+      skip: form.data.page.page * form.data.page.size,
+      take: form.data.page.size
+    });
+
+    return {
+      form,
+      ok: true,
+      query: { data: users.map(minifyUser), count: await prisma.users.count({ where: where }) }
+    };
   }
 };

--- a/source/SIL.AppBuilder.Portal/src/routes/(authenticated)/users/+page.svelte
+++ b/source/SIL.AppBuilder.Portal/src/routes/(authenticated)/users/+page.svelte
@@ -14,18 +14,18 @@
 </script>
 
 <div class="w-full">
-  <div class="flex flex-row place-content-between align-middle flex-wrap items-center">
-    <h1 class="pb-6">{m.users_title()}</h1>
-    <div
-      class="content-center m-4 gap-2 flex flex-wrap items-end w-full place-content-between"
-    >
-      {#if data.organizations.length > 1}
+  <div class="flex flex-row place-content-between w-full pt-4 flex-wrap">
+    <div class="inline-block">
+      <h1 class="p-4 pl-6">{m.users_title()}</h1>
+    </div>
+    <div class="flex flex-row place-content-end items-center ml-4">
+      {#if data.organizationCount > 1}
         <label class="flex flex-wrap items-center gap-x-2">
-          <span>{m.users_organization_filter()}:</span>
+          <span class="label-text">{m.users_organization_filter()}:</span>
           <select class="select select-bordered" name="org" bind:value={selectedOrg}>
             <option value={0}>{m.org_allOrganizations()}</option>
-            {#each data.organizations as organization}
-              <option value={organization.Id}>{organization.Name}</option>
+            {#each Object.entries(data.organizations) as [Id, Name]}
+              <option value={Id}>{Name}</option>
             {/each}
           </select>
         </label>
@@ -43,30 +43,28 @@
         </tr>
       </thead>
       <tbody>
-        {#each data.users
-          .filter((u) => (u.Name.toLowerCase().includes(searchQuery.toLowerCase()) || u.Email?.toLowerCase().includes(searchQuery.toLowerCase())) && u.Organizations.find((o) => o.Id === selectedOrg || selectedOrg === 0))
-          .sort((a, b) => a.FamilyName.localeCompare(b.FamilyName, languageTag())) as user}
+        {#each data.users as user}
           <tr class="align-top">
             <td class="p-2">
               <p>
-                <a href="/users/{user.Id}/settings" class="link pb-2">
-                  {user.Name}
+                <a href="/users/{user.I}/settings" class="link pb-2">
+                  {user.N}
                 </a>
               </p>
               <p class="text-sm overflow-hidden">
-                {user.Email?.replace('@', '\u200b@')}
+                {user.E?.replace('@', '\u200b@')}
               </p>
             </td>
             <td class="py-2">
-              {#each user.Organizations as org}
+              {#each user.O as org}
                 <div class="p-1">
                   <span>
                     <b>
-                      {data.organizations.find((o) => o.Id === org.Id)?.Name}
+                      {data.organizations[org.I]}
                     </b>
                   </span>
                   <br />
-                  {org.Roles.map(
+                  {org.R.map(
                     (r) =>
                       [
                         '',
@@ -80,15 +78,15 @@
               {/each}
             </td>
             <td class="py-2">
-              {#each user.Organizations as org}
+              {#each user.O as org}
                 <div class="p-1">
                   <span>
                     <b>
-                      {data.organizations.find((o) => o.Id === org.Id)?.Name}
+                      {data.organizations[org.I]}
                     </b>
                   </span>
                   <br />
-                  {org.Groups.join(', ') || m.common_none()}
+                  {org.G.map((g) => data.groups[g]).join(', ') || m.common_none()}
                 </div>
               {/each}
             </td>

--- a/source/SIL.AppBuilder.Portal/src/routes/(authenticated)/users/+page.svelte
+++ b/source/SIL.AppBuilder.Portal/src/routes/(authenticated)/users/+page.svelte
@@ -1,16 +1,12 @@
 <script lang="ts">
   import SearchBar from '$lib/components/SearchBar.svelte';
   import * as m from '$lib/paraglide/messages';
-  import { languageTag } from '$lib/paraglide/runtime';
   import type { PageData } from './$types';
+  import { enhance } from '$app/forms';
 
   export let data: PageData;
   let selectedOrg: number = 0;
   let searchQuery = '';
-
-  let forms: { [key: string]: any } = {};
-
-  const timeouts = new Map<number, any>();
 </script>
 
 <div class="w-full">
@@ -40,6 +36,7 @@
           <th>{m.users_table_columns_name()}</th>
           <th>{m.users_table_columns_role()}</th>
           <th>{m.users_table_columns_groups()}</th>
+          <th>{m.users_table_columns_active()}</th>
         </tr>
       </thead>
       <tbody>
@@ -89,6 +86,34 @@
                   {org.G.map((g) => data.groups[g]).join(', ') || m.common_none()}
                 </div>
               {/each}
+            </td>
+            <td class="py-2">
+              <form
+                method="POST"
+                action="?/lock"
+                class="form-control"
+                use:enhance={() => {
+                  return async ({ update }) => {
+                    await update({ reset: false, invalidateAll: false });
+                  };
+                }}
+              >
+                <input class="hidden" type="hidden" name="user" value={user.I} />
+                <input
+                  class="toggle"
+                  disabled={data.session?.user.userId === user.I}
+                  type="checkbox"
+                  name="active"
+                  bind:checked={user.A}
+                  on:change={(e) => {
+                    if (data.session?.user.userId !== user.I) {
+                      //@ts-ignore
+                      e.currentTarget.parentElement?.requestSubmit();
+                      // Apparently full TS is not supported in this instance, otherwise I would just cast to HTMLFormElement
+                    }
+                  }}
+                />
+              </form>
             </td>
           </tr>
         {/each}

--- a/source/SIL.AppBuilder.Portal/src/routes/(authenticated)/users/+page.svelte
+++ b/source/SIL.AppBuilder.Portal/src/routes/(authenticated)/users/+page.svelte
@@ -2,11 +2,35 @@
   import SearchBar from '$lib/components/SearchBar.svelte';
   import * as m from '$lib/paraglide/messages';
   import type { PageData } from './$types';
-  import { enhance } from '$app/forms';
+  import { enhance as svk_enhance } from '$app/forms';
+  import { writable } from 'svelte/store';
+  import Pagination from '$lib/components/Pagination.svelte';
+  import { superForm, type FormResult } from 'sveltekit-superforms';
+  import type { MinifiedUser } from './proxy+page.server';
 
   export let data: PageData;
-  let selectedOrg: number = 0;
-  let searchQuery = '';
+
+  const users = writable(data.users);
+  const count = writable(data.userCount);
+
+  const { form, enhance, submit } = superForm(data.form, {
+    dataType: 'json',
+    resetForm: false,
+    onChange(event) {
+      if (!(event.paths.includes('page.size') || event.paths.includes('search'))) {
+        submit();
+      }
+    },
+    onUpdate(event) {
+      const data = event.result.data as FormResult<{
+        query: { data: MinifiedUser[]; count: number };
+      }>;
+      if (event.form.valid && data.query) {
+        users.set(data.query.data);
+        count.set(data.query.count);
+      }
+    }
+  });
 </script>
 
 <div class="w-full">
@@ -14,20 +38,25 @@
     <div class="inline-block">
       <h1 class="p-4 pl-6">{m.users_title()}</h1>
     </div>
-    <div class="flex flex-row place-content-end items-center ml-4">
+    <form
+      method="POST"
+      action="?/page"
+      use:enhance
+      class="flex flex-row flex-wrap place-content-end items-center p-2 gap-1"
+    >
       {#if data.organizationCount > 1}
-        <label class="flex flex-wrap items-center gap-x-2">
+        <label class="flex flex-wrap items-center gap-x-2 w-full max-w-xs md:w-auto md:max-w-none">
           <span class="label-text">{m.users_organization_filter()}:</span>
-          <select class="select select-bordered" name="org" bind:value={selectedOrg}>
-            <option value={0}>{m.org_allOrganizations()}</option>
+          <select class="select select-bordered grow" name="org" bind:value={$form.organizationId}>
+            <option value={null}>{m.org_allOrganizations()}</option>
             {#each Object.entries(data.organizations) as [Id, Name]}
               <option value={Id}>{Name}</option>
             {/each}
           </select>
         </label>
       {/if}
-      <SearchBar bind:value={searchQuery} className="w-full max-w-xs md:w-auto md:max-w-none" />
-    </div>
+      <SearchBar bind:value={$form.search} className="w-full max-w-xs md:w-auto md:max-w-none" />
+      </form>
   </div>
   <div class="m-4 relative mt-0">
     <table class="w-full">
@@ -40,7 +69,7 @@
         </tr>
       </thead>
       <tbody>
-        {#each data.users as user}
+        {#each $users as user}
           <tr class="align-top">
             <td class="p-2">
               <p>
@@ -92,7 +121,7 @@
                 method="POST"
                 action="?/lock"
                 class="form-control"
-                use:enhance={() => {
+                use:svk_enhance={() => {
                   return async ({ update }) => {
                     await update({ reset: false, invalidateAll: false });
                   };
@@ -120,6 +149,14 @@
       </tbody>
     </table>
   </div>
+  <form
+    method="POST"
+    action="?/page"
+    use:enhance
+    class="m-4 pb-4 flex flex-row flex-wrap gap-2 place-content-center"
+  >
+    <Pagination bind:size={$form.page.size} total={$count} bind:page={$form.page.page} />
+  </form>
 </div>
 
 <style>

--- a/source/SIL.AppBuilder.Portal/src/routes/(authenticated)/users/+page.svelte
+++ b/source/SIL.AppBuilder.Portal/src/routes/(authenticated)/users/+page.svelte
@@ -6,7 +6,7 @@
   import { writable } from 'svelte/store';
   import Pagination from '$lib/components/Pagination.svelte';
   import { superForm, type FormResult } from 'sveltekit-superforms';
-  import type { MinifiedUser } from './proxy+page.server';
+  import type { MinifiedUser } from './common';
 
   export let data: PageData;
 

--- a/source/SIL.AppBuilder.Portal/src/routes/(authenticated)/users/+page.svelte
+++ b/source/SIL.AppBuilder.Portal/src/routes/(authenticated)/users/+page.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
   import SearchBar from '$lib/components/SearchBar.svelte';
-import * as m from '$lib/paraglide/messages';
+  import * as m from '$lib/paraglide/messages';
   import { languageTag } from '$lib/paraglide/runtime';
   import type { PageData } from './$types';
 
@@ -20,7 +20,7 @@ import * as m from '$lib/paraglide/messages';
       class="content-center m-4 gap-2 flex flex-wrap items-end w-full place-content-between"
     >
       {#if data.organizations.length > 1}
-        <span class="flex flex-wrap items-center gap-x-2">
+        <label class="flex flex-wrap items-center gap-x-2">
           <span>{m.users_organization_filter()}:</span>
           <select class="select select-bordered" name="org" bind:value={selectedOrg}>
             <option value={0}>{m.org_allOrganizations()}</option>
@@ -28,7 +28,7 @@ import * as m from '$lib/paraglide/messages';
               <option value={organization.Id}>{organization.Name}</option>
             {/each}
           </select>
-        </span>
+        </label>
       {/if}
       <SearchBar bind:value={searchQuery} className="w-full max-w-xs md:w-auto md:max-w-none" />
     </div>

--- a/source/SIL.AppBuilder.Portal/src/routes/(authenticated)/users/[id=idNumber]/settings/+layout.svelte
+++ b/source/SIL.AppBuilder.Portal/src/routes/(authenticated)/users/[id=idNumber]/settings/+layout.svelte
@@ -12,10 +12,10 @@
   ];
 
   export let data: LayoutData;
-  // TODO: route must be permission protected
+  // route permissions are handled for individual subroutes
 </script>
 
-<!-- TODO: not good enough; needs to check if org admin for one of the user's orgs -->
+<!-- permissions handled in server -->
 {#if data.canEdit}
   <TabbedMenu
     routeId="/(authenticated)/users/[id=idNumber]/settings"

--- a/source/SIL.AppBuilder.Portal/src/routes/(authenticated)/users/common.ts
+++ b/source/SIL.AppBuilder.Portal/src/routes/(authenticated)/users/common.ts
@@ -1,0 +1,41 @@
+type UserInfo = {
+  Id: number;
+  Name: string | null;
+  Email: string | null;
+  UserRoles: { OrganizationId: number; RoleId: number }[];
+  GroupMemberships: { Group: { Id: number; OwnerId: number } }[];
+  OrganizationMemberships: {
+    OrganizationId: number;
+  }[];
+  IsLocked: boolean;
+};
+
+// or by using smaller (or even minified) keys (eg N instead of Name, O instead of Organizations)
+// Done - Aidan
+export function minifyUser(user: UserInfo) {
+  return {
+    /** User Id */
+    I: user.Id,
+    /** User Name */
+    N: user.Name,
+    /** User Email */
+    E: user.Email,
+    /** User OrganizationMemberships */
+    O: user.OrganizationMemberships.map((orgMem) => ({
+      /** Roles */
+      R: user.UserRoles.filter((ur) => ur.OrganizationId === orgMem.OrganizationId).map(
+        (r) => r.RoleId
+      ),
+      /** Organization Id */
+      I: orgMem.OrganizationId,
+      /** Group Ids */
+      G: user.GroupMemberships.filter(
+        (groupMem) => groupMem.Group.OwnerId === orgMem.OrganizationId
+      ).map((group) => group.Group.Id)
+    })),
+    /** User IsLocked */
+    A: !user.IsLocked
+  };
+}
+
+export type MinifiedUser = ReturnType<typeof minifyUser>;


### PR DESCRIPTION
Added server-side pagination and search to `/users`.
Also handled locking and unlocking of users. I have no idea how this is used in S1, but we can figure that out later, for now I have just implemented the ability to mark a user as locked or unlocked in the database. I also added code to prevent a user from being able to lock themself by disabling the toggle in the client and running a sanity check in the server.

I am willing to consider adding a few more features before merging, if those features would be best added here.
Features I would consider:
- Handling permissions for locked users.
- Sorting (this may entail rebasing and using [feature/svelte-headless-table](https://github.com/sillsdev/appbuilder-portal/tree/feature/svelte-headless-table)
- Searching over more than just user name and email
- Improving data display on mobile

Here is a screenshot of what the page looks like now. Primary difference is adding the toggle for locking/unlocking.

![image](https://github.com/user-attachments/assets/ae2fabe6-8fc0-40fc-b78d-0a90cb133c4b)

Here is mobile. I am not a big fan of how the data is displayed for mobile, but I am unsure how to improve it.

![image](https://github.com/user-attachments/assets/bfb568d8-e852-4584-b565-3712e5f52af4)
