### PR TITLE
Add tooltip to search bar

### DIFF
--- a/source/SIL.AppBuilder.Portal/src/lib/components/SearchBar.svelte
+++ b/source/SIL.AppBuilder.Portal/src/lib/components/SearchBar.svelte
@@ -4,9 +4,23 @@
 
   export let className: string = '';
   export let value: string;
+  export let tooltip: string = '';
 </script>
 
-<label class="input input-bordered flex items-center gap-2 {className}">
-  <input type="text" placeholder={m.search()} class="flex-grow" bind:value={value} />
-  <IconContainer icon="mdi:search" class="ml-auto" width={24} />
-</label>
+<div
+  class="{className} {tooltip ? 'tooltip tooltip-bottom' : ''}"
+  data-html="true"
+  data-tip={tooltip}
+>
+  <label class="input input-bordered flex items-center gap-2 w-full">
+    <input type="text" placeholder={m.search()} class="flex-grow" bind:value />
+    <IconContainer icon="mdi:search" class="ml-auto" width={24} />
+  </label>
+</div>
+
+<style>
+  .tooltip:before {
+    white-space: pre-wrap;
+    text-align: start;
+  }
+</style>


### PR DESCRIPTION
Added an optional tooltip to the search bar. This was necessary to replicate behavior in the project directory in S1.

A screenshot of what this looks like in the project directory in S2:

![image](https://github.com/user-attachments/assets/bcd74740-a5e9-446c-922b-b202404fb829)

Note: This did require changing the locale JSON to use `\n` instead of `<br />` tags.