### PR TITLE
Anchor size selector to right side on mobile

### DIFF
--- a/source/SIL.AppBuilder.Portal/src/lib/components/Pagination.svelte
+++ b/source/SIL.AppBuilder.Portal/src/lib/components/Pagination.svelte
@@ -94,7 +94,7 @@
     <div class="input flex items-center w-fit">
       {m.common_total({ total })}
     </div>
-    <div class="hidden grow md:inline-block">&nbsp;</div>
+    <div class="grow">&nbsp;</div>
     <select class="select select-bordered" name="size" bind:value={size}>
       <option value={10}>10</option>
       <option value={25}>25</option>


### PR DESCRIPTION
Fixed pagination component so that the size selector was always pushed to the right side on mobile too.

Before:

![image](https://github.com/user-attachments/assets/f38b57c7-4b36-4f43-9f0a-97e23f8afdba)

After:

![image](https://github.com/user-attachments/assets/d030ce10-cb1d-4177-a766-ed9fa5a8e673)