### PR TITLE
Apply link style to anchor elements in instructions

### DIFF
--- a/source/SIL.AppBuilder.Portal/src/routes/(authenticated)/tasks/[product_id]/+page.svelte
+++ b/source/SIL.AppBuilder.Portal/src/routes/(authenticated)/tasks/[product_id]/+page.svelte
@@ -215,4 +215,7 @@
   #instructions :global(h3) {
     @apply text-info;
   }
+  #instructions :global(a) {
+    @apply link;
+  }
 </style>


### PR DESCRIPTION
Before:

![image](https://github.com/user-attachments/assets/599494ab-6def-495b-b5ca-109f471d5cd4)

After:

![image](https://github.com/user-attachments/assets/120c0e2e-b075-4fb3-a11c-4ee40fc3a79e)
