### PR TITLE
Revert the relationship between Products and WorkflowInstances to be 1-1

### DIFF
--- a/source/SIL.AppBuilder.Portal/common/prisma/migrations/6_products_instances_1-1/migration.sql
+++ b/source/SIL.AppBuilder.Portal/common/prisma/migrations/6_products_instances_1-1/migration.sql
@@ -1,0 +1,2 @@
+-- CreateIndex
+CREATE UNIQUE INDEX "WorkflowInstances_ProductId_key" ON "WorkflowInstances"("ProductId");

--- a/source/SIL.AppBuilder.Portal/common/prisma/schema.prisma
+++ b/source/SIL.AppBuilder.Portal/common/prisma/schema.prisma
@@ -290,7 +290,7 @@ model Products {
   StoreLanguage       StoreLanguages?       @relation(fields: [StoreLanguageId], references: [Id], onDelete: Restrict, onUpdate: NoAction, map: "FK_Products_StoreLanguages_StoreLanguageId")
   Store               Stores?               @relation(fields: [StoreId], references: [Id], onDelete: Restrict, onUpdate: NoAction, map: "FK_Products_Stores_StoreId")
   UserTasks           UserTasks[]
-  WorkflowInstances   WorkflowInstances[]
+  WorkflowInstance    WorkflowInstances?
 
   @@index([ProductDefinitionId], map: "IX_Products_ProductDefinitionId")
   @@index([ProjectId], map: "IX_Products_ProjectId")
@@ -488,7 +488,7 @@ model WorkflowDefinitions {
   Workflows            ProductDefinitions[] @relation("ProductDefinitions_WorkflowIdToWorkflowDefinitions")
   StoreType            StoreTypes?          @relation(fields: [StoreTypeId], references: [Id], onDelete: Restrict, onUpdate: NoAction, map: "FK_WorkflowDefinitions_StoreTypes_StoreTypeId")
   ProductType          Int                  @default(0)
-  WorkflowOptions      Int[]                @default([0])
+  WorkflowOptions      Int[]                @default([])
   WorkflowInstances    WorkflowInstances[]
 
   @@index([StoreTypeId], map: "IX_WorkflowDefinitions_StoreTypeId")
@@ -759,7 +759,7 @@ model WorkflowInstances {
   State        String
   Context      String
   WorkflowDefinitionId Int
-  ProductId    String       @db.Uuid
+  ProductId    String       @unique @db.Uuid
   DateCreated               DateTime? @default(now()) @db.Timestamp
   DateUpdated               DateTime? @updatedAt @db.Timestamp
   Product      Products     @relation(fields: [ProductId], references: [Id], onDelete: NoAction, onUpdate: NoAction, map: "FK_WorkflowInstances_Products_ProductId")

--- a/source/SIL.AppBuilder.Portal/common/public/workflow.ts
+++ b/source/SIL.AppBuilder.Portal/common/public/workflow.ts
@@ -49,9 +49,7 @@ export enum WorkflowState {
   Published = 'Published'
 }
 
-export const TerminalStateFilter: Prisma.WorkflowInstancesWhereInput = {
-  State: { in: [WorkflowState.Terminated, WorkflowState.Published] }
-};
+export const TerminalStates = [WorkflowState.Terminated, WorkflowState.Published];
 
 export enum WorkflowAction {
   Default = 'Default',

--- a/source/SIL.AppBuilder.Portal/common/workflow/index.ts
+++ b/source/SIL.AppBuilder.Portal/common/workflow/index.ts
@@ -229,12 +229,19 @@ export class Workflow {
           WorkflowUserId: null
         }
       });
-      await DatabaseWrites.productTransitions.createMany({
-        data: await Workflow.transitionEntriesFromState(snap.value, this.productId, this.config)
-      });
-
-      await this.createSnapshot(snap.context);
-      await this.updateUserTasks(event.event.comment || undefined);
+      if (snap.value in TerminalStates) {
+        await DatabaseWrites.workflowInstances.delete({ where: {
+          ProductId: this.productId
+        }});
+      }
+      else {
+        await DatabaseWrites.productTransitions.createMany({
+          data: await Workflow.transitionEntriesFromState(snap.value, this.productId, this.config)
+        });
+  
+        await this.createSnapshot(snap.context);
+        await this.updateUserTasks(event.event.comment || undefined);
+      }
     }
   }
 

--- a/source/SIL.AppBuilder.Portal/common/workflow/index.ts
+++ b/source/SIL.AppBuilder.Portal/common/workflow/index.ts
@@ -232,10 +232,8 @@ export class Workflow {
       await DatabaseWrites.productTransitions.createMany({
         data: await Workflow.transitionEntriesFromState(snap.value, this.productId, this.config)
       });
-    }
 
-    await this.createSnapshot(snap.context);
-    if (old && Workflow.stateName(old) !== snap.value) {
+      await this.createSnapshot(snap.context);
       await this.updateUserTasks(event.event.comment || undefined);
     }
   }

--- a/source/SIL.AppBuilder.Portal/common/workflow/index.ts
+++ b/source/SIL.AppBuilder.Portal/common/workflow/index.ts
@@ -19,7 +19,7 @@ import {
   WorkflowTransitionMeta,
   Snapshot,
   WorkflowState,
-  TerminalStateFilter
+  TerminalStates
 } from '../public/workflow.js';
 import prisma from '../prisma.js';
 import { RoleId, ProductTransitionType, WorkflowType } from '../public/prisma.js';
@@ -109,10 +109,9 @@ export class Workflow {
 
   /** Retrieves the workflow's snapshot from the database */
   public static async getSnapshot(productId: string): Promise<Snapshot> {
-    const snap = await prisma.workflowInstances.findFirst({
+    const snap = await prisma.workflowInstances.findUnique({
       where: {
-        ProductId: productId,
-        NOT: TerminalStateFilter
+        ProductId: productId
       },
       select: {
         State: true,
@@ -242,16 +241,6 @@ export class Workflow {
   }
 
   private async createSnapshot(context: WorkflowContext) {
-    const instance = await prisma.workflowInstances.findFirst({
-      where: {
-        ProductId: this.productId,
-        NOT: TerminalStateFilter
-      },
-      select: {
-        Id: true
-      }
-    });
-
     const filtered = {
       ...context,
       productId: undefined,
@@ -260,39 +249,34 @@ export class Workflow {
       productType: undefined,
       options: undefined
     } as WorkflowContextBase;
-    if (instance) {
-      return DatabaseWrites.workflowInstances.update({
-        where: {
-          Id: instance.Id
-        },
-        data: {
-          State: Workflow.stateName(this.currentState),
-          Context: JSON.stringify(filtered)
-        }
-      });
-    } else {
-      return DatabaseWrites.workflowInstances.create({
-        data: {
-          ProductId: this.productId,
-          State: Workflow.stateName(this.currentState),
-          Context: JSON.stringify(context),
-          WorkflowDefinitionId: (
-            await prisma.products.findUnique({
-              where: {
-                Id: this.productId
-              },
-              select: {
-                ProductDefinition: {
-                  select: {
-                    WorkflowId: true
-                  }
+    return DatabaseWrites.workflowInstances.upsert({
+      where: {
+        ProductId: this.productId
+      },
+      create: {
+        ProductId: this.productId,
+        State: Workflow.stateName(this.currentState),
+        Context: JSON.stringify(context),
+        WorkflowDefinitionId: (
+          await prisma.products.findUnique({
+            where: {
+              Id: this.productId
+            },
+            select: {
+              ProductDefinition: {
+                select: {
+                  WorkflowId: true
                 }
               }
-            })
-          ).ProductDefinition.WorkflowId
-        }
-      });
-    }
+            }
+          })
+        ).ProductDefinition.WorkflowId
+      },
+      update: {
+        State: Workflow.stateName(this.currentState),
+        Context: JSON.stringify(filtered)
+      }
+    });
   }
 
   /** Filter a states transitions based on provided context */


### PR DESCRIPTION
After some discussion, it was determined that a Product should only ever have one active WorkflowInstance.

Also updated the database schema to have the correct default for WorkflowOptions.