### PR TITLE
Recurring Job to check system statuses

### DIFF
--- a/source/SIL.AppBuilder.Portal/common/bullmq/queues.ts
+++ b/source/SIL.AppBuilder.Portal/common/bullmq/queues.ts
@@ -2,6 +2,12 @@ import { Queue } from 'bullmq';
 import type { Job } from './types.js';
 import { QueueName } from './types.js';
 
+/** Queue for default recurring jobs such as the BuildEngine status check */
+export const DefaultRecurring = new Queue<Job>(QueueName.DefaultRecurring, {
+  connection: {
+    host: process.env.NODE_ENV === 'development' ? 'localhost' : 'redis'
+  }
+});
 /** Queue for operations on UserTasks */
 export const UserTasks = new Queue<Job>(QueueName.UserTasks, {
   connection: {

--- a/source/SIL.AppBuilder.Portal/common/bullmq/types.ts
+++ b/source/SIL.AppBuilder.Portal/common/bullmq/types.ts
@@ -16,12 +16,21 @@ export const Retry5e5: RetryOptions = {
 };
 
 export enum QueueName {
+  DefaultRecurring = 'Default Recurring',
   UserTasks = 'User Tasks'
 }
 
 export enum JobType {
+  // System Tasks
+  System_CheckStatuses = 'Check System Statuses',
   // UserTasks
   UserTasks_Reassign = 'Reassign UserTasks'
+}
+
+export namespace System {
+  export interface CheckStatuses {
+    type: JobType.System_CheckStatuses;
+  }
 }
 
 export namespace UserTasks {
@@ -34,6 +43,7 @@ export namespace UserTasks {
 export type Job = JobTypeMap[keyof JobTypeMap];
 
 export type JobTypeMap = {
+  [JobType.System_CheckStatuses]: System.CheckStatuses;
   [JobType.UserTasks_Reassign]: UserTasks.Reassign;
   // Add more mappings here as needed
 };

--- a/source/SIL.AppBuilder.Portal/node-server/dev.ts
+++ b/source/SIL.AppBuilder.Portal/node-server/dev.ts
@@ -18,5 +18,5 @@ createBullBoard({
 app.use(serverAdapter.getRouter());
 app.listen(3000, () => console.log('Dev server started'));
 
-
+new Workers.DefaultRecurring();
 new Workers.UserTasks();

--- a/source/SIL.AppBuilder.Portal/node-server/index.ts
+++ b/source/SIL.AppBuilder.Portal/node-server/index.ts
@@ -75,6 +75,7 @@ app.get('/healthcheck', (req, res) => {
 // Running on svelte process right now. Consider putting on new thread
 // Fine like this if majority of job time is waiting for network requests
 // If there is much processing it should be moved to another thread
+new Workers.DefaultRecurring();
 new Workers.UserTasks();
 
 const serverAdapter = new ExpressAdapter();

--- a/source/SIL.AppBuilder.Portal/node-server/job-executors/index.ts
+++ b/source/SIL.AppBuilder.Portal/node-server/job-executors/index.ts
@@ -1,1 +1,2 @@
+export * as System from './system.js';
 export * as UserTasks from './userTasks.js';

--- a/source/SIL.AppBuilder.Portal/node-server/job-executors/system.ts
+++ b/source/SIL.AppBuilder.Portal/node-server/job-executors/system.ts
@@ -1,0 +1,16 @@
+import { Job } from 'bullmq';
+import { BullMQ, prisma } from 'sil.appbuilder.portal.common';
+
+export async function checkStatuses(job: Job<BullMQ.System.CheckStatuses>): Promise<unknown> {
+  // TODO: Do I use the `SystemStatus` table? Why does this table even exist? It mostly duplicates data from `Organizations` but is completely disconnected from `Organizations`. Can these be consolidated?
+  const systems = await prisma.systemStatuses.findMany();
+  job.updateProgress(10);
+  //const timestamp = new Date();
+  systems.forEach((s, i) => {
+    // TODO: Not doing anything here until above TODO is resolved
+    job.updateProgress(10 + ((i + 1) * 80) / systems.length);
+  });
+  //await prisma.$transaction(systems.map());
+  job.updateProgress(100);
+  return systems.length;
+}


### PR DESCRIPTION
Added a job to periodically update the SystemStatuses table with a unique list of Build Engine URLs and tokens, and then query with each pair to verify availability.