### PR TITLE
Sort data returned from server (as much as feasible)

### DIFF
--- a/source/SIL.AppBuilder.Portal/src/lib/components/OrganizationDropdown.svelte
+++ b/source/SIL.AppBuilder.Portal/src/lib/components/OrganizationDropdown.svelte
@@ -2,13 +2,24 @@
   import { org_allOrganizations } from '$lib/paraglide/messages';
   import { languageTag } from '$lib/paraglide/runtime';
   import { byName } from '$lib/utils';
-  export let organizations: { Id: number; Name: string | null }[];
-  export let value: number | null;
-  export let className: string = '';
-  export let allowNull: boolean = false;
+  interface Props {
+    organizations: { Id: number; Name: string | null }[];
+    value: number | null;
+    className?: string;
+    allowNull?: boolean;
+    [key: string]: any
+  }
+
+  let {
+    organizations,
+    value = $bindable(),
+    className = '',
+    allowNull = false,
+    ...rest
+  }: Props = $props();
 </script>
 
-<select class="select select-bordered {className}" bind:value {...$$restProps}>
+<select class="select select-bordered {className}" bind:value {...rest}>
   {#if allowNull}
     <option value={null} selected>{org_allOrganizations()}</option>
   {/if}

--- a/source/SIL.AppBuilder.Portal/src/lib/components/OrganizationDropdown.svelte
+++ b/source/SIL.AppBuilder.Portal/src/lib/components/OrganizationDropdown.svelte
@@ -1,0 +1,18 @@
+<script lang="ts">
+  import { org_allOrganizations } from '$lib/paraglide/messages';
+  import { languageTag } from '$lib/paraglide/runtime';
+  import { byName } from '$lib/utils';
+  export let organizations: { Id: number; Name: string | null }[];
+  export let value: number | null;
+  export let className: string = '';
+  export let allowNull: boolean = false;
+</script>
+
+<select class="select select-bordered {className}" bind:value {...$$restProps}>
+  {#if allowNull}
+    <option value={null} selected>{org_allOrganizations()}</option>
+  {/if}
+  {#each organizations.sort((a, b) => byName(a, b, languageTag())) as organization}
+    <option value={organization.Id}>{organization.Name}</option>
+  {/each}
+</select>

--- a/source/SIL.AppBuilder.Portal/src/lib/components/OrganizationDropdown.svelte
+++ b/source/SIL.AppBuilder.Portal/src/lib/components/OrganizationDropdown.svelte
@@ -12,7 +12,7 @@
   {#if allowNull}
     <option value={null} selected>{org_allOrganizations()}</option>
   {/if}
-  {#each organizations.sort((a, b) => byName(a, b, languageTag())) as organization}
+  {#each organizations.toSorted((a, b) => byName(a, b, languageTag())) as organization}
     <option value={organization.Id}>{organization.Name}</option>
   {/each}
 </select>

--- a/source/SIL.AppBuilder.Portal/src/lib/components/OrganizationSelector.svelte
+++ b/source/SIL.AppBuilder.Portal/src/lib/components/OrganizationSelector.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
   import { languageTag } from '$lib/paraglide/runtime';
-  import { sortByName } from '$lib/utils';
+  import { byName } from '$lib/utils';
   import type { Prisma } from '@prisma/client';
   interface Props {
     organizations: Prisma.OrganizationsGetPayload<{
@@ -25,7 +25,7 @@
       </tr>
     </thead>
     <tbody>
-      {#each organizations.sort((a, b) => sortByName(a, b, languageTag())) as org}
+      {#each organizations.sort((a, b) => byName(a, b, languageTag())) as org}
         <tr
           class="h-16 border-y hover:bg-base-200 cursor-pointer"
           onclick={() => onSelect(org.Id)}

--- a/source/SIL.AppBuilder.Portal/src/lib/components/OrganizationSelector.svelte
+++ b/source/SIL.AppBuilder.Portal/src/lib/components/OrganizationSelector.svelte
@@ -25,7 +25,7 @@
       </tr>
     </thead>
     <tbody>
-      {#each organizations.sort((a, b) => byName(a, b, languageTag())) as org}
+      {#each organizations.toSorted((a, b) => byName(a, b, languageTag())) as org}
         <tr
           class="h-16 border-y hover:bg-base-200 cursor-pointer"
           onclick={() => onSelect(org.Id)}

--- a/source/SIL.AppBuilder.Portal/src/lib/components/OrganizationSelector.svelte
+++ b/source/SIL.AppBuilder.Portal/src/lib/components/OrganizationSelector.svelte
@@ -1,4 +1,6 @@
 <script lang="ts">
+  import { languageTag } from '$lib/paraglide/runtime';
+  import { sortByName } from '$lib/utils';
   import type { Prisma } from '@prisma/client';
   interface Props {
     organizations: Prisma.OrganizationsGetPayload<{
@@ -23,7 +25,7 @@
       </tr>
     </thead>
     <tbody>
-      {#each organizations as org}
+      {#each organizations.sort((a, b) => sortByName(a, b, languageTag())) as org}
         <tr
           class="h-16 border-y hover:bg-base-200 cursor-pointer"
           onclick={() => onSelect(org.Id)}

--- a/source/SIL.AppBuilder.Portal/src/lib/components/Pagination.svelte
+++ b/source/SIL.AppBuilder.Portal/src/lib/components/Pagination.svelte
@@ -68,7 +68,7 @@
     </div>
     <div class="grow">&nbsp;</div>
     <select class="select select-bordered" name="size" bind:value={size}>
-      {#each [10, 25, 50, 100].concat(extraSizeOptions).sort((a, b) => a - b) as value}
+      {#each [10, 25, 50, 100].concat(extraSizeOptions).toSorted((a, b) => a - b) as value}
         <option {value}>{value}</option>
       {/each}
     </select>

--- a/source/SIL.AppBuilder.Portal/src/lib/products/components/BuildArtifacts.svelte
+++ b/source/SIL.AppBuilder.Portal/src/lib/products/components/BuildArtifacts.svelte
@@ -4,7 +4,7 @@
   import * as m from '$lib/paraglide/messages';
   import { languageTag } from '$lib/paraglide/runtime';
   import { getRelativeTime } from '$lib/timeUtils';
-  import { bytesToHumanSize } from '$lib/utils';
+  import { bytesToHumanSize, sortByNullableString } from '$lib/utils';
 
 
   interface Props {
@@ -82,7 +82,7 @@
           </tr>
         </thead>
         <tbody>
-          {#each build.ProductArtifacts as artifact}
+          {#each build.ProductArtifacts.sort( (a, b) => sortByNullableString(a.ArtifactType, b.ArtifactType, langTag) ) as artifact}
             <tr>
               <td><IconContainer icon="mdi:file" width="20" /> {artifact.ArtifactType}</td>
               <td>

--- a/source/SIL.AppBuilder.Portal/src/lib/products/components/BuildArtifacts.svelte
+++ b/source/SIL.AppBuilder.Portal/src/lib/products/components/BuildArtifacts.svelte
@@ -6,25 +6,24 @@
   import { getRelativeTime } from '$lib/timeUtils';
   import { byString, bytesToHumanSize } from '$lib/utils';
 
-
   interface Props {
     build: {
-    Version: string | null;
-    Success: boolean | null;
-    BuildId: number;
-    ProductArtifacts: {
-      ArtifactType: string | null;
-      FileSize: bigint | null;
-      Url: string | null;
-      DateUpdated: Date | null;
-    }[];
-    ProductPublications: {
-      Channel: string | null;
+      Version: string | null;
       Success: boolean | null;
-      LogUrl: string | null;
-      DateUpdated: Date | null;
-    }[];
-  };
+      BuildId: number;
+      ProductArtifacts: {
+        ArtifactType: string | null;
+        FileSize: bigint | null;
+        Url: string | null;
+        DateUpdated: Date | null;
+      }[];
+      ProductPublications: {
+        Channel: string | null;
+        Success: boolean | null;
+        LogUrl: string | null;
+        DateUpdated: Date | null;
+      }[];
+    };
     latestBuildId: number | undefined;
   }
 
@@ -82,13 +81,11 @@
           </tr>
         </thead>
         <tbody>
-          {#each build.ProductArtifacts.sort( (a, b) => byString(a.ArtifactType, b.ArtifactType, langTag) ) as artifact}
+          {#each build.ProductArtifacts.toSorted( (a, b) => byString(a.ArtifactType, b.ArtifactType, langTag) ) as artifact}
             <tr>
               <td><IconContainer icon="mdi:file" width="20" /> {artifact.ArtifactType}</td>
               <td>
-                <Tooltip
-                  tip={artifact.DateUpdated?.toLocaleString(langTag)}
-                >
+                <Tooltip tip={artifact.DateUpdated?.toLocaleString(langTag)}>
                   {getRelativeTime(artifact.DateUpdated)}
                 </Tooltip>
               </td>

--- a/source/SIL.AppBuilder.Portal/src/lib/products/components/BuildArtifacts.svelte
+++ b/source/SIL.AppBuilder.Portal/src/lib/products/components/BuildArtifacts.svelte
@@ -4,7 +4,7 @@
   import * as m from '$lib/paraglide/messages';
   import { languageTag } from '$lib/paraglide/runtime';
   import { getRelativeTime } from '$lib/timeUtils';
-  import { bytesToHumanSize, sortByNullableString } from '$lib/utils';
+  import { byString, bytesToHumanSize } from '$lib/utils';
 
 
   interface Props {
@@ -82,7 +82,7 @@
           </tr>
         </thead>
         <tbody>
-          {#each build.ProductArtifacts.sort( (a, b) => sortByNullableString(a.ArtifactType, b.ArtifactType, langTag) ) as artifact}
+          {#each build.ProductArtifacts.sort( (a, b) => byString(a.ArtifactType, b.ArtifactType, langTag) ) as artifact}
             <tr>
               <td><IconContainer icon="mdi:file" width="20" /> {artifact.ArtifactType}</td>
               <td>

--- a/source/SIL.AppBuilder.Portal/src/lib/projects/components/ProjectCard.svelte
+++ b/source/SIL.AppBuilder.Portal/src/lib/projects/components/ProjectCard.svelte
@@ -4,7 +4,7 @@
   import * as m from '$lib/paraglide/messages';
   import { languageTag } from '$lib/paraglide/runtime';
   import { getTimeDateString } from '$lib/timeUtils';
-  import { sortByNullableString } from '$lib/utils';
+  import { byString } from '$lib/utils';
   import type { PrunedProject } from '../common';
 
   interface Props {
@@ -88,7 +88,7 @@
           </tr>
         </thead>
         <tbody>
-          {#each project.Products.sort((a, b) => sortByNullableString(a.ProductDefinitionName, b.ProductDefinitionName, langTag)) as product}
+          {#each project.Products.sort((a, b) => byString(a.ProductDefinitionName, b.ProductDefinitionName, langTag)) as product}
             <tr>
               <td class="p-2">
                 <div class="flex items-center">

--- a/source/SIL.AppBuilder.Portal/src/lib/projects/components/ProjectCard.svelte
+++ b/source/SIL.AppBuilder.Portal/src/lib/projects/components/ProjectCard.svelte
@@ -2,7 +2,9 @@
   import IconContainer from '$lib/components/IconContainer.svelte';
   import { getIcon } from '$lib/icons/productDefinitionIcon';
   import * as m from '$lib/paraglide/messages';
+  import { languageTag } from '$lib/paraglide/runtime';
   import { getTimeDateString } from '$lib/timeUtils';
+  import { sortByNullableString } from '$lib/utils';
   import type { PrunedProject } from '../common';
 
   interface Props {
@@ -76,6 +78,7 @@
   </div>
   <div class="w-full bg-base-100 p-4 pt-2">
     {#if project.Products.length > 0}
+      {@const langTag = languageTag()}
       <table class="w-full">
         <thead>
           <tr class="text-left">
@@ -85,7 +88,7 @@
           </tr>
         </thead>
         <tbody>
-          {#each project.Products as product}
+          {#each project.Products.sort((a, b) => sortByNullableString(a.ProductDefinitionName, b.ProductDefinitionName, langTag)) as product}
             <tr>
               <td class="p-2">
                 <div class="flex items-center">

--- a/source/SIL.AppBuilder.Portal/src/lib/projects/components/ProjectCard.svelte
+++ b/source/SIL.AppBuilder.Portal/src/lib/projects/components/ProjectCard.svelte
@@ -88,7 +88,7 @@
           </tr>
         </thead>
         <tbody>
-          {#each project.Products.sort((a, b) => byString(a.ProductDefinitionName, b.ProductDefinitionName, langTag)) as product}
+          {#each project.Products.toSorted( (a, b) => byString(a.ProductDefinitionName, b.ProductDefinitionName, langTag) ) as product}
             <tr>
               <td class="p-2">
                 <div class="flex items-center">

--- a/source/SIL.AppBuilder.Portal/src/lib/utils.ts
+++ b/source/SIL.AppBuilder.Portal/src/lib/utils.ts
@@ -25,8 +25,8 @@ export function sortByName(a: NamedEntity, b: NamedEntity, languageTag: string):
 }
 
 export function sortByNullableString(
-  a: string | null,
-  b: string | null,
+  a: string | null | undefined,
+  b: string | null | undefined,
   languageTag: string
 ): number {
   return a?.localeCompare(b ?? '', languageTag) ?? 0;

--- a/source/SIL.AppBuilder.Portal/src/lib/utils.ts
+++ b/source/SIL.AppBuilder.Portal/src/lib/utils.ts
@@ -20,11 +20,15 @@ interface NamedEntity {
   Name: string | null;
 }
 
-export function sortByName(a: NamedEntity, b: NamedEntity, languageTag: string): number {
-  return sortByNullableString(a.Name, b.Name, languageTag);
+export function byName(
+  a: NamedEntity | null | undefined,
+  b: NamedEntity | null | undefined,
+  languageTag: string
+): number {
+  return byString(a?.Name, b?.Name, languageTag);
 }
 
-export function sortByNullableString(
+export function byString(
   a: string | null | undefined,
   b: string | null | undefined,
   languageTag: string
@@ -32,7 +36,7 @@ export function sortByNullableString(
   return a?.localeCompare(b ?? '', languageTag) ?? 0;
 }
 
-export function sortByNullableNumber(a: number | bigint | null, b: number | bigint | null): number {
+export function byNumber(a: number | bigint | null, b: number | bigint | null): number {
   return a === b ? 0 : (a ?? 0) > (b ?? 0) ? 1 : -1;
 }
 

--- a/source/SIL.AppBuilder.Portal/src/lib/utils.ts
+++ b/source/SIL.AppBuilder.Portal/src/lib/utils.ts
@@ -21,7 +21,19 @@ interface NamedEntity {
 }
 
 export function sortByName(a: NamedEntity, b: NamedEntity, languageTag: string): number {
-  return a.Name?.localeCompare(b.Name ?? '', languageTag) ?? 0;
+  return sortByNullableString(a.Name, b.Name, languageTag);
+}
+
+export function sortByNullableString(
+  a: string | null,
+  b: string | null,
+  languageTag: string
+): number {
+  return a?.localeCompare(b ?? '', languageTag) ?? 0;
+}
+
+export function sortByNullableNumber(a: number | bigint | null, b: number | bigint | null): number {
+  return a === b ? 0 : (a ?? 0) > (b ?? 0) ? 1 : -1;
 }
 
 /** returns true if user is a SuperAdmin, or is an OrgAdmin for the specified organization

--- a/source/SIL.AppBuilder.Portal/src/routes/(authenticated)/admin/settings/build-engines/+page.svelte
+++ b/source/SIL.AppBuilder.Portal/src/routes/(authenticated)/admin/settings/build-engines/+page.svelte
@@ -4,6 +4,7 @@
   import * as m from '$lib/paraglide/messages';
   import { languageTag } from '$lib/paraglide/runtime';
   import { getRelativeTime } from '$lib/timeUtils';
+  import { sortByNullableString } from '$lib/utils';
   import type { PageData } from './$types';
 
   interface Props {
@@ -21,7 +22,7 @@
 {/snippet}
 
 <div class="flex flex-col w-full">
-  {#each data.buildEngines as buildEngine}
+  {#each data.buildEngines.sort( (a, b) => sortByNullableString(a.BuildEngineUrl, b.BuildEngineUrl, languageTag()) ) as buildEngine}
     <DataDisplayBox
       title={buildEngine.BuildEngineUrl}
       data={buildEngine}

--- a/source/SIL.AppBuilder.Portal/src/routes/(authenticated)/admin/settings/build-engines/+page.svelte
+++ b/source/SIL.AppBuilder.Portal/src/routes/(authenticated)/admin/settings/build-engines/+page.svelte
@@ -4,7 +4,7 @@
   import * as m from '$lib/paraglide/messages';
   import { languageTag } from '$lib/paraglide/runtime';
   import { getRelativeTime } from '$lib/timeUtils';
-  import { sortByNullableString } from '$lib/utils';
+  import { byString } from '$lib/utils';
   import type { PageData } from './$types';
 
   interface Props {
@@ -22,7 +22,7 @@
 {/snippet}
 
 <div class="flex flex-col w-full">
-  {#each data.buildEngines.sort( (a, b) => sortByNullableString(a.BuildEngineUrl, b.BuildEngineUrl, languageTag()) ) as buildEngine}
+  {#each data.buildEngines.sort( (a, b) => byString(a.BuildEngineUrl, b.BuildEngineUrl, languageTag()) ) as buildEngine}
     <DataDisplayBox
       title={buildEngine.BuildEngineUrl}
       data={buildEngine}

--- a/source/SIL.AppBuilder.Portal/src/routes/(authenticated)/admin/settings/build-engines/+page.svelte
+++ b/source/SIL.AppBuilder.Portal/src/routes/(authenticated)/admin/settings/build-engines/+page.svelte
@@ -22,7 +22,7 @@
 {/snippet}
 
 <div class="flex flex-col w-full">
-  {#each data.buildEngines.sort( (a, b) => byString(a.BuildEngineUrl, b.BuildEngineUrl, languageTag()) ) as buildEngine}
+  {#each data.buildEngines.toSorted( (a, b) => byString(a.BuildEngineUrl, b.BuildEngineUrl, languageTag()) ) as buildEngine}
     <DataDisplayBox
       title={buildEngine.BuildEngineUrl}
       data={buildEngine}

--- a/source/SIL.AppBuilder.Portal/src/routes/(authenticated)/admin/settings/organizations/+page.svelte
+++ b/source/SIL.AppBuilder.Portal/src/routes/(authenticated)/admin/settings/organizations/+page.svelte
@@ -3,7 +3,7 @@
   import DataDisplayBox from '$lib/components/settings/DataDisplayBox.svelte';
   import * as m from '$lib/paraglide/messages';
   import { languageTag } from '$lib/paraglide/runtime';
-  import { sortByName } from '$lib/utils';
+  import { byName } from '$lib/utils';
   import type { PageData } from './$types';
 
   interface Props {
@@ -18,7 +18,7 @@
 </a>
 
 <div class="flex flex-col w-full">
-  {#each data.organizations.sort((a, b) => sortByName(a, b, languageTag())) as organization}
+  {#each data.organizations.sort((a, b) => byName(a, b, languageTag())) as organization}
     <DataDisplayBox
       editable
       onEdit={() => goto('/admin/settings/organizations/edit?id=' + organization.Id)}

--- a/source/SIL.AppBuilder.Portal/src/routes/(authenticated)/admin/settings/organizations/+page.svelte
+++ b/source/SIL.AppBuilder.Portal/src/routes/(authenticated)/admin/settings/organizations/+page.svelte
@@ -18,7 +18,7 @@
 </a>
 
 <div class="flex flex-col w-full">
-  {#each data.organizations.sort((a, b) => byName(a, b, languageTag())) as organization}
+  {#each data.organizations.toSorted((a, b) => byName(a, b, languageTag())) as organization}
     <DataDisplayBox
       editable
       onEdit={() => goto('/admin/settings/organizations/edit?id=' + organization.Id)}

--- a/source/SIL.AppBuilder.Portal/src/routes/(authenticated)/admin/settings/organizations/edit/+page.svelte
+++ b/source/SIL.AppBuilder.Portal/src/routes/(authenticated)/admin/settings/organizations/edit/+page.svelte
@@ -4,6 +4,8 @@
   import MultiselectBox from '$lib/components/settings/MultiselectBox.svelte';
   import MultiselectBoxElement from '$lib/components/settings/MultiselectBoxElement.svelte';
   import * as m from '$lib/paraglide/messages';
+  import { languageTag } from '$lib/paraglide/runtime';
+  import { byName } from '$lib/utils';
   import { superForm } from 'sveltekit-superforms';
   import type { PageData } from './$types';
 
@@ -42,7 +44,7 @@
   </LabeledFormInput>
   <LabeledFormInput name="admin_settings_organizations_owner">
     <select class="select select-bordered" name="owner" bind:value={$superFormData.owner}>
-      {#each data.options.users as option}
+      {#each data.options.users.toSorted((a, b) => byName(a, b, languageTag())) as option}
         <option value={option.Id}>{option.Name}</option>
       {/each}
     </select>
@@ -99,7 +101,7 @@
       </div>
     </label>
   </div>
-
+  <!-- TODO: sort this. I think this will need a refactor of MultiselectBox -->
   <MultiselectBox header={m.org_storeSelectTitle()}>
     {#each $superFormData.stores as store}
       <MultiselectBoxElement

--- a/source/SIL.AppBuilder.Portal/src/routes/(authenticated)/admin/settings/organizations/new/+page.svelte
+++ b/source/SIL.AppBuilder.Portal/src/routes/(authenticated)/admin/settings/organizations/new/+page.svelte
@@ -2,6 +2,8 @@
   import { goto } from '$app/navigation';
   import LabeledFormInput from '$lib/components/settings/LabeledFormInput.svelte';
   import * as m from '$lib/paraglide/messages';
+  import { languageTag } from '$lib/paraglide/runtime';
+  import { byName } from '$lib/utils';
   import { superForm } from 'sveltekit-superforms';
   import type { PageData } from './$types';
 
@@ -28,7 +30,7 @@
   </LabeledFormInput>
   <LabeledFormInput name="admin_settings_organizations_owner">
     <select class="select select-bordered" name="owner" bind:value={$form.owner}>
-      {#each data.options.users as user}
+      {#each data.options.users.toSorted((a, b) => byName(a, b, languageTag())) as user}
         <option value={user.Id}>{user.Name}</option>
       {/each}
     </select>

--- a/source/SIL.AppBuilder.Portal/src/routes/(authenticated)/admin/settings/product-definitions/+page.svelte
+++ b/source/SIL.AppBuilder.Portal/src/routes/(authenticated)/admin/settings/product-definitions/+page.svelte
@@ -19,7 +19,7 @@
 </a>
 
 <div class="flex flex-col w-full">
-  {#each data.productDefinitions.sort((a, b) => byName(a, b, languageTag())) as pD}
+  {#each data.productDefinitions.toSorted((a, b) => byName(a, b, languageTag())) as pD}
     <DataDisplayBox
       editable
       onEdit={() => goto(base + '/admin/settings/product-definitions/edit?id=' + pD.Id)}

--- a/source/SIL.AppBuilder.Portal/src/routes/(authenticated)/admin/settings/product-definitions/+page.svelte
+++ b/source/SIL.AppBuilder.Portal/src/routes/(authenticated)/admin/settings/product-definitions/+page.svelte
@@ -4,7 +4,7 @@
   import DataDisplayBox from '$lib/components/settings/DataDisplayBox.svelte';
   import * as m from '$lib/paraglide/messages';
   import { languageTag } from '$lib/paraglide/runtime';
-  import { sortByName } from '$lib/utils';
+  import { byName } from '$lib/utils';
   import type { PageData } from './$types';
 
   interface Props {
@@ -19,7 +19,7 @@
 </a>
 
 <div class="flex flex-col w-full">
-  {#each data.productDefinitions.sort((a, b) => sortByName(a, b, languageTag())) as pD}
+  {#each data.productDefinitions.sort((a, b) => byName(a, b, languageTag())) as pD}
     <DataDisplayBox
       editable
       onEdit={() => goto(base + '/admin/settings/product-definitions/edit?id=' + pD.Id)}

--- a/source/SIL.AppBuilder.Portal/src/routes/(authenticated)/admin/settings/product-definitions/edit/+page.svelte
+++ b/source/SIL.AppBuilder.Portal/src/routes/(authenticated)/admin/settings/product-definitions/edit/+page.svelte
@@ -2,6 +2,8 @@
   import { goto } from '$app/navigation';
   import LabeledFormInput from '$lib/components/settings/LabeledFormInput.svelte';
   import * as m from '$lib/paraglide/messages';
+  import { languageTag } from '$lib/paraglide/runtime';
+  import { byName } from '$lib/utils';
   import { superForm } from 'sveltekit-superforms';
   import type { PageData } from './$types';
 
@@ -21,9 +23,18 @@
       }
     }
   });
-  const workflows = data.options.workflows.filter((w) => w.Type === 1);
-  const rebuildWorkflows = data.options.workflows.filter((w) => w.Type === 2);
-  const republishWorkflows = data.options.workflows.filter((w) => w.Type === 3);
+
+  const langTag = languageTag();
+
+  const workflows = data.options.workflows
+    .filter((w) => w.Type === 1)
+    .sort((a, b) => byName(a, b, langTag));
+  const rebuildWorkflows = data.options.workflows
+    .filter((w) => w.Type === 2)
+    .sort((a, b) => byName(a, b, langTag));
+  const republishWorkflows = data.options.workflows
+    .filter((w) => w.Type === 3)
+    .sort((a, b) => byName(a, b, langTag));
 </script>
 
 <!-- <SuperDebug data={superForm} /> -->

--- a/source/SIL.AppBuilder.Portal/src/routes/(authenticated)/admin/settings/product-definitions/edit/+page.svelte
+++ b/source/SIL.AppBuilder.Portal/src/routes/(authenticated)/admin/settings/product-definitions/edit/+page.svelte
@@ -54,14 +54,14 @@
       name="applicationType"
       bind:value={$superFormData.applicationType}
     >
-      {#each data.options.applicationTypes as type}
+      {#each data.options.applicationTypes.toSorted((a, b) => byName(a, b, langTag)) as type}
         <option value={type.Id}>{type.Name}</option>
       {/each}
     </select>
   </LabeledFormInput>
   <LabeledFormInput name="admin_settings_productDefinitions_workflow">
     <select class="select select-bordered" name="workflow" bind:value={$superFormData.workflow}>
-      {#each workflows.filter((w) => w.Type) as workflow}
+      {#each workflows as workflow}
         <option value={workflow.Id}>{workflow.Name}</option>
       {/each}
     </select>
@@ -73,7 +73,7 @@
       bind:value={$superFormData.rebuildWorkflow}
     >
       <option value={null}>{m.admin_settings_productDefinitions_noWorkflow()}</option>
-      {#each rebuildWorkflows.filter((w) => w.Type) as workflow}
+      {#each rebuildWorkflows as workflow}
         <option value={workflow.Id}>{workflow.Name}</option>
       {/each}
     </select>
@@ -85,7 +85,7 @@
       bind:value={$superFormData.republishWorkflow}
     >
       <option value={null}>{m.admin_settings_productDefinitions_noWorkflow()}</option>
-      {#each republishWorkflows.filter((w) => w.Type) as workflow}
+      {#each republishWorkflows as workflow}
         <option value={workflow.Id}>{workflow.Name}</option>
       {/each}
     </select>

--- a/source/SIL.AppBuilder.Portal/src/routes/(authenticated)/admin/settings/product-definitions/new/+page.svelte
+++ b/source/SIL.AppBuilder.Portal/src/routes/(authenticated)/admin/settings/product-definitions/new/+page.svelte
@@ -1,9 +1,11 @@
 <script lang="ts">
-  import * as m from '$lib/paraglide/messages';
-  import { superForm } from 'sveltekit-superforms';
-  import type { ActionData, PageData } from './$types';
-  import LabeledFormInput from '$lib/components/settings/LabeledFormInput.svelte';
   import { goto } from '$app/navigation';
+  import LabeledFormInput from '$lib/components/settings/LabeledFormInput.svelte';
+  import * as m from '$lib/paraglide/messages';
+  import { languageTag } from '$lib/paraglide/runtime';
+  import { byName } from '$lib/utils';
+  import { superForm } from 'sveltekit-superforms';
+  import type { PageData } from './$types';
 
   interface Props {
     data: PageData;
@@ -18,6 +20,18 @@
       }
     }
   });
+
+  const langTag = languageTag();
+
+  const workflows = data.options.workflows
+    .filter((w) => w.Type === 1)
+    .sort((a, b) => byName(a, b, langTag));
+  const rebuildWorkflows = data.options.workflows
+    .filter((w) => w.Type === 2)
+    .sort((a, b) => byName(a, b, langTag));
+  const republishWorkflows = data.options.workflows
+    .filter((w) => w.Type === 3)
+    .sort((a, b) => byName(a, b, langTag));
 </script>
 
 <h3>{m.admin_settings_productDefinitions_add()}</h3>
@@ -39,7 +53,7 @@
   </LabeledFormInput>
   <LabeledFormInput name="admin_settings_productDefinitions_workflow">
     <select class="select select-bordered" name="workflow" bind:value={$form.workflow}>
-      {#each data.options.workflows.filter((w) => w.Type === 1) as wf}
+      {#each workflows as wf}
         <option value={wf.Id}>{wf.Name}</option>
       {/each}
     </select>
@@ -51,7 +65,7 @@
       bind:value={$form.rebuildWorkflow}
     >
       <option value={null}>{m.admin_settings_productDefinitions_noWorkflow()}</option>
-      {#each data.options.workflows.filter((w) => w.Type === 2) as wf}
+      {#each rebuildWorkflows as wf}
         <option value={wf.Id}>{wf.Name}</option>
       {/each}
     </select>
@@ -63,7 +77,7 @@
       bind:value={$form.republishWorkflow}
     >
       <option value={null}>{m.admin_settings_productDefinitions_noWorkflow()}</option>
-      {#each data.options.workflows.filter((w) => w.Type === 3) as wf}
+      {#each republishWorkflows as wf}
         <option value={wf.Id}>{wf.Name}</option>
       {/each}
     </select>

--- a/source/SIL.AppBuilder.Portal/src/routes/(authenticated)/admin/settings/store-types/+page.svelte
+++ b/source/SIL.AppBuilder.Portal/src/routes/(authenticated)/admin/settings/store-types/+page.svelte
@@ -18,7 +18,7 @@
 </a>
 
 <div class="flex flex-col w-full">
-  {#each data.storeTypes.sort((a, b) => byName(a, b, languageTag())) as storeType}
+  {#each data.storeTypes.toSorted((a, b) => byName(a, b, languageTag())) as storeType}
     <DataDisplayBox
       editable
       onEdit={() => goto('/admin/settings/store-types/edit?id=' + storeType.Id)}

--- a/source/SIL.AppBuilder.Portal/src/routes/(authenticated)/admin/settings/store-types/+page.svelte
+++ b/source/SIL.AppBuilder.Portal/src/routes/(authenticated)/admin/settings/store-types/+page.svelte
@@ -3,7 +3,7 @@
   import DataDisplayBox from '$lib/components/settings/DataDisplayBox.svelte';
   import * as m from '$lib/paraglide/messages';
   import { languageTag } from '$lib/paraglide/runtime';
-  import { sortByName } from '$lib/utils';
+  import { byName } from '$lib/utils';
   import type { PageData } from './$types';
 
   interface Props {
@@ -18,7 +18,7 @@
 </a>
 
 <div class="flex flex-col w-full">
-  {#each data.storeTypes.sort((a, b) => sortByName(a, b, languageTag())) as storeType}
+  {#each data.storeTypes.sort((a, b) => byName(a, b, languageTag())) as storeType}
     <DataDisplayBox
       editable
       onEdit={() => goto('/admin/settings/store-types/edit?id=' + storeType.Id)}

--- a/source/SIL.AppBuilder.Portal/src/routes/(authenticated)/admin/settings/stores/+page.svelte
+++ b/source/SIL.AppBuilder.Portal/src/routes/(authenticated)/admin/settings/stores/+page.svelte
@@ -3,7 +3,7 @@
   import DataDisplayBox from '$lib/components/settings/DataDisplayBox.svelte';
   import * as m from '$lib/paraglide/messages';
   import { languageTag } from '$lib/paraglide/runtime';
-  import { sortByName } from '$lib/utils';
+  import { byName } from '$lib/utils';
   import type { PageData } from './$types';
 
   interface Props {
@@ -18,7 +18,7 @@
 </a>
 
 <div class="flex flex-col w-full">
-  {#each data.stores.sort((a, b) => sortByName(a, b, languageTag())) as store}
+  {#each data.stores.sort((a, b) => byName(a, b, languageTag())) as store}
     <DataDisplayBox
       editable
       onEdit={() => goto('/admin/settings/stores/edit?id=' + store.Id)}

--- a/source/SIL.AppBuilder.Portal/src/routes/(authenticated)/admin/settings/stores/+page.svelte
+++ b/source/SIL.AppBuilder.Portal/src/routes/(authenticated)/admin/settings/stores/+page.svelte
@@ -18,7 +18,7 @@
 </a>
 
 <div class="flex flex-col w-full">
-  {#each data.stores.sort((a, b) => byName(a, b, languageTag())) as store}
+  {#each data.stores.toSorted((a, b) => byName(a, b, languageTag())) as store}
     <DataDisplayBox
       editable
       onEdit={() => goto('/admin/settings/stores/edit?id=' + store.Id)}

--- a/source/SIL.AppBuilder.Portal/src/routes/(authenticated)/admin/settings/stores/edit/+page.svelte
+++ b/source/SIL.AppBuilder.Portal/src/routes/(authenticated)/admin/settings/stores/edit/+page.svelte
@@ -1,6 +1,8 @@
 <script lang="ts">
   import { goto } from '$app/navigation';
   import LabeledFormInput from '$lib/components/settings/LabeledFormInput.svelte';
+  import { languageTag } from '$lib/paraglide/runtime';
+  import { byName } from '$lib/utils';
   import { superForm } from 'sveltekit-superforms';
   import type { PageData } from './$types';
 
@@ -42,7 +44,7 @@
   </LabeledFormInput>
   <LabeledFormInput name="storeTypes_name">
     <select class="select select-bordered" name="storeType" bind:value={$superFormData.storeType}>
-      {#each data.options as option}
+      {#each data.options.toSorted((a, b) => byName(a, b, languageTag())) as option}
         <option value={option.Id}>{option.Name}</option>
       {/each}
     </select>

--- a/source/SIL.AppBuilder.Portal/src/routes/(authenticated)/admin/settings/stores/new/+page.svelte
+++ b/source/SIL.AppBuilder.Portal/src/routes/(authenticated)/admin/settings/stores/new/+page.svelte
@@ -1,9 +1,11 @@
 <script lang="ts">
-  import * as m from '$lib/paraglide/messages';
-  import { superForm } from 'sveltekit-superforms';
-  import type { ActionData, PageData } from './$types';
-  import LabeledFormInput from '$lib/components/settings/LabeledFormInput.svelte';
   import { goto } from '$app/navigation';
+  import LabeledFormInput from '$lib/components/settings/LabeledFormInput.svelte';
+  import * as m from '$lib/paraglide/messages';
+  import { languageTag } from '$lib/paraglide/runtime';
+  import { byName } from '$lib/utils';
+  import { superForm } from 'sveltekit-superforms';
+  import type { PageData } from './$types';
 
   interface Props {
     data: PageData;
@@ -36,7 +38,7 @@
   </LabeledFormInput>
   <LabeledFormInput name="storeTypes_name">
     <select class="select select-bordered" name="storeType" bind:value={$form.storeType}>
-      {#each data.options.storeType as type}
+      {#each data.options.storeType.toSorted((a, b) => byName(a, b, languageTag())) as type}
         <option value={type.Id}>{type.Name}</option>
       {/each}
     </select>

--- a/source/SIL.AppBuilder.Portal/src/routes/(authenticated)/admin/settings/workflow-definitions/+page.svelte
+++ b/source/SIL.AppBuilder.Portal/src/routes/(authenticated)/admin/settings/workflow-definitions/+page.svelte
@@ -3,7 +3,7 @@
   import DataDisplayBox from '$lib/components/settings/DataDisplayBox.svelte';
   import * as m from '$lib/paraglide/messages';
   import { languageTag } from '$lib/paraglide/runtime';
-  import { sortByName } from '$lib/utils';
+  import { byName } from '$lib/utils';
   import type { PageData } from './$types';
 
   interface Props {
@@ -18,7 +18,7 @@
 </a>
 
 <div class="flex flex-col w-full">
-  {#each data.workflowDefinitions.sort((a, b) => sortByName(a, b, languageTag())) as wd}
+  {#each data.workflowDefinitions.sort((a, b) => byName(a, b, languageTag())) as wd}
     <DataDisplayBox
       editable
       onEdit={() => goto('/admin/settings/workflow-definitions/edit?id=' + wd.Id)}

--- a/source/SIL.AppBuilder.Portal/src/routes/(authenticated)/admin/settings/workflow-definitions/+page.svelte
+++ b/source/SIL.AppBuilder.Portal/src/routes/(authenticated)/admin/settings/workflow-definitions/+page.svelte
@@ -18,7 +18,7 @@
 </a>
 
 <div class="flex flex-col w-full">
-  {#each data.workflowDefinitions.sort((a, b) => byName(a, b, languageTag())) as wd}
+  {#each data.workflowDefinitions.toSorted((a, b) => byName(a, b, languageTag())) as wd}
     <DataDisplayBox
       editable
       onEdit={() => goto('/admin/settings/workflow-definitions/edit?id=' + wd.Id)}

--- a/source/SIL.AppBuilder.Portal/src/routes/(authenticated)/admin/settings/workflow-definitions/edit/+page.svelte
+++ b/source/SIL.AppBuilder.Portal/src/routes/(authenticated)/admin/settings/workflow-definitions/edit/+page.svelte
@@ -2,6 +2,8 @@
   import { goto } from '$app/navigation';
   import LabeledFormInput from '$lib/components/settings/LabeledFormInput.svelte';
   import * as m from '$lib/paraglide/messages';
+  import { languageTag } from '$lib/paraglide/runtime';
+  import { byName, byString } from '$lib/utils';
   import { ProductType, WorkflowOptions } from 'sil.appbuilder.portal.common/workflow';
   import { superForm } from 'sveltekit-superforms';
   import { businessFlows } from '../common';
@@ -54,7 +56,7 @@
   </LabeledFormInput>
   <LabeledFormInput name="admin_settings_workflowDefinitions_storeType">
     <select class="select select-bordered" name="storeType" bind:value={$superFormData.storeType}>
-      {#each data.storeTypes as storeType}
+      {#each data.storeTypes.toSorted((a, b) => byName(a, b, languageTag())) as storeType}
         <option value={storeType.Id}>{storeType.Name}</option>
       {/each}
     </select>
@@ -99,7 +101,7 @@
       name="workflowScheme"
       bind:value={$superFormData.workflowScheme}
     >
-      {#each data.schemes as scheme}
+      {#each data.schemes.toSorted((a, b) => byString(a.Code, b.Code, languageTag())) as scheme}
         <option value={scheme.Code}>{scheme.Code}</option>
       {/each}
     </select>

--- a/source/SIL.AppBuilder.Portal/src/routes/(authenticated)/admin/settings/workflow-definitions/new/+page.svelte
+++ b/source/SIL.AppBuilder.Portal/src/routes/(authenticated)/admin/settings/workflow-definitions/new/+page.svelte
@@ -2,6 +2,8 @@
   import { goto } from '$app/navigation';
   import LabeledFormInput from '$lib/components/settings/LabeledFormInput.svelte';
   import * as m from '$lib/paraglide/messages';
+  import { languageTag } from '$lib/paraglide/runtime';
+  import { byName, byString } from '$lib/utils';
   import { ProductType, WorkflowOptions } from 'sil.appbuilder.portal.common/workflow';
   import { superForm } from 'sveltekit-superforms';
   import { businessFlows } from '../common';
@@ -46,7 +48,7 @@
   </LabeledFormInput>
   <LabeledFormInput name="admin_settings_workflowDefinitions_storeType">
     <select class="select select-bordered" name="storeType" bind:value={$form.storeType}>
-      {#each data.options.storeType as type}
+      {#each data.options.storeType.toSorted((a, b) => byName(a, b, languageTag())) as type}
         <option value={type.Id}>{type.Name}</option>
       {/each}
     </select>
@@ -80,7 +82,7 @@
   </LabeledFormInput>
   <LabeledFormInput name="admin_settings_workflowDefinitions_workflowScheme">
     <select class="select select-bordered" name="workflowScheme" bind:value={$form.workflowScheme}>
-      {#each data.options.schemes as scheme}
+      {#each data.options.schemes.toSorted((a, b) => byString(a.Code, b.Code, languageTag())) as scheme}
         <option value={scheme.Code}>{scheme.Code}</option>
       {/each}
     </select>

--- a/source/SIL.AppBuilder.Portal/src/routes/(authenticated)/directory/+page.server.ts
+++ b/source/SIL.AppBuilder.Portal/src/routes/(authenticated)/directory/+page.server.ts
@@ -24,7 +24,10 @@ export const load = (async () => {
       Group: true,
       Organization: true
     },
-    take: 10
+    take: 10,
+    orderBy: {
+      Name: 'asc'
+    }
   });
   const productDefinitions = await prisma.productDefinitions.findMany();
   return {
@@ -78,7 +81,10 @@ export const actions: Actions = {
         Organization: true
       },
       skip: form.data.page.size * form.data.page.page,
-      take: form.data.page.size
+      take: form.data.page.size,
+      orderBy: {
+        Name: 'asc'
+      }
     });
 
     const count = await prisma.projects.count({ where: where });

--- a/source/SIL.AppBuilder.Portal/src/routes/(authenticated)/directory/+page.svelte
+++ b/source/SIL.AppBuilder.Portal/src/routes/(authenticated)/directory/+page.svelte
@@ -4,8 +4,11 @@
   import Pagination from '$lib/components/Pagination.svelte';
   import SearchBar from '$lib/components/SearchBar.svelte';
   import * as m from '$lib/paraglide/messages';
+  import { languageTag } from '$lib/paraglide/runtime';
   import type { PrunedProject } from '$lib/projects/common';
   import ProjectCard from '$lib/projects/components/ProjectCard.svelte';
+  import { sortByName } from '$lib/utils';
+  import 'flatpickr/dist/flatpickr.css';
   import type { FormResult } from 'sveltekit-superforms';
   import { superForm } from 'sveltekit-superforms';
   import type { PageData } from './$types';
@@ -92,8 +95,9 @@
     </div>
   </form>
   {#if projects.length > 0}
+    {@const langTag = languageTag()}
     <div class="w-full relative p-4">
-      {#each projects as project}
+      {#each projects.sort((a, b) => sortByName(a, b, langTag)) as project}
         <ProjectCard {project} route='directory' />
       {/each}
     </div>

--- a/source/SIL.AppBuilder.Portal/src/routes/(authenticated)/directory/+page.svelte
+++ b/source/SIL.AppBuilder.Portal/src/routes/(authenticated)/directory/+page.svelte
@@ -7,7 +7,7 @@
   import { languageTag } from '$lib/paraglide/runtime';
   import type { PrunedProject } from '$lib/projects/common';
   import ProjectCard from '$lib/projects/components/ProjectCard.svelte';
-  import { sortByName } from '$lib/utils';
+  import { byName } from '$lib/utils';
   import 'flatpickr/dist/flatpickr.css';
   import type { FormResult } from 'sveltekit-superforms';
   import { superForm } from 'sveltekit-superforms';
@@ -97,7 +97,7 @@
   {#if projects.length > 0}
     {@const langTag = languageTag()}
     <div class="w-full relative p-4">
-      {#each projects.sort((a, b) => sortByName(a, b, langTag)) as project}
+      {#each projects.sort((a, b) => byName(a, b, langTag)) as project}
         <ProjectCard {project} route='directory' />
       {/each}
     </div>

--- a/source/SIL.AppBuilder.Portal/src/routes/(authenticated)/directory/+page.svelte
+++ b/source/SIL.AppBuilder.Portal/src/routes/(authenticated)/directory/+page.svelte
@@ -5,12 +5,14 @@
   import Pagination from '$lib/components/Pagination.svelte';
   import SearchBar from '$lib/components/SearchBar.svelte';
   import * as m from '$lib/paraglide/messages';
+  import { languageTag } from '$lib/paraglide/runtime';
   import type { PrunedProject } from '$lib/projects/common';
   import ProjectCard from '$lib/projects/components/ProjectCard.svelte';
+  import { byName } from '$lib/utils';
   import type { FormResult } from 'sveltekit-superforms';
   import { superForm } from 'sveltekit-superforms';
   import type { PageData } from './$types';
-  
+
   interface Props {
     data: PageData;
   }
@@ -84,7 +86,7 @@
       </div>
       <select class="select select-bordered max-w-full" bind:value={$form.productDefinitionId}>
         <option value={null} selected>{m.productDefinitions_filterAllProjects()}</option>
-        {#each data.productDefinitions as pD}
+        {#each data.productDefinitions.toSorted((a, b) => byName(a, b, languageTag())) as pD}
           <option value={pD.Id}>{pD.Name}</option>
         {/each}
       </select>

--- a/source/SIL.AppBuilder.Portal/src/routes/(authenticated)/directory/+page.svelte
+++ b/source/SIL.AppBuilder.Portal/src/routes/(authenticated)/directory/+page.svelte
@@ -97,7 +97,7 @@
   {#if projects.length > 0}
     <div class="w-full relative p-4">
       {#each projects as project}
-        <ProjectCard project={$state.snapshot(project)} route='directory' />
+        <ProjectCard project={project} route='directory' />
       {/each}
     </div>
   {:else}

--- a/source/SIL.AppBuilder.Portal/src/routes/(authenticated)/directory/+page.svelte
+++ b/source/SIL.AppBuilder.Portal/src/routes/(authenticated)/directory/+page.svelte
@@ -9,7 +9,6 @@
   import type { PrunedProject } from '$lib/projects/common';
   import ProjectCard from '$lib/projects/components/ProjectCard.svelte';
   import { byName } from '$lib/utils';
-  import 'flatpickr/dist/flatpickr.css';
   import type { FormResult } from 'sveltekit-superforms';
   import { superForm } from 'sveltekit-superforms';
   import type { PageData } from './$types';

--- a/source/SIL.AppBuilder.Portal/src/routes/(authenticated)/directory/+page.svelte
+++ b/source/SIL.AppBuilder.Portal/src/routes/(authenticated)/directory/+page.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
   import DateRangePicker from '$lib/components/DateRangePicker.svelte';
   import LanguageCodeTypeahead from '$lib/components/LanguageCodeTypeahead.svelte';
+  import OrganizationDropdown from '$lib/components/OrganizationDropdown.svelte';
   import Pagination from '$lib/components/Pagination.svelte';
   import SearchBar from '$lib/components/SearchBar.svelte';
   import * as m from '$lib/paraglide/messages';
@@ -40,6 +41,8 @@
       }
     }
   });
+
+  const mobileSizing = 'w-full max-w-xs md:w-auto md:max-w-none';
 </script>
 
 <div class="w-full max-w-6xl mx-auto relative px-2 pt-4">
@@ -53,29 +56,29 @@
     }}
   >
     <div
-      class="flex flex-row flex-wrap md:flex-nowrap place-content-end items-center px-4 gap-1 mobile-sizing"
+      class="flex flex-row flex-wrap md:flex-nowrap place-content-end items-center px-4 gap-1 {mobileSizing}"
     >
-      <div class="inline-block grow mobile-sizing">
+      <div class="inline-block grow {mobileSizing}">
         <h1 class="py-4 px-2">{m.sidebar_projectDirectory()}</h1>
       </div>
       <div
-        class="flex flex-row flex-wrap md:flex-nowrap place-content-end items-center gap-1 mobile-sizing"
+        class="flex flex-row flex-wrap md:flex-nowrap place-content-end items-center gap-1 {mobileSizing}"
       >
-        <select class="select select-bordered mobile-sizing" bind:value={$form.organizationId}>
-          <option value={null} selected>{m.org_allOrganizations()}</option>
-          {#each data.organizations as organization}
-            <option value={organization.Id}>{organization.Name}</option>
-          {/each}
-        </select>
+        <OrganizationDropdown
+          className={mobileSizing}
+          organizations={data.organizations}
+          bind:value={$form.organizationId}
+          allowNull={true}
+        />
         <SearchBar
           bind:value={$form.search}
-          className="w-full max-w-xs md:w-auto md:max-w-none"
+          className={mobileSizing}
           tooltip={m.directory_searchHelp()}
         />
       </div>
     </div>
-    <div class="flex flex-row flex-wrap gap-1 place-content-start px-4 pt-1 mobile-sizing">
-      <div class="mobile-sizing">
+    <div class="flex flex-row flex-wrap gap-1 place-content-start px-4 pt-1 {mobileSizing}">
+      <div class={mobileSizing}>
         <LanguageCodeTypeahead
           bind:langCode={$form.langCode}
           onLangCodeSelected={() => submit()}
@@ -129,13 +132,5 @@
   }
   :global(li[aria-selected='true'] .listElement) {
     background-color: oklch(var(--b2));
-  }
-  .mobile-sizing {
-    @apply w-full max-w-xs;
-  }
-  @media screen(md) {
-    .mobile-sizing {
-      @apply w-auto max-w-none;
-    }
   }
 </style>

--- a/source/SIL.AppBuilder.Portal/src/routes/(authenticated)/directory/+page.svelte
+++ b/source/SIL.AppBuilder.Portal/src/routes/(authenticated)/directory/+page.svelte
@@ -5,10 +5,8 @@
   import Pagination from '$lib/components/Pagination.svelte';
   import SearchBar from '$lib/components/SearchBar.svelte';
   import * as m from '$lib/paraglide/messages';
-  import { languageTag } from '$lib/paraglide/runtime';
   import type { PrunedProject } from '$lib/projects/common';
   import ProjectCard from '$lib/projects/components/ProjectCard.svelte';
-  import { byName } from '$lib/utils';
   import type { FormResult } from 'sveltekit-superforms';
   import { superForm } from 'sveltekit-superforms';
   import type { PageData } from './$types';
@@ -97,10 +95,9 @@
     </div>
   </form>
   {#if projects.length > 0}
-    {@const langTag = languageTag()}
     <div class="w-full relative p-4">
-      {#each projects.sort((a, b) => byName(a, b, langTag)) as project}
-        <ProjectCard {project} route='directory' />
+      {#each projects as project}
+        <ProjectCard project={$state.snapshot(project)} route='directory' />
       {/each}
     </div>
   {:else}

--- a/source/SIL.AppBuilder.Portal/src/routes/(authenticated)/directory/[id]/+page.svelte
+++ b/source/SIL.AppBuilder.Portal/src/routes/(authenticated)/directory/[id]/+page.svelte
@@ -72,7 +72,7 @@
         {m.projectTable_noProducts()}
       {:else}
         {@const langTag = languageTag()}
-        {#each data.project.Products.sort( (a, b) => byName(a.ProductDefinition, b.ProductDefinition, langTag) ) as product}
+        {#each data.project.Products.toSorted( (a, b) => byName(a.ProductDefinition, b.ProductDefinition, langTag) ) as product}
           {@const release = product.ProductPublications.at(0)}
           {@const build = release?.ProductBuild}
           <div>

--- a/source/SIL.AppBuilder.Portal/src/routes/(authenticated)/directory/[id]/+page.svelte
+++ b/source/SIL.AppBuilder.Portal/src/routes/(authenticated)/directory/[id]/+page.svelte
@@ -7,7 +7,7 @@
   import BuildArtifacts from '$lib/products/components/BuildArtifacts.svelte';
   import { canModifyProject } from '$lib/projects/common';
   import { getRelativeTime } from '$lib/timeUtils';
-  import { sortByName } from '$lib/utils';
+  import { byName } from '$lib/utils';
   import type { PageData } from './$types';
 
   interface Props {
@@ -72,7 +72,7 @@
         {m.projectTable_noProducts()}
       {:else}
         {@const langTag = languageTag()}
-        {#each data.project.Products.sort( (a, b) => sortByName(a.ProductDefinition, b.ProductDefinition, langTag) ) as product}
+        {#each data.project.Products.sort( (a, b) => byName(a.ProductDefinition, b.ProductDefinition, langTag) ) as product}
           {@const release = product.ProductPublications.at(0)}
           {@const build = release?.ProductBuild}
           <div>

--- a/source/SIL.AppBuilder.Portal/src/routes/(authenticated)/organizations/[id]/settings/groups/+page.svelte
+++ b/source/SIL.AppBuilder.Portal/src/routes/(authenticated)/organizations/[id]/settings/groups/+page.svelte
@@ -1,6 +1,8 @@
 <script lang="ts">
   import IconContainer from '$lib/components/IconContainer.svelte';
   import { org_addGroupButton } from '$lib/paraglide/messages';
+  import { languageTag } from '$lib/paraglide/runtime';
+  import { sortByName } from '$lib/utils';
   import { superForm } from 'sveltekit-superforms';
   import type { PageData } from './$types';
 
@@ -14,7 +16,7 @@
   const { form: deleteForm, enhance: deleteEnhance } = superForm(data.deleteForm);
 </script>
 
-{#each data.organization.Groups as group}
+{#each data.organization.Groups.sort((a, b) => sortByName(a, b, languageTag())) as group}
   <form action="?/deleteGroup" class="m-2" method="post" use:deleteEnhance>
     <input type="hidden" name="id" value={group.Id} />
     <div class="border w-full flex flex-row p-2 rounded-md items-center place-content-between">

--- a/source/SIL.AppBuilder.Portal/src/routes/(authenticated)/organizations/[id]/settings/groups/+page.svelte
+++ b/source/SIL.AppBuilder.Portal/src/routes/(authenticated)/organizations/[id]/settings/groups/+page.svelte
@@ -2,7 +2,7 @@
   import IconContainer from '$lib/components/IconContainer.svelte';
   import { org_addGroupButton } from '$lib/paraglide/messages';
   import { languageTag } from '$lib/paraglide/runtime';
-  import { sortByName } from '$lib/utils';
+  import { byName } from '$lib/utils';
   import { superForm } from 'sveltekit-superforms';
   import type { PageData } from './$types';
 
@@ -16,7 +16,7 @@
   const { form: deleteForm, enhance: deleteEnhance } = superForm(data.deleteForm);
 </script>
 
-{#each data.organization.Groups.sort((a, b) => sortByName(a, b, languageTag())) as group}
+{#each data.organization.Groups.sort((a, b) => byName(a, b, languageTag())) as group}
   <form action="?/deleteGroup" class="m-2" method="post" use:deleteEnhance>
     <input type="hidden" name="id" value={group.Id} />
     <div class="border w-full flex flex-row p-2 rounded-md items-center place-content-between">

--- a/source/SIL.AppBuilder.Portal/src/routes/(authenticated)/organizations/[id]/settings/groups/+page.svelte
+++ b/source/SIL.AppBuilder.Portal/src/routes/(authenticated)/organizations/[id]/settings/groups/+page.svelte
@@ -16,7 +16,7 @@
   const { form: deleteForm, enhance: deleteEnhance } = superForm(data.deleteForm);
 </script>
 
-{#each data.organization.Groups.sort((a, b) => byName(a, b, languageTag())) as group}
+{#each data.organization.Groups.toSorted((a, b) => byName(a, b, languageTag())) as group}
   <form action="?/deleteGroup" class="m-2" method="post" use:deleteEnhance>
     <input type="hidden" name="id" value={group.Id} />
     <div class="border w-full flex flex-row p-2 rounded-md items-center place-content-between">

--- a/source/SIL.AppBuilder.Portal/src/routes/(authenticated)/organizations/[id]/settings/products/+page.server.ts
+++ b/source/SIL.AppBuilder.Portal/src/routes/(authenticated)/organizations/[id]/settings/products/+page.server.ts
@@ -30,7 +30,9 @@ export const load = (async (event) => {
       OrganizationId: id
     }
   });
-  const allProductDefs = await prisma.productDefinitions.findMany();
+  const allProductDefs = (await prisma.productDefinitions.findMany()).map(
+    (pd) => [pd.Id, pd] as [number, typeof pd]
+  );
   if (!data) return redirect(302, base + '/organizations');
   const setOrgProductDefs = new Set(orgProductDefs.map((p) => p.ProductDefinitionId));
   const form = await superValidate(
@@ -38,8 +40,8 @@ export const load = (async (event) => {
       id: data.Id,
       publicByDefault: data.PublicByDefault ?? false,
       products: allProductDefs.map((pD) => ({
-        productId: pD.Id,
-        enabled: setOrgProductDefs.has(pD.Id)
+        productId: pD[0],
+        enabled: setOrgProductDefs.has(pD[0])
       }))
     },
     valibot(editProductsSchema)
@@ -62,7 +64,7 @@ export const actions = {
           Id: id
         },
         data: {
-          PublicByDefault: publicByDefault
+          PublicByDefault: publicByDefault // TODO: what are we doing with this? Should projects be
         }
       });
       return { ok: true, form };

--- a/source/SIL.AppBuilder.Portal/src/routes/(authenticated)/organizations/[id]/settings/products/+page.svelte
+++ b/source/SIL.AppBuilder.Portal/src/routes/(authenticated)/organizations/[id]/settings/products/+page.svelte
@@ -2,6 +2,8 @@
   import MultiselectBox from '$lib/components/settings/MultiselectBox.svelte';
   import MultiselectBoxElement from '$lib/components/settings/MultiselectBoxElement.svelte';
   import * as m from '$lib/paraglide/messages';
+  import { languageTag } from '$lib/paraglide/runtime';
+  import { sortByNullableString } from '$lib/utils';
   import { superForm } from 'sveltekit-superforms';
   import type { PageData } from './$types';
   interface Props {
@@ -18,6 +20,8 @@
     dataType: 'json',
     resetForm: false
   });
+
+  const allProductDefs = new Map(data.allProductDefs);
 </script>
 
 <h2>{m.org_productsTitle()}</h2>
@@ -43,11 +47,11 @@
     </label>
   </div>
   <MultiselectBox header={m.org_productSelectTitle()}>
-    {#each $superFormData.products as productDef}
+    {#each $superFormData.products.sort( (a, b) => sortByNullableString(allProductDefs.get(a.productId)?.Name, allProductDefs.get(b.productId)?.Name, languageTag()) ) as productDef}
+      {@const pdLook = allProductDefs.get(productDef.productId)}
       <MultiselectBoxElement
-        title={data.allProductDefs.find((p) => p.Id === productDef.productId)?.Name ?? ''}
-        description={data.allProductDefs.find((p) => p.Id === productDef.productId)?.Description ??
-          ''}
+        title={pdLook?.Name ?? ''}
+        description={pdLook?.Description ?? ''}
         bind:checked={productDef.enabled}
       />
     {/each}

--- a/source/SIL.AppBuilder.Portal/src/routes/(authenticated)/organizations/[id]/settings/products/+page.svelte
+++ b/source/SIL.AppBuilder.Portal/src/routes/(authenticated)/organizations/[id]/settings/products/+page.svelte
@@ -47,7 +47,7 @@
     </label>
   </div>
   <MultiselectBox header={m.org_productSelectTitle()}>
-    {#each $superFormData.products.sort( (a, b) => byName(allProductDefs.get(a.productId), allProductDefs.get(b.productId), languageTag()) ) as productDef}
+    {#each $superFormData.products.toSorted( (a, b) => byName(allProductDefs.get(a.productId), allProductDefs.get(b.productId), languageTag()) ) as productDef}
       {@const pdLook = allProductDefs.get(productDef.productId)}
       <MultiselectBoxElement
         title={pdLook?.Name ?? ''}

--- a/source/SIL.AppBuilder.Portal/src/routes/(authenticated)/organizations/[id]/settings/products/+page.svelte
+++ b/source/SIL.AppBuilder.Portal/src/routes/(authenticated)/organizations/[id]/settings/products/+page.svelte
@@ -3,7 +3,7 @@
   import MultiselectBoxElement from '$lib/components/settings/MultiselectBoxElement.svelte';
   import * as m from '$lib/paraglide/messages';
   import { languageTag } from '$lib/paraglide/runtime';
-  import { sortByNullableString } from '$lib/utils';
+  import { byName } from '$lib/utils';
   import { superForm } from 'sveltekit-superforms';
   import type { PageData } from './$types';
   interface Props {
@@ -47,7 +47,7 @@
     </label>
   </div>
   <MultiselectBox header={m.org_productSelectTitle()}>
-    {#each $superFormData.products.sort( (a, b) => sortByNullableString(allProductDefs.get(a.productId)?.Name, allProductDefs.get(b.productId)?.Name, languageTag()) ) as productDef}
+    {#each $superFormData.products.sort( (a, b) => byName(allProductDefs.get(a.productId), allProductDefs.get(b.productId), languageTag()) ) as productDef}
       {@const pdLook = allProductDefs.get(productDef.productId)}
       <MultiselectBoxElement
         title={pdLook?.Name ?? ''}

--- a/source/SIL.AppBuilder.Portal/src/routes/(authenticated)/organizations/[id]/settings/stores/+page.server.ts
+++ b/source/SIL.AppBuilder.Portal/src/routes/(authenticated)/organizations/[id]/settings/stores/+page.server.ts
@@ -29,15 +29,15 @@ export const load = (async (event) => {
       OrganizationId: id
     }
   });
-  const allStores = await prisma.stores.findMany();
+  const allStores = (await prisma.stores.findMany()).map((s) => [s.Id, s] as [number, typeof s]);
   if (!data) return redirect(302, base + '/organizations');
-  const setOrgProductDefs = new Set(orgStores.map((p) => p.StoreId));
+  const setOrgStores = new Set(orgStores.map((p) => p.StoreId));
   const form = await superValidate(
     {
       id: data.Id,
-      stores: allStores.map((pD) => ({
-        storeId: pD.Id,
-        enabled: setOrgProductDefs.has(pD.Id)
+      stores: allStores.map((s) => ({
+        storeId: s[0],
+        enabled: setOrgStores.has(s[0])
       }))
     },
     valibot(editStoresSchema)

--- a/source/SIL.AppBuilder.Portal/src/routes/(authenticated)/organizations/[id]/settings/stores/+page.svelte
+++ b/source/SIL.AppBuilder.Portal/src/routes/(authenticated)/organizations/[id]/settings/stores/+page.svelte
@@ -2,6 +2,8 @@
   import MultiselectBox from '$lib/components/settings/MultiselectBox.svelte';
   import MultiselectBoxElement from '$lib/components/settings/MultiselectBoxElement.svelte';
   import * as m from '$lib/paraglide/messages';
+  import { languageTag } from '$lib/paraglide/runtime';
+  import { sortByNullableString } from '$lib/utils';
   import { superForm } from 'sveltekit-superforms';
   import type { PageData } from './$types';
   interface Props {
@@ -18,16 +20,19 @@
     dataType: 'json',
     resetForm: false
   });
+
+  const allStores = new Map(data.allStores);
 </script>
 
 <h2>{m.org_storesTitle()}</h2>
 <form action="" class="m-4" method="post" use:enhance>
   <MultiselectBox header={m.org_storeSelectTitle()}>
     <div>
-      {#each $superFormData.stores as store}
+      {#each $superFormData.stores.sort( (a, b) => sortByNullableString(allStores.get(a.storeId)?.Name, allStores.get(b.storeId)?.Name, languageTag())) as store}
+        {@const storeLook = allStores.get(store.storeId)}
         <MultiselectBoxElement
-          title={data.allStores.find((p) => p.Id === store.storeId)?.Name ?? ''}
-          description={data.allStores.find((p) => p.Id === store.storeId)?.Description ?? ''}
+          title={storeLook?.Name ?? ''}
+          description={storeLook?.Description ?? ''}
           bind:checked={store.enabled}
         />
       {/each}

--- a/source/SIL.AppBuilder.Portal/src/routes/(authenticated)/organizations/[id]/settings/stores/+page.svelte
+++ b/source/SIL.AppBuilder.Portal/src/routes/(authenticated)/organizations/[id]/settings/stores/+page.svelte
@@ -3,7 +3,7 @@
   import MultiselectBoxElement from '$lib/components/settings/MultiselectBoxElement.svelte';
   import * as m from '$lib/paraglide/messages';
   import { languageTag } from '$lib/paraglide/runtime';
-  import { sortByNullableString } from '$lib/utils';
+  import { byName } from '$lib/utils';
   import { superForm } from 'sveltekit-superforms';
   import type { PageData } from './$types';
   interface Props {
@@ -28,7 +28,7 @@
 <form action="" class="m-4" method="post" use:enhance>
   <MultiselectBox header={m.org_storeSelectTitle()}>
     <div>
-      {#each $superFormData.stores.sort( (a, b) => sortByNullableString(allStores.get(a.storeId)?.Name, allStores.get(b.storeId)?.Name, languageTag())) as store}
+      {#each $superFormData.stores.sort( (a, b) => byName(allStores.get(a.storeId), allStores.get(b.storeId), languageTag())) as store}
         {@const storeLook = allStores.get(store.storeId)}
         <MultiselectBoxElement
           title={storeLook?.Name ?? ''}

--- a/source/SIL.AppBuilder.Portal/src/routes/(authenticated)/organizations/[id]/settings/stores/+page.svelte
+++ b/source/SIL.AppBuilder.Portal/src/routes/(authenticated)/organizations/[id]/settings/stores/+page.svelte
@@ -28,7 +28,7 @@
 <form action="" class="m-4" method="post" use:enhance>
   <MultiselectBox header={m.org_storeSelectTitle()}>
     <div>
-      {#each $superFormData.stores.sort( (a, b) => byName(allStores.get(a.storeId), allStores.get(b.storeId), languageTag())) as store}
+      {#each $superFormData.stores.toSorted( (a, b) => byName(allStores.get(a.storeId), allStores.get(b.storeId), languageTag())) as store}
         {@const storeLook = allStores.get(store.storeId)}
         <MultiselectBoxElement
           title={storeLook?.Name ?? ''}

--- a/source/SIL.AppBuilder.Portal/src/routes/(authenticated)/products/[id]/files/+page.svelte
+++ b/source/SIL.AppBuilder.Portal/src/routes/(authenticated)/products/[id]/files/+page.svelte
@@ -55,7 +55,7 @@
   <div id="files" class="overflow-y-auto grow">
     {#each builds as build}
       <BuildArtifacts
-        {build}
+        build={$state.snapshot(build)}
         latestBuildId={data.product?.WorkflowBuildId}
       />
     {/each}

--- a/source/SIL.AppBuilder.Portal/src/routes/(authenticated)/products/[id]/files/+page.svelte
+++ b/source/SIL.AppBuilder.Portal/src/routes/(authenticated)/products/[id]/files/+page.svelte
@@ -14,7 +14,7 @@
   let { data }: Props = $props();
 
   let builds = $state(data.builds);
-  let count = $state(data.count)
+  let count = $state(data.count);
 
   const { form, enhance, submit } = superForm(data.form, {
     resetForm: false,
@@ -23,7 +23,7 @@
     },
     onUpdate(event) {
       const data = event.result.data as FormResult<{
-        query: { data: any[], count: number };
+        query: { data: any[]; count: number };
       }>;
       if (event.form.valid && data.query) {
         builds = data.query.data;
@@ -54,10 +54,7 @@
   </div>
   <div id="files" class="overflow-y-auto grow">
     {#each builds as build}
-      <BuildArtifacts
-        build={$state.snapshot(build)}
-        latestBuildId={data.product?.WorkflowBuildId}
-      />
+      <BuildArtifacts {build} latestBuildId={data.product?.WorkflowBuildId} />
     {/each}
   </div>
   <form method="POST" action="?/page" use:enhance>

--- a/source/SIL.AppBuilder.Portal/src/routes/(authenticated)/projects/[filter=projectSelector]/[id]/+page.svelte
+++ b/source/SIL.AppBuilder.Portal/src/routes/(authenticated)/projects/[filter=projectSelector]/[id]/+page.svelte
@@ -331,7 +331,7 @@
               allowActions={data.allowActions}
               allowReactivate={data.allowReactivate}
               userGroups={data.userGroups}
-              orgId={parseInt($page.params.id)}
+              orgId={parseInt(page.params.id)}
             />
           {/snippet}
         </ProjectCard>

--- a/source/SIL.AppBuilder.Portal/src/routes/(authenticated)/projects/[filter=projectSelector]/[id]/+page.svelte
+++ b/source/SIL.AppBuilder.Portal/src/routes/(authenticated)/projects/[filter=projectSelector]/[id]/+page.svelte
@@ -2,6 +2,7 @@
   import { afterNavigate, goto } from '$app/navigation';
   import { page } from '$app/state';
   import IconContainer from '$lib/components/IconContainer.svelte';
+  import OrganizationDropdown from '$lib/components/OrganizationDropdown.svelte';
   import Pagination from '$lib/components/Pagination.svelte';
   import SearchBar from '$lib/components/SearchBar.svelte';
   import { getIcon } from '$lib/icons/productDefinitionIcon';
@@ -134,18 +135,12 @@
       <div
         class="flex flex-row flex-wrap md:flex-nowrap place-content-end items-center mx-4 gap-1 {mobileSizing}"
       >
-        <!-- TODO: convert this to OrganizationDropdown after upgrade/svelte-5 -->
-        <select
-          class="select select-bordered {mobileSizing}"
+        <OrganizationDropdown
+          className={mobileSizing}
+          organizations={data.organizations}
           bind:value={$pageForm.organizationId}
           onchange={() => goto($pageForm.organizationId + '')}
-        >
-          {#each data.organizations.toSorted((a, b) => byName(a, b, languageTag())) as organization}
-            <option value={organization.Id} selected={$pageForm.organizationId === organization.Id}>
-              {organization.Name}
-            </option>
-          {/each}
-        </select>
+        />
         <SearchBar bind:value={$pageForm.search} className={mobileSizing} />
       </div>
     </div>
@@ -221,7 +216,7 @@
               <div class="p-2">
                 <h3>{project.Name}</h3>
                 {#if products?.length}
-                  {#each products.toSorted((a, b) => byString(a.ProductDefinitionName, b.ProductDefinitionName, languageTag())) as product}
+                  {#each products.toSorted( (a, b) => byString(a.ProductDefinitionName, b.ProductDefinitionName, languageTag()) ) as product}
                     <!-- svelte-ignore a11y_click_events_have_key_events -->
                     <!-- svelte-ignore a11y_no_noninteractive_element_interactions -->
                     <label

--- a/source/SIL.AppBuilder.Portal/src/routes/(authenticated)/projects/[filter=projectSelector]/[id]/+page.svelte
+++ b/source/SIL.AppBuilder.Portal/src/routes/(authenticated)/projects/[filter=projectSelector]/[id]/+page.svelte
@@ -140,7 +140,7 @@
           bind:value={$pageForm.organizationId}
           onchange={() => goto($pageForm.organizationId + '')}
         >
-          {#each data.organizations.sort((a, b) => byName(a, b, languageTag())) as organization}
+          {#each data.organizations.toSorted((a, b) => byName(a, b, languageTag())) as organization}
             <option value={organization.Id} selected={$pageForm.organizationId === organization.Id}>
               {organization.Name}
             </option>
@@ -314,7 +314,7 @@
   {#if data.projects.length > 0}
     {@const langTag = languageTag()}
     <div class="w-full relative p-4">
-      {#each data.projects.sort((a, b) => byName(a, b, langTag)) as project}
+      {#each data.projects.toSorted((a, b) => byName(a, b, langTag)) as project}
         <ProjectCard {project}>
           {#snippet select()}
             <input

--- a/source/SIL.AppBuilder.Portal/src/routes/(authenticated)/projects/[filter=projectSelector]/[id]/+page.svelte
+++ b/source/SIL.AppBuilder.Portal/src/routes/(authenticated)/projects/[filter=projectSelector]/[id]/+page.svelte
@@ -12,7 +12,7 @@
   import ProjectActionMenu from '$lib/projects/components/ProjectActionMenu.svelte';
   import ProjectCard from '$lib/projects/components/ProjectCard.svelte';
   import ProjectFilterSelector from '$lib/projects/components/ProjectFilterSelector.svelte';
-  import { byName } from '$lib/utils';
+  import { byName, byString } from '$lib/utils';
   import type { FormResult } from 'sveltekit-superforms';
   import { superForm } from 'sveltekit-superforms';
   import type { PageData } from './$types';
@@ -216,12 +216,12 @@
           </div>
           <hr />
           <div class="flex flex-col pt-1 space-y-1">
-            {#each selectedProjects as project}
+            {#each selectedProjects.toSorted((a, b) => byName(a, b, languageTag())) as project}
               {@const products = project.Products?.filter((p) => p.CanRebuild || p.CanRepublish)}
               <div class="p-2">
                 <h3>{project.Name}</h3>
                 {#if products?.length}
-                  {#each products as product}
+                  {#each products.toSorted((a, b) => byString(a.ProductDefinitionName, b.ProductDefinitionName, languageTag())) as product}
                     <!-- svelte-ignore a11y_click_events_have_key_events -->
                     <!-- svelte-ignore a11y_no_noninteractive_element_interactions -->
                     <label

--- a/source/SIL.AppBuilder.Portal/src/routes/(authenticated)/projects/[filter=projectSelector]/[id]/+page.svelte
+++ b/source/SIL.AppBuilder.Portal/src/routes/(authenticated)/projects/[filter=projectSelector]/[id]/+page.svelte
@@ -12,7 +12,7 @@
   import ProjectActionMenu from '$lib/projects/components/ProjectActionMenu.svelte';
   import ProjectCard from '$lib/projects/components/ProjectCard.svelte';
   import ProjectFilterSelector from '$lib/projects/components/ProjectFilterSelector.svelte';
-  import { sortByName } from '$lib/utils';
+  import { byName } from '$lib/utils';
   import type { FormResult } from 'sveltekit-superforms';
   import { superForm } from 'sveltekit-superforms';
   import type { PageData } from './$types';
@@ -137,7 +137,7 @@
           bind:value={$pageForm.organizationId}
           onchange={() => goto($pageForm.organizationId + '')}
         >
-          {#each data.organizations.sort((a, b) => sortByName(a, b, languageTag())) as organization}
+          {#each data.organizations.sort((a, b) => byName(a, b, languageTag())) as organization}
             <option value={organization.Id} selected={$pageForm.organizationId === organization.Id}>
               {organization.Name}
             </option>
@@ -314,7 +314,7 @@
   {#if data.projects.length > 0}
     {@const langTag = languageTag()}
     <div class="w-full relative p-4">
-      {#each data.projects.sort((a, b) => sortByName(a, b, langTag)) as project}
+      {#each data.projects.sort((a, b) => byName(a, b, langTag)) as project}
         <ProjectCard {project}>
           {#snippet select()}
             <input

--- a/source/SIL.AppBuilder.Portal/src/routes/(authenticated)/projects/[filter=projectSelector]/[id]/+page.svelte
+++ b/source/SIL.AppBuilder.Portal/src/routes/(authenticated)/projects/[filter=projectSelector]/[id]/+page.svelte
@@ -35,7 +35,14 @@
     resetForm: false,
     invalidateAll: false,
     onChange(event) {
-      if (!(event.paths.includes('langCode') || event.paths.includes('search'))) {
+      if (
+        !(
+          event.paths.includes('langCode') ||
+          event.paths.includes('search') ||
+          // handle organization change solely through routing
+          event.paths.includes('organizationId')
+        )
+      ) {
         pageSubmit();
       }
     },
@@ -86,6 +93,10 @@
   let selectedProducts: ProductForAction[] = $state([]);
 
   afterNavigate((navigation) => {
+    // tried workaround with $effect: https://github.com/sveltejs/kit/issues/11116#issuecomment-2574727891
+    // this way worked much better for our use case
+    projects = data.projects;
+    count = data.count;
     $pageForm.organizationId = data.pageForm.data.organizationId;
   });
 
@@ -306,10 +317,10 @@
       </div>
     {/if}
   </div>
-  {#if data.projects.length > 0}
+  {#if projects.length > 0}
     {@const langTag = languageTag()}
     <div class="w-full relative p-4">
-      {#each data.projects.toSorted((a, b) => byName(a, b, langTag)) as project}
+      {#each projects.toSorted((a, b) => byName(a, b, langTag)) as project}
         <ProjectCard {project}>
           {#snippet select()}
             <input

--- a/source/SIL.AppBuilder.Portal/src/routes/(authenticated)/projects/[filter=projectSelector]/[id]/+page.svelte
+++ b/source/SIL.AppBuilder.Portal/src/routes/(authenticated)/projects/[filter=projectSelector]/[id]/+page.svelte
@@ -6,11 +6,13 @@
   import SearchBar from '$lib/components/SearchBar.svelte';
   import { getIcon } from '$lib/icons/productDefinitionIcon';
   import * as m from '$lib/paraglide/messages';
+  import { languageTag } from '$lib/paraglide/runtime';
   import type { ProjectForAction, PrunedProject } from '$lib/projects/common';
   import { canArchive, canReactivate } from '$lib/projects/common';
   import ProjectActionMenu from '$lib/projects/components/ProjectActionMenu.svelte';
   import ProjectCard from '$lib/projects/components/ProjectCard.svelte';
   import ProjectFilterSelector from '$lib/projects/components/ProjectFilterSelector.svelte';
+  import { sortByName } from '$lib/utils';
   import type { FormResult } from 'sveltekit-superforms';
   import { superForm } from 'sveltekit-superforms';
   import type { PageData } from './$types';
@@ -135,7 +137,7 @@
           bind:value={$pageForm.organizationId}
           onchange={() => goto($pageForm.organizationId + '')}
         >
-          {#each data.organizations as organization}
+          {#each data.organizations.sort((a, b) => sortByName(a, b, languageTag())) as organization}
             <option value={organization.Id} selected={$pageForm.organizationId === organization.Id}>
               {organization.Name}
             </option>
@@ -309,9 +311,10 @@
       </div>
     {/if}
   </div>
-  {#if projects.length > 0}
+  {#if data.projects.length > 0}
+    {@const langTag = languageTag()}
     <div class="w-full relative p-4">
-      {#each projects as project}
+      {#each data.projects.sort((a, b) => sortByName(a, b, langTag)) as project}
         <ProjectCard {project}>
           {#snippet select()}
             <input

--- a/source/SIL.AppBuilder.Portal/src/routes/(authenticated)/projects/[filter=projectSelector]/[id]/+page.svelte
+++ b/source/SIL.AppBuilder.Portal/src/routes/(authenticated)/projects/[filter=projectSelector]/[id]/+page.svelte
@@ -112,7 +112,9 @@
   });
   $effect(() => {
     $productForm.products = selectedProducts.map((p) => p.Id);
-  })
+  });
+
+  const mobileSizing = 'w-full max-w-xs md:w-auto md:max-w-none';
 </script>
 
 <div class="w-full max-w-6xl mx-auto relative px-2">
@@ -130,10 +132,11 @@
         <ProjectFilterSelector />
       </div>
       <div
-        class="flex flex-row flex-wrap md:flex-nowrap place-content-end items-center mx-4 mobile-sizing gap-1"
+        class="flex flex-row flex-wrap md:flex-nowrap place-content-end items-center mx-4 gap-1 {mobileSizing}"
       >
+        <!-- TODO: convert this to OrganizationDropdown after upgrade/svelte-5 -->
         <select
-          class="select select-bordered mobile-sizing"
+          class="select select-bordered {mobileSizing}"
           bind:value={$pageForm.organizationId}
           onchange={() => goto($pageForm.organizationId + '')}
         >
@@ -143,16 +146,13 @@
             </option>
           {/each}
         </select>
-        <SearchBar
-          bind:value={$pageForm.search}
-          className="w-full max-w-xs md:w-auto md:max-w-none"
-        />
+        <SearchBar bind:value={$pageForm.search} className={mobileSizing} />
       </div>
     </div>
   </form>
   <div class="w-full flex flex-row flex-wrap place-content-between gap-1 mt-4">
     <form
-      class="flex flex-row flex-wrap mobile-sizing gap-1 mx-4"
+      class="flex flex-row flex-wrap {mobileSizing} gap-1 mx-4"
       method="POST"
       action="?/projectAction"
       use:actionEnhance
@@ -301,7 +301,7 @@
       </form>
     </dialog>
     {#if page.params.filter === 'own'}
-      <div class="flex flex-row flex-wrap mobile-sizing gap-1 mx-4">
+      <div class="flex flex-row flex-wrap {mobileSizing} gap-1 mx-4">
         <a class="action btn btn-outline" href="/projects/import/{$pageForm.organizationId}">
           {m.project_importProjects()}
         </a>
@@ -350,24 +350,12 @@
     }}
   >
     <div class="w-full flex flex-row place-content-start p-4 space-between-4 flex-wrap gap-1">
-      <Pagination
-        bind:size={$pageForm.page.size}
-        total={count}
-        bind:page={$pageForm.page.page}
-      />
+      <Pagination bind:size={$pageForm.page.size} total={count} bind:page={$pageForm.page.page} />
     </div>
   </form>
 </div>
 
 <style lang="postcss">
-  .mobile-sizing {
-    @apply w-full max-w-xs;
-  }
-  @media screen(md) {
-    .mobile-sizing {
-      @apply w-auto max-w-none;
-    }
-  }
   .action {
     @apply form-control w-full max-w-xs;
   }

--- a/source/SIL.AppBuilder.Portal/src/routes/(authenticated)/projects/[id=idNumber]/+page.svelte
+++ b/source/SIL.AppBuilder.Portal/src/routes/(authenticated)/projects/[id=idNumber]/+page.svelte
@@ -11,7 +11,7 @@
   import ProductDetails from '$lib/products/components/ProductDetails.svelte';
   import ProjectActionMenu from '$lib/projects/components/ProjectActionMenu.svelte';
   import { getRelativeTime } from '$lib/timeUtils';
-  import { isAdminForOrg, isSuperAdmin, sortByName } from '$lib/utils';
+  import { byName, isAdminForOrg, isSuperAdmin } from '$lib/utils';
   import { ProductType } from 'sil.appbuilder.portal.common/workflow';
   import { superForm } from 'sveltekit-superforms';
   import type { PageData } from './$types';
@@ -191,7 +191,7 @@
               </div>
               <hr />
               <div class="flex flex-col pt-1 space-y-1">
-                {#each data.productsToAdd.sort( (a, b) => sortByName(a, b, languageTag()) ) as productDef, i}
+                {#each data.productsToAdd.sort( (a, b) => byName(a, b, languageTag()) ) as productDef, i}
                   <!-- svelte-ignore a11y_click_events_have_key_events -->
                   <!-- svelte-ignore a11y_no_noninteractive_element_interactions -->
                   <label
@@ -237,7 +237,7 @@
               <div class="flex flex-col pt-1 space-y-1">
                 {#if availableStores.length}
                   {@const langTag = languageTag()}
-                  {#each availableStores.sort((a, b) => sortByName(a, b, langTag)) as store}
+                  {#each availableStores.sort((a, b) => byName(a, b, langTag)) as store}
                     <!-- svelte-ignore a11y_click_events_have_key_events -->
                     <!-- svelte-ignore a11y_no_noninteractive_element_interactions -->
                     <label
@@ -275,7 +275,7 @@
           {m.projectTable_noProducts()}
         {:else}
           {@const langTag = languageTag()}
-          {#each data.project.Products.sort( (a, b) => sortByName(a.ProductDefinition, b.ProductDefinition, langTag) ) as product}
+          {#each data.project.Products.sort( (a, b) => byName(a.ProductDefinition, b.ProductDefinition, langTag) ) as product}
             <div class="rounded-md border border-slate-400 w-full my-2">
               <div class="bg-neutral p-2 flex flex-row rounded-t-md">
                 <span class="grow min-w-0">
@@ -512,7 +512,7 @@
                       bind:this={ownerField}
                     />
                     <ul class="menu menu-compact overflow-hidden rounded-md">
-                      {#each data.possibleProjectOwners.sort( (a, b) => sortByName(a, b, languageTag()) ) as owner}
+                      {#each data.possibleProjectOwners.sort( (a, b) => byName(a, b, languageTag()) ) as owner}
                         <li class="w-full rounded-none">
                           <button
                             class="text-nowrap"
@@ -559,7 +559,7 @@
                       bind:this={groupField}
                     />
                     <ul class="menu menu-compact overflow-hidden rounded-md">
-                      {#each data.possibleGroups.sort( (a, b) => sortByName(a, b, languageTag()) ) as group}
+                      {#each data.possibleGroups.sort( (a, b) => byName(a, b, languageTag()) ) as group}
                         <li class="w-full rounded-none">
                           <button
                             class="text-nowrap"
@@ -589,7 +589,7 @@
         <div class="p-2">
           {#if data.project.Authors.length}
             {@const langTag = languageTag()}
-            {#each data.project.Authors.sort( (a, b) => sortByName(a.Users, b.Users, langTag) ) as author}
+            {#each data.project.Authors.sort((a, b) => byName(a.Users, b.Users, langTag)) as author}
               <div class="flex flex-row w-full place-content-between p-2">
                 <span>{author.Users.Name}</span>
                 <form action="?/deleteAuthor" method="post" use:authorDeleteEnhance>
@@ -614,7 +614,7 @@
               >
                 {#each data.authorsToAdd
                   .filter((author) => !data.project?.Authors.some((au) => au.Users.Id === author.Id))
-                  .sort((a, b) => sortByName(a, b, languageTag())) as author}
+                  .sort((a, b) => byName(a, b, languageTag())) as author}
                   <option value={author.Id}>
                     {author.Name}
                   </option>
@@ -634,7 +634,7 @@
         <div class="p-2">
           {#if data.project.Reviewers.length}
             {@const langTag = languageTag()}
-            {#each data.project.Reviewers.sort((a, b) => sortByName(a, b, langTag)) as reviewer}
+            {#each data.project.Reviewers.sort((a, b) => byName(a, b, langTag)) as reviewer}
               <div class="flex flex-row w-full place-content-between p-2">
                 <span>{reviewer.Name} ({reviewer.Email})</span>
                 <form action="?/deleteReviewer" method="post" use:reviewerDeleteEnhance>

--- a/source/SIL.AppBuilder.Portal/src/routes/(authenticated)/projects/[id=idNumber]/+page.svelte
+++ b/source/SIL.AppBuilder.Portal/src/routes/(authenticated)/projects/[id=idNumber]/+page.svelte
@@ -191,7 +191,7 @@
               </div>
               <hr />
               <div class="flex flex-col pt-1 space-y-1">
-                {#each data.productsToAdd as productDef, i}
+                {#each data.productsToAdd.sort( (a, b) => sortByName(a, b, languageTag()) ) as productDef, i}
                   <!-- svelte-ignore a11y_click_events_have_key_events -->
                   <!-- svelte-ignore a11y_no_noninteractive_element_interactions -->
                   <label
@@ -236,7 +236,8 @@
               <hr />
               <div class="flex flex-col pt-1 space-y-1">
                 {#if availableStores.length}
-                  {#each availableStores as store}
+                  {@const langTag = languageTag()}
+                  {#each availableStores.sort((a, b) => sortByName(a, b, langTag)) as store}
                     <!-- svelte-ignore a11y_click_events_have_key_events -->
                     <!-- svelte-ignore a11y_no_noninteractive_element_interactions -->
                     <label
@@ -511,7 +512,7 @@
                       bind:this={ownerField}
                     />
                     <ul class="menu menu-compact overflow-hidden rounded-md">
-                      {#each data.possibleProjectOwners.sort((a, b) => a.Name?.localeCompare(b.Name ?? '') ?? 0) as owner}
+                      {#each data.possibleProjectOwners.sort( (a, b) => sortByName(a, b, languageTag()) ) as owner}
                         <li class="w-full rounded-none">
                           <button
                             class="text-nowrap"
@@ -558,7 +559,7 @@
                       bind:this={groupField}
                     />
                     <ul class="menu menu-compact overflow-hidden rounded-md">
-                      {#each data.possibleGroups.sort((a, b) => a.Name?.localeCompare(b.Name ?? '') ?? 0) as group}
+                      {#each data.possibleGroups.sort( (a, b) => sortByName(a, b, languageTag()) ) as group}
                         <li class="w-full rounded-none">
                           <button
                             class="text-nowrap"
@@ -586,8 +587,9 @@
           <h2>{m.project_side_authors_title()}</h2>
         </div>
         <div class="p-2">
-          {#if data.project?.Authors.length ?? 0 > 0}
-            {#each data.project?.Authors ?? [] as author}
+          {#if data.project.Authors.length}
+            {@const langTag = languageTag()}
+            {#each data.project.Authors.sort( (a, b) => sortByName(a.Users, b.Users, langTag) ) as author}
               <div class="flex flex-row w-full place-content-between p-2">
                 <span>{author.Users.Name}</span>
                 <form action="?/deleteAuthor" method="post" use:authorDeleteEnhance>
@@ -610,7 +612,9 @@
                 name="author"
                 bind:value={$authorForm.author}
               >
-                {#each data.authorsToAdd.filter((author) => !data.project?.Authors.some((au) => au.Users.Id === author.Id)) as author}
+                {#each data.authorsToAdd
+                  .filter((author) => !data.project?.Authors.some((au) => au.Users.Id === author.Id))
+                  .sort((a, b) => sortByName(a, b, languageTag())) as author}
                   <option value={author.Id}>
                     {author.Name}
                   </option>
@@ -628,8 +632,9 @@
           <h2>{m.project_side_reviewers_title()}</h2>
         </div>
         <div class="p-2">
-          {#if data.project?.Reviewers.length ?? 0 > 0}
-            {#each data.project?.Reviewers ?? [] as reviewer}
+          {#if data.project.Reviewers.length}
+            {@const langTag = languageTag()}
+            {#each data.project.Reviewers.sort((a, b) => sortByName(a, b, langTag)) as reviewer}
               <div class="flex flex-row w-full place-content-between p-2">
                 <span>{reviewer.Name} ({reviewer.Email})</span>
                 <form action="?/deleteReviewer" method="post" use:reviewerDeleteEnhance>
@@ -742,7 +747,7 @@
     column-gap: 0.75rem;
   }
   /* source: https://github.com/saadeghi/daisyui/issues/3040#issuecomment-2250530354 */
-  :root:has(:is(.modal-open, .modal:target, .modal-toggle:checked + .modal, .modal[open])) {
+  :root:has(:global(:is(.modal-open, .modal:target, .modal-toggle:checked + .modal, .modal[open]))) {
     scrollbar-gutter: unset;
   }
 </style>

--- a/source/SIL.AppBuilder.Portal/src/routes/(authenticated)/projects/[id=idNumber]/+page.svelte
+++ b/source/SIL.AppBuilder.Portal/src/routes/(authenticated)/projects/[id=idNumber]/+page.svelte
@@ -191,7 +191,7 @@
               </div>
               <hr />
               <div class="flex flex-col pt-1 space-y-1">
-                {#each data.productsToAdd.sort( (a, b) => byName(a, b, languageTag()) ) as productDef, i}
+                {#each data.productsToAdd.toSorted( (a, b) => byName(a, b, languageTag()) ) as productDef, i}
                   <!-- svelte-ignore a11y_click_events_have_key_events -->
                   <!-- svelte-ignore a11y_no_noninteractive_element_interactions -->
                   <label
@@ -237,7 +237,7 @@
               <div class="flex flex-col pt-1 space-y-1">
                 {#if availableStores.length}
                   {@const langTag = languageTag()}
-                  {#each availableStores.sort((a, b) => byName(a, b, langTag)) as store}
+                  {#each availableStores.toSorted((a, b) => byName(a, b, langTag)) as store}
                     <!-- svelte-ignore a11y_click_events_have_key_events -->
                     <!-- svelte-ignore a11y_no_noninteractive_element_interactions -->
                     <label
@@ -275,7 +275,7 @@
           {m.projectTable_noProducts()}
         {:else}
           {@const langTag = languageTag()}
-          {#each data.project.Products.sort( (a, b) => byName(a.ProductDefinition, b.ProductDefinition, langTag) ) as product}
+          {#each data.project.Products.toSorted( (a, b) => byName(a.ProductDefinition, b.ProductDefinition, langTag) ) as product}
             <div class="rounded-md border border-slate-400 w-full my-2">
               <div class="bg-neutral p-2 flex flex-row rounded-t-md">
                 <span class="grow min-w-0">
@@ -512,7 +512,7 @@
                       bind:this={ownerField}
                     />
                     <ul class="menu menu-compact overflow-hidden rounded-md">
-                      {#each data.possibleProjectOwners.sort( (a, b) => byName(a, b, languageTag()) ) as owner}
+                      {#each data.possibleProjectOwners.toSorted( (a, b) => byName(a, b, languageTag()) ) as owner}
                         <li class="w-full rounded-none">
                           <button
                             class="text-nowrap"
@@ -559,7 +559,7 @@
                       bind:this={groupField}
                     />
                     <ul class="menu menu-compact overflow-hidden rounded-md">
-                      {#each data.possibleGroups.sort( (a, b) => byName(a, b, languageTag()) ) as group}
+                      {#each data.possibleGroups.toSorted( (a, b) => byName(a, b, languageTag()) ) as group}
                         <li class="w-full rounded-none">
                           <button
                             class="text-nowrap"
@@ -589,7 +589,7 @@
         <div class="p-2">
           {#if data.project.Authors.length}
             {@const langTag = languageTag()}
-            {#each data.project.Authors.sort((a, b) => byName(a.Users, b.Users, langTag)) as author}
+            {#each data.project.Authors.toSorted((a, b) => byName(a.Users, b.Users, langTag)) as author}
               <div class="flex flex-row w-full place-content-between p-2">
                 <span>{author.Users.Name}</span>
                 <form action="?/deleteAuthor" method="post" use:authorDeleteEnhance>
@@ -634,7 +634,7 @@
         <div class="p-2">
           {#if data.project.Reviewers.length}
             {@const langTag = languageTag()}
-            {#each data.project.Reviewers.sort((a, b) => byName(a, b, langTag)) as reviewer}
+            {#each data.project.Reviewers.toSorted((a, b) => byName(a, b, langTag)) as reviewer}
               <div class="flex flex-row w-full place-content-between p-2">
                 <span>{reviewer.Name} ({reviewer.Email})</span>
                 <form action="?/deleteReviewer" method="post" use:reviewerDeleteEnhance>

--- a/source/SIL.AppBuilder.Portal/src/routes/(authenticated)/projects/[id=idNumber]/edit/+page.svelte
+++ b/source/SIL.AppBuilder.Portal/src/routes/(authenticated)/projects/[id=idNumber]/edit/+page.svelte
@@ -3,6 +3,8 @@
   import { page } from '$app/state';
   import LanguageCodeTypeahead from '$lib/components/LanguageCodeTypeahead.svelte';
   import * as m from '$lib/paraglide/messages';
+  import { languageTag } from '$lib/paraglide/runtime';
+  import { byName } from '$lib/utils';
   import { superForm } from 'sveltekit-superforms';
   import type { PageData } from './$types';
 
@@ -32,7 +34,7 @@
       <div class="w-full flex place-content-between">
         <label for="owner">{m.project_projectOwner()}</label>
         <select name="owner" id="owner" class="select select-bordered" bind:value={$form.owner}>
-          {#each data.owners as owner}
+          {#each data.owners.toSorted((a, b) => byName(a, b, languageTag())) as owner}
             <option value={owner.Id}>{owner.Name}</option>
           {/each}
         </select>
@@ -40,7 +42,7 @@
       <div class="w-full flex place-content-between">
         <label for="group">{m.project_projectGroup()}:</label>
         <select name="group" id="group" class="select select-bordered" bind:value={$form.group}>
-          {#each data.groups as group}
+          {#each data.groups.toSorted((a, b) => byName(a, b, languageTag())) as group}
             <option value={group.Id}>{group.Name}</option>
           {/each}
         </select>
@@ -59,7 +61,7 @@
           id="description"
           class="textarea textarea-bordered w-full"
           bind:value={$form.description}
-></textarea>
+        ></textarea>
       </label>
     </div>
     <div class="flex place-content-end space-x-2">

--- a/source/SIL.AppBuilder.Portal/src/routes/(authenticated)/projects/import/[id=idNumber]/+page.server.ts
+++ b/source/SIL.AppBuilder.Portal/src/routes/(authenticated)/projects/import/[id=idNumber]/+page.server.ts
@@ -58,8 +58,8 @@ export const load = (async ({ locals, params }) => {
 
   const form = await superValidate(
     {
-      group: organization?.Groups[0]?.Id ?? undefined,
-      type: types?.[0].Id ?? undefined
+      group: organization.Groups.at(0)?.Id ?? undefined,
+      type: types?.at(0)?.Id ?? undefined
     },
     valibot(projectsImportSchema),
     { errors: false }

--- a/source/SIL.AppBuilder.Portal/src/routes/(authenticated)/projects/import/[id=idNumber]/+page.svelte
+++ b/source/SIL.AppBuilder.Portal/src/routes/(authenticated)/projects/import/[id=idNumber]/+page.svelte
@@ -1,7 +1,9 @@
 <script lang="ts">
   import { page } from '$app/state';
   import * as m from '$lib/paraglide/messages';
+  import { languageTag } from '$lib/paraglide/runtime';
   import { importJSONSchema } from '$lib/projects/common';
+  import { byName, byString } from '$lib/utils';
   import { onMount } from 'svelte';
   import type { FormResult } from 'sveltekit-superforms';
   import { superForm } from 'sveltekit-superforms';
@@ -55,8 +57,7 @@
         } else {
           parseErrors = flatten<typeof importJSONSchema>(res.issues);
         }
-      }
-      catch (e) {
+      } catch (e) {
         //@ts-expect-error I just want to add the error!
         parseErrors = { root: [e] };
       }
@@ -78,7 +79,7 @@
       <label class="form-control w-full max-w-xs">
         <span class="label-text">{m.project_projectGroup()}:</span>
         <select name="group" id="group" class="select select-bordered" bind:value={$form.group}>
-          {#each data.organization?.Groups ?? [] as group}
+          {#each data.organization.Groups.toSorted((a, b) => byName(a, b, languageTag())) as group}
             <option value={group.Id}>{group.Name}</option>
           {/each}
         </select>
@@ -86,7 +87,7 @@
       <label class="form-control w-full max-w-xs">
         <span class="label-text">{m.project_type()}:</span>
         <select name="type" id="type" class="select select-bordered" bind:value={$form.type}>
-          {#each data.types ?? [] as type}
+          {#each data.types.toSorted( (a, b) => byString(a.Description, b.Description, languageTag()) ) as type}
             <option value={type.Id}>{type.Description}</option>
           {/each}
         </select>

--- a/source/SIL.AppBuilder.Portal/src/routes/(authenticated)/projects/new/[id=idNumber]/+page.server.ts
+++ b/source/SIL.AppBuilder.Portal/src/routes/(authenticated)/projects/new/[id=idNumber]/+page.server.ts
@@ -24,6 +24,8 @@ export const load = (async ({ locals, params }) => {
     }
   });
 
+  if (!organization) return error(404);
+
   // There shouldn't actually be any restriction on this
   const types = await prisma.applicationTypes.findMany({
     select: {
@@ -34,8 +36,8 @@ export const load = (async ({ locals, params }) => {
 
   const form = await superValidate(
     {
-      group: organization?.Groups[0]?.Id ?? undefined,
-      type: types?.[0].Id ?? undefined,
+      group: organization.Groups.at(0)?.Id ?? undefined,
+      type: types.at(0)?.Id ?? undefined,
       IsPublic: organization?.PublicByDefault ?? undefined
     },
     valibot(projectCreateSchema),

--- a/source/SIL.AppBuilder.Portal/src/routes/(authenticated)/projects/new/[id=idNumber]/+page.svelte
+++ b/source/SIL.AppBuilder.Portal/src/routes/(authenticated)/projects/new/[id=idNumber]/+page.svelte
@@ -2,6 +2,8 @@
   import { page } from '$app/state';
   import LanguageCodeTypeahead from '$lib/components/LanguageCodeTypeahead.svelte';
   import * as m from '$lib/paraglide/messages';
+  import { languageTag } from '$lib/paraglide/runtime';
+  import { byName, byString } from '$lib/utils';
   import { superForm } from 'sveltekit-superforms';
   import type { PageData } from './$types';
 
@@ -32,7 +34,7 @@
         <label class="form-control">
           <span class="label-text">{m.project_projectGroup()}:</span>
           <select name="group" id="group" class="select select-bordered" bind:value={$form.group}>
-            {#each data.organization?.Groups ?? [] as group}
+            {#each data.organization.Groups.toSorted( (a, b) => byName(a, b, languageTag()) ) as group}
               <option value={group.Id}>{group.Name}</option>
             {/each}
           </select>
@@ -52,7 +54,7 @@
         <label class="form-control">
           <span class="label-text">{m.project_type()}:</span>
           <select name="type" id="type" class="select select-bordered" bind:value={$form.type}>
-            {#each data.types ?? [] as type}
+            {#each data.types.toSorted( (a, b) => byString(a.Description, b.Description, languageTag()) ) as type}
               <option value={type.Id}>{type.Description}</option>
             {/each}
           </select>
@@ -66,7 +68,7 @@
             id="description"
             class="textarea textarea-bordered w-full"
             bind:value={$form.Description}
-></textarea>
+          ></textarea>
         </label>
         <div class="form-control">
           <label for="public" class="label">

--- a/source/SIL.AppBuilder.Portal/src/routes/(authenticated)/tasks/+page.server.ts
+++ b/source/SIL.AppBuilder.Portal/src/routes/(authenticated)/tasks/+page.server.ts
@@ -19,7 +19,11 @@ export const load: PageServerLoad = async (event) => {
         }
       }
     },
-    distinct: 'ProductId'
+    distinct: 'ProductId',
+    orderBy: {
+      // most recent first
+      DateUpdated: 'desc'
+    }
   });
   return { tasks };
 };

--- a/source/SIL.AppBuilder.Portal/src/routes/(authenticated)/users/+page.svelte
+++ b/source/SIL.AppBuilder.Portal/src/routes/(authenticated)/users/+page.svelte
@@ -37,6 +37,8 @@
       }
     }
   });
+
+  const mobileSizing = 'w-full max-w-xs md:w-auto md:max-w-none';
 </script>
 
 <div class="w-full">
@@ -58,8 +60,9 @@
     >
       {#if data.organizationCount > 1}
         {@const langTag = languageTag()}
-        <label class="flex flex-wrap items-center gap-x-2 w-full max-w-xs md:w-auto md:max-w-none">
+        <label class="flex flex-wrap items-center gap-x-2 {mobileSizing}">
           <span class="label-text">{m.users_organization_filter()}:</span>
+          <!-- TODO: convert after fix/user-page-org-select -->
           <select class="select select-bordered grow" name="org" bind:value={$form.organizationId}>
             <option value={null}>{m.org_allOrganizations()}</option>
             {#each Object.entries(data.organizations).sort( (a, b) => byString(a[1], b[1], langTag) ) as [Id, Name]}
@@ -68,7 +71,7 @@
           </select>
         </label>
       {/if}
-      <SearchBar bind:value={$form.search} className="w-full max-w-xs md:w-auto md:max-w-none" />
+      <SearchBar bind:value={$form.search} className={mobileSizing} />
     </form>
   </div>
   <div class="m-4 relative mt-0">

--- a/source/SIL.AppBuilder.Portal/src/routes/(authenticated)/users/+page.svelte
+++ b/source/SIL.AppBuilder.Portal/src/routes/(authenticated)/users/+page.svelte
@@ -82,7 +82,7 @@
         </tr>
       </thead>
       <tbody>
-        {#each users.sort((a, b) => byString(a.N, b.N, languageTag())) as user}
+        {#each users as user}
           {@const langTag = languageTag()}
           {@const userOrgs = user.O.map((o) => ({ ...o, Name: data.organizations[o.I] })).sort(
             (a, b) => byName(a, b, langTag)

--- a/source/SIL.AppBuilder.Portal/src/routes/(authenticated)/users/+page.svelte
+++ b/source/SIL.AppBuilder.Portal/src/routes/(authenticated)/users/+page.svelte
@@ -4,7 +4,8 @@
   import Pagination from '$lib/components/Pagination.svelte';
   import SearchBar from '$lib/components/SearchBar.svelte';
   import * as m from '$lib/paraglide/messages';
-  import { isAdmin } from '$lib/utils';
+  import { languageTag } from '$lib/paraglide/runtime';
+  import { isAdmin, sortByNullableString } from '$lib/utils';
   import { superForm, type FormResult } from 'sveltekit-superforms';
   import type { PageData } from './$types';
   import type { MinifiedUser } from './common';
@@ -31,7 +32,9 @@
         query: { data: MinifiedUser[]; count: number };
       }>;
       if (event.form.valid && data.query) {
-        users = data.query.data;
+        const langTag = languageTag();
+        // may need to sort orgs/groups later...
+        users = data.query.data.sort((a, b) => sortByNullableString(a.N, b.N, langTag));
         count = data.query.count;
       }
     }
@@ -56,11 +59,12 @@
       class="flex flex-row flex-wrap place-content-end items-center p-2 gap-1"
     >
       {#if data.organizationCount > 1}
+        {@const langTag = languageTag()}
         <label class="flex flex-wrap items-center gap-x-2 w-full max-w-xs md:w-auto md:max-w-none">
           <span class="label-text">{m.users_organization_filter()}:</span>
           <select class="select select-bordered grow" name="org" bind:value={$form.organizationId}>
             <option value={null}>{m.org_allOrganizations()}</option>
-            {#each Object.entries(data.organizations) as [Id, Name]}
+            {#each Object.entries(data.organizations).sort( (a, b) => sortByNullableString(a[1], b[1], langTag) ) as [Id, Name]}
               <option value={Id}>{Name}</option>
             {/each}
           </select>

--- a/source/SIL.AppBuilder.Portal/src/routes/(authenticated)/users/+page.svelte
+++ b/source/SIL.AppBuilder.Portal/src/routes/(authenticated)/users/+page.svelte
@@ -5,7 +5,7 @@
   import SearchBar from '$lib/components/SearchBar.svelte';
   import * as m from '$lib/paraglide/messages';
   import { languageTag } from '$lib/paraglide/runtime';
-  import { isAdmin, sortByName, sortByNullableString } from '$lib/utils';
+  import { byName, byString, isAdmin } from '$lib/utils';
   import { superForm, type FormResult } from 'sveltekit-superforms';
   import type { PageData } from './$types';
   import type { MinifiedUser } from './common';
@@ -62,7 +62,7 @@
           <span class="label-text">{m.users_organization_filter()}:</span>
           <select class="select select-bordered grow" name="org" bind:value={$form.organizationId}>
             <option value={null}>{m.org_allOrganizations()}</option>
-            {#each Object.entries(data.organizations).sort( (a, b) => sortByNullableString(a[1], b[1], langTag) ) as [Id, Name]}
+            {#each Object.entries(data.organizations).sort( (a, b) => byString(a[1], b[1], langTag) ) as [Id, Name]}
               <option value={Id}>{Name}</option>
             {/each}
           </select>
@@ -82,10 +82,10 @@
         </tr>
       </thead>
       <tbody>
-        {#each users.sort((a, b) => sortByNullableString(a.N, b.N, languageTag())) as user}
+        {#each users.sort((a, b) => byString(a.N, b.N, languageTag())) as user}
           {@const langTag = languageTag()}
           {@const userOrgs = user.O.map((o) => ({ ...o, Name: data.organizations[o.I] })).sort(
-            (a, b) => sortByName(a, b, langTag)
+            (a, b) => byName(a, b, langTag)
           )}
           <tr class="align-top">
             <td class="p-2">
@@ -117,7 +117,7 @@
                         m.users_roles_author()
                       ][r]
                   )
-                    .sort((a, b) => sortByNullableString(a, b, langTag))
+                    .sort((a, b) => byString(a, b, langTag))
                     .join(', ') || m.users_noRoles()}
                 </div>
               {/each}
@@ -132,7 +132,7 @@
                   </span>
                   <br />
                   {org.G.map((g) => data.groups[g])
-                    .sort((a, b) => sortByNullableString(a, b, langTag))
+                    .sort((a, b) => byString(a, b, langTag))
                     .join(', ') || m.common_none()}
                 </div>
               {/each}

--- a/source/SIL.AppBuilder.Portal/src/routes/(authenticated)/users/GroupsSelector.svelte
+++ b/source/SIL.AppBuilder.Portal/src/routes/(authenticated)/users/GroupsSelector.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
   import { languageTag } from "$lib/paraglide/runtime";
-  import { sortByName } from "$lib/utils";
+  import { byName } from "$lib/utils";
 
   interface Props {
     groups: { Id: number; Name: string | null }[];
@@ -12,7 +12,7 @@
 
 <div class="flex w-full">
   <div class="shrink space-y-2">
-    {#each groups.sort((a, b) => sortByName(a, b, languageTag())) as group}
+    {#each groups.sort((a, b) => byName(a, b, languageTag())) as group}
       <div class="flex space-x-2">
         <input
           type="checkbox"

--- a/source/SIL.AppBuilder.Portal/src/routes/(authenticated)/users/GroupsSelector.svelte
+++ b/source/SIL.AppBuilder.Portal/src/routes/(authenticated)/users/GroupsSelector.svelte
@@ -12,7 +12,7 @@
 
 <div class="flex w-full">
   <div class="shrink space-y-2">
-    {#each groups.sort((a, b) => byName(a, b, languageTag())) as group}
+    {#each groups.toSorted((a, b) => byName(a, b, languageTag())) as group}
       <div class="flex space-x-2">
         <input
           type="checkbox"

--- a/source/SIL.AppBuilder.Portal/src/routes/(authenticated)/users/[id=idNumber]/settings/groups/+page.server.ts
+++ b/source/SIL.AppBuilder.Portal/src/routes/(authenticated)/users/[id=idNumber]/settings/groups/+page.server.ts
@@ -27,22 +27,18 @@ export const load = (async ({ params, locals }) => {
 
   const groupsByOrg = await prisma.organizations.findMany({
     where: {
-      Owner: {
-        // Only send a list of groups for orgs that the subject user is in and the current user has access to
-        AND: isSuper
-          ? undefined
-          : {
-              UserRoles: {
-                some: {
-                  UserId: userId,
-                  RoleId: RoleId.OrgAdmin
-                }
-              }
-            },
-        OrganizationMemberships: {
-          some: {
-            UserId: subjectUserId
-          }
+      // Only send a list of groups for orgs that the subject user is in and the current user has access to
+      UserRoles: isSuper
+        ? undefined
+        : {
+            some: {
+              UserId: userId,
+              RoleId: RoleId.OrgAdmin
+            }
+          },
+      OrganizationMemberships: {
+        some: {
+          UserId: subjectUserId
         }
       }
     },

--- a/source/SIL.AppBuilder.Portal/src/routes/(authenticated)/users/[id=idNumber]/settings/groups/+page.svelte
+++ b/source/SIL.AppBuilder.Portal/src/routes/(authenticated)/users/[id=idNumber]/settings/groups/+page.svelte
@@ -17,6 +17,7 @@
 
 <form action="" method="post" use:enhance>
   <div class="flex flex-col px-4">
+    <!-- I would sort this, but it doesn't work properly... -->
     {#each $form.organizations as org}
       {@const groups = data.groupsByOrg.find((o) => o.Id === org.id)?.Groups ?? []}
       <h3>{org.name}</h3>

--- a/source/SIL.AppBuilder.Portal/src/routes/(authenticated)/users/[id=idNumber]/settings/roles/+page.svelte
+++ b/source/SIL.AppBuilder.Portal/src/routes/(authenticated)/users/[id=idNumber]/settings/roles/+page.svelte
@@ -17,6 +17,7 @@
 
 <form action="" method="post" use:enhance>
   <div class="flex flex-col px-4">
+    <!-- I would sort this, but it doesn't work properly... -->
     {#each $form.organizations as org}
       <h3>{org.name}</h3>
       <!-- https://github.com/sveltejs/svelte/issues/12721#issuecomment-2269544690 -->

--- a/source/SIL.AppBuilder.Portal/src/routes/(authenticated)/users/invite/+page.svelte
+++ b/source/SIL.AppBuilder.Portal/src/routes/(authenticated)/users/invite/+page.svelte
@@ -2,7 +2,7 @@
   import LabeledFormInput from '$lib/components/settings/LabeledFormInput.svelte';
   import * as m from '$lib/paraglide/messages';
   import { languageTag } from '$lib/paraglide/runtime';
-  import { sortByName } from '$lib/utils';
+  import { byName } from '$lib/utils';
   import { onMount } from 'svelte';
   import { superForm } from 'sveltekit-superforms';
   import GroupsSelector from '../GroupsSelector.svelte';
@@ -60,7 +60,7 @@
             name="organizationId"
             bind:value={$form.organizationId}
           >
-            {#each data.groupsByOrg.sort((a, b) => sortByName(a, b, languageTag())) as org}
+            {#each data.groupsByOrg.sort((a, b) => byName(a, b, languageTag())) as org}
               <option value={org.Id}>{org.Name}</option>
             {/each}
           </select>

--- a/source/SIL.AppBuilder.Portal/src/routes/(authenticated)/users/invite/+page.svelte
+++ b/source/SIL.AppBuilder.Portal/src/routes/(authenticated)/users/invite/+page.svelte
@@ -1,8 +1,7 @@
 <script lang="ts">
+  import OrganizationDropdown from '$lib/components/OrganizationDropdown.svelte';
   import LabeledFormInput from '$lib/components/settings/LabeledFormInput.svelte';
   import * as m from '$lib/paraglide/messages';
-  import { languageTag } from '$lib/paraglide/runtime';
-  import { byName } from '$lib/utils';
   import { onMount } from 'svelte';
   import { superForm } from 'sveltekit-superforms';
   import GroupsSelector from '../GroupsSelector.svelte';
@@ -55,15 +54,12 @@
         </LabeledFormInput>
         <!-- TODO: Should technically not be this i18n key -->
         <LabeledFormInput name="project_side_organization">
-          <select
-            class="select select-bordered w-full"
+          <OrganizationDropdown
+            className="w-full"
             name="organizationId"
             bind:value={$form.organizationId}
-          >
-            {#each data.groupsByOrg.sort((a, b) => byName(a, b, languageTag())) as org}
-              <option value={org.Id}>{org.Name}</option>
-            {/each}
-          </select>
+            organizations={data.groupsByOrg}
+          />
         </LabeledFormInput>
       </div>
       <div class="flex flex-col h-full min-w-96">

--- a/source/SIL.AppBuilder.Portal/src/routes/(authenticated)/workflow-instances/+page.svelte
+++ b/source/SIL.AppBuilder.Portal/src/routes/(authenticated)/workflow-instances/+page.svelte
@@ -4,7 +4,9 @@
   import SearchBar from '$lib/components/SearchBar.svelte';
   import SortTable from '$lib/components/SortTable.svelte';
   import * as m from '$lib/paraglide/messages';
+  import { languageTag } from '$lib/paraglide/runtime';
   import { getRelativeTime } from '$lib/timeUtils';
+  import { sortByName } from '$lib/utils';
   import type { FormResult } from 'sveltekit-superforms';
   import { superForm } from 'sveltekit-superforms';
   import type { PageData } from './$types';
@@ -59,7 +61,7 @@
       >
         <select class="select select-bordered mobile-sizing" bind:value={$form.organizationId}>
           <option value={null} selected>{m.org_allOrganizations()}</option>
-          {#each data.organizations as organization}
+          {#each data.organizations.sort((a, b) => sortByName(a, b, languageTag())) as organization}
             <option value={organization.Id}>{organization.Name}</option>
           {/each}
         </select>
@@ -69,7 +71,7 @@
     <div class="flex flex-row flex-wrap gap-1 place-content-start px-4 pt-1 mobile-sizing">
       <select class="select select-bordered mobile-sizing" bind:value={$form.productDefinitionId}>
         <option value={null} selected>{m.productDefinitions_filterAllProjects()}</option>
-        {#each data.productDefinitions as pD}
+        {#each data.productDefinitions.sort((a, b) => sortByName(a, b, languageTag())) as pD}
           <option value={pD.Id}>{pD.Name}</option>
         {/each}
       </select>
@@ -85,6 +87,7 @@
         data={instances}
         columns={[
           {
+            // This will not sort by locale... need a good solution...
             id: 'organization',
             header: m.project_side_organization(),
             data: (i) => i.Product.Project.Organization,

--- a/source/SIL.AppBuilder.Portal/src/routes/(authenticated)/workflow-instances/+page.svelte
+++ b/source/SIL.AppBuilder.Portal/src/routes/(authenticated)/workflow-instances/+page.svelte
@@ -74,7 +74,7 @@
     <div class="flex flex-row flex-wrap gap-1 place-content-start px-4 pt-1 {mobileSizing}">
       <select class="select select-bordered {mobileSizing}" bind:value={$form.productDefinitionId}>
         <option value={null} selected>{m.productDefinitions_filterAllProjects()}</option>
-        {#each data.productDefinitions.sort((a, b) => byName(a, b, languageTag())) as pD}
+        {#each data.productDefinitions.toSorted((a, b) => byName(a, b, languageTag())) as pD}
           <option value={pD.Id}>{pD.Name}</option>
         {/each}
       </select>

--- a/source/SIL.AppBuilder.Portal/src/routes/(authenticated)/workflow-instances/+page.svelte
+++ b/source/SIL.AppBuilder.Portal/src/routes/(authenticated)/workflow-instances/+page.svelte
@@ -6,7 +6,7 @@
   import * as m from '$lib/paraglide/messages';
   import { languageTag } from '$lib/paraglide/runtime';
   import { getRelativeTime } from '$lib/timeUtils';
-  import { sortByName } from '$lib/utils';
+  import { byName } from '$lib/utils';
   import type { FormResult } from 'sveltekit-superforms';
   import { superForm } from 'sveltekit-superforms';
   import type { PageData } from './$types';
@@ -61,7 +61,7 @@
       >
         <select class="select select-bordered mobile-sizing" bind:value={$form.organizationId}>
           <option value={null} selected>{m.org_allOrganizations()}</option>
-          {#each data.organizations.sort((a, b) => sortByName(a, b, languageTag())) as organization}
+          {#each data.organizations.sort((a, b) => byName(a, b, languageTag())) as organization}
             <option value={organization.Id}>{organization.Name}</option>
           {/each}
         </select>
@@ -71,7 +71,7 @@
     <div class="flex flex-row flex-wrap gap-1 place-content-start px-4 pt-1 mobile-sizing">
       <select class="select select-bordered mobile-sizing" bind:value={$form.productDefinitionId}>
         <option value={null} selected>{m.productDefinitions_filterAllProjects()}</option>
-        {#each data.productDefinitions.sort((a, b) => sortByName(a, b, languageTag())) as pD}
+        {#each data.productDefinitions.sort((a, b) => byName(a, b, languageTag())) as pD}
           <option value={pD.Id}>{pD.Name}</option>
         {/each}
       </select>

--- a/source/SIL.AppBuilder.Portal/src/routes/(authenticated)/workflow-instances/+page.svelte
+++ b/source/SIL.AppBuilder.Portal/src/routes/(authenticated)/workflow-instances/+page.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
   import DateRangePicker from '$lib/components/DateRangePicker.svelte';
+  import OrganizationDropdown from '$lib/components/OrganizationDropdown.svelte';
   import Pagination from '$lib/components/Pagination.svelte';
   import SearchBar from '$lib/components/SearchBar.svelte';
   import SortTable from '$lib/components/SortTable.svelte';
@@ -38,6 +39,8 @@
       }
     }
   });
+
+  const mobileSizing = 'w-full max-w-xs md:w-auto md:max-w-none';
 </script>
 
 <div class="w-full">
@@ -51,25 +54,25 @@
     }}
   >
     <div
-      class="flex flex-row flex-wrap md:flex-nowrap place-content-end items-center px-4 gap-1 mobile-sizing"
+      class="flex flex-row flex-wrap md:flex-nowrap place-content-end items-center px-4 gap-1 {mobileSizing}"
     >
-      <div class="inline-block grow mobile-sizing">
+      <div class="inline-block grow {mobileSizing}">
         <h1 class="py-4 px-2">{m.workflowInstances_title()}</h1>
       </div>
       <div
-        class="flex flex-row flex-wrap md:flex-nowrap place-content-end items-center gap-1 mobile-sizing"
+        class="flex flex-row flex-wrap md:flex-nowrap place-content-end items-center gap-1 {mobileSizing}"
       >
-        <select class="select select-bordered mobile-sizing" bind:value={$form.organizationId}>
-          <option value={null} selected>{m.org_allOrganizations()}</option>
-          {#each data.organizations.sort((a, b) => byName(a, b, languageTag())) as organization}
-            <option value={organization.Id}>{organization.Name}</option>
-          {/each}
-        </select>
-        <SearchBar bind:value={$form.search} className="w-full max-w-xs md:w-auto md:max-w-none" />
+        <OrganizationDropdown 
+          className={mobileSizing}
+          organizations={data.organizations}
+          allowNull={true}
+          bind:value={$form.organizationId}
+        />
+        <SearchBar bind:value={$form.search} className={mobileSizing} />
       </div>
     </div>
-    <div class="flex flex-row flex-wrap gap-1 place-content-start px-4 pt-1 mobile-sizing">
-      <select class="select select-bordered mobile-sizing" bind:value={$form.productDefinitionId}>
+    <div class="flex flex-row flex-wrap gap-1 place-content-start px-4 pt-1 {mobileSizing}">
+      <select class="select select-bordered {mobileSizing}" bind:value={$form.productDefinitionId}>
         <option value={null} selected>{m.productDefinitions_filterAllProjects()}</option>
         {#each data.productDefinitions.sort((a, b) => byName(a, b, languageTag())) as pD}
           <option value={pD.Id}>{pD.Name}</option>
@@ -147,14 +150,3 @@
     </div>
   </form>
 </div>
-
-<style lang="postcss">
-  .mobile-sizing {
-    @apply w-full max-w-xs;
-  }
-  @media screen(md) {
-    .mobile-sizing {
-      @apply w-auto max-w-none;
-    }
-  }
-</style>


### PR DESCRIPTION
Fixes #1064 
As best as I can tell, the only routes that are still not sorted (at least by locale) are the ones with server-side pagination (i.e. `/workflow-instances`, `/users`, and `/directory`)