### PR TITLE
Add UserId field to ProductTransitions

### DIFF
--- a/source/SIL.AppBuilder.Portal/common/prisma/migrations/9_transistions_user_id/migration.sql
+++ b/source/SIL.AppBuilder.Portal/common/prisma/migrations/9_transistions_user_id/migration.sql
@@ -1,0 +1,5 @@
+-- AlterTable
+ALTER TABLE "ProductTransitions" ADD COLUMN     "UserId" INTEGER;
+
+-- AddForeignKey
+ALTER TABLE "ProductTransitions" ADD CONSTRAINT "ProductTransitions_UserId_fkey" FOREIGN KEY ("UserId") REFERENCES "Users"("Id") ON DELETE SET NULL ON UPDATE CASCADE;

--- a/source/SIL.AppBuilder.Portal/common/prisma/schema.prisma
+++ b/source/SIL.AppBuilder.Portal/common/prisma/schema.prisma
@@ -249,9 +249,9 @@ model ProductPublications {
 model ProductTransitions {
   Id               Int       @id(map: "PK_ProductTransitions") @default(autoincrement())
   ProductId        String    @db.Uuid
+  // Since users are never deleted, only locked, this should be fine
+  UserId           Int?
   // TODO: remove when DWKit is replaced
-  // Could possibly be replaced with regular UserId, but probably shouldn't, because what if a User is deleted?
-  // Maybe replace with name? Or perhaps this would already be taken care of by populating AllowedUserNames with just the name of the user who caused the product transition...
   WorkflowUserId   String?   @db.Uuid
   AllowedUserNames String?
   InitialState     String?
@@ -262,6 +262,7 @@ model ProductTransitions {
   TransitionType   Int       @default(1)
   WorkflowType     Int?
   Product          Products  @relation(fields: [ProductId], references: [Id], onDelete: Cascade, onUpdate: NoAction, map: "FK_ProductTransitions_Products_ProductId")
+  User             Users?    @relation(fields: [UserId], references: [Id])
 
   @@index([ProductId], map: "IX_ProductTransitions_ProductId")
 }
@@ -472,6 +473,7 @@ model Users {
   Projects                      Projects[]
   UserRoles                     UserRoles[]
   UserTasks                     UserTasks[]
+  ProductTransitions            ProductTransitions[]
 
   @@index([WorkflowUserId], map: "IX_Users_WorkflowUserId")
 }

--- a/source/SIL.AppBuilder.Portal/common/workflow/index.ts
+++ b/source/SIL.AppBuilder.Portal/common/workflow/index.ts
@@ -287,7 +287,8 @@ export class Workflow {
         where: {
           ProductId: this.productId,
           DateTransition: null,
-          WorkflowUserId: null
+          WorkflowUserId: null,
+          UserId: null
         }
       });
       // Yes, the ModifyUserTasks will also delete tasks. I just have this here so the tasks are cleared immediately, and so that the tasks are also cleared when the instance is deleted.
@@ -486,6 +487,7 @@ export class Workflow {
           Id: transition.Id
         },
         data: {
+          UserId: userId,
           WorkflowUserId: user?.WorkflowUserId ?? null,
           AllowedUserNames: user?.Name ?? null,
           Command: command ?? null,
@@ -497,6 +499,7 @@ export class Workflow {
       await DatabaseWrites.productTransitions.create({
         data: {
           ProductId: this.productId,
+          UserId: userId,
           WorkflowUserId: user?.WorkflowUserId ?? null,
           AllowedUserNames: user?.Name ?? null,
           InitialState: initialState,

--- a/source/SIL.AppBuilder.Portal/node-server/job-executors/userTasks.ts
+++ b/source/SIL.AppBuilder.Portal/node-server/job-executors/userTasks.ts
@@ -30,6 +30,7 @@ export async function modify(job: Job<BullMQ.UserTasks.Modify>): Promise<unknown
   await DatabaseWrites.productTransitions.deleteMany({
     where: {
       WorkflowUserId: null,
+      UserId: null,
       ProductId: { in: productIds },
       DateTransition: null
     }

--- a/source/SIL.AppBuilder.Portal/src/lib/products/components/ProductDetails.svelte
+++ b/source/SIL.AppBuilder.Portal/src/lib/products/components/ProductDetails.svelte
@@ -16,6 +16,7 @@
       Command: string | null;
       Comment: string | null;
       DateTransition: Date | null;
+      User: { Name: string | null } | null;
     }[];
   };
   }
@@ -101,7 +102,7 @@
             <td>
               <!-- Does not include WorkflowUserId mapping. Might be needed but didn't seem like it to me -->
               {#if ![2, 3, 4].includes(transition.TransitionType)}
-                {transition.AllowedUserNames || m.appName()}
+                {transition.User?.Name || transition.AllowedUserNames || m.appName()}
               {/if}
             </td>
             <td>{transition.Command ?? ''}</td>

--- a/source/SIL.AppBuilder.Portal/src/routes/(authenticated)/projects/[id=idNumber]/+page.server.ts
+++ b/source/SIL.AppBuilder.Portal/src/routes/(authenticated)/projects/[id=idNumber]/+page.server.ts
@@ -183,7 +183,14 @@ export const load = (async ({ locals, params }) => {
       {
         Id: 'asc'
       }
-    ]
+    ],
+    include: {
+      User: {
+        select: {
+          Name: true
+        }
+      }
+    }
   });
   const strippedTransitions = project.Products.map((p) => [
     transitions.findLast((tr) => tr.ProductId === p.Id && tr.DateTransition !== null)!,

--- a/source/SIL.AppBuilder.Portal/src/routes/(authenticated)/workflow-instances/[product_id]/+page.server.ts
+++ b/source/SIL.AppBuilder.Portal/src/routes/(authenticated)/workflow-instances/[product_id]/+page.server.ts
@@ -50,7 +50,12 @@ export const load: PageServerLoad = async ({ params }) => {
           TransitionType: true,
           WorkflowType: true,
           AllowedUserNames: true,
-          Comment: true
+          Comment: true,
+          User: {
+            select: {
+              Name: true
+            }
+          }
         },
         orderBy: [
           {

--- a/source/SIL.AppBuilder.Portal/src/routes/(unauthenticated)/api/projects/[id=idNumber]/token/+server.ts
+++ b/source/SIL.AppBuilder.Portal/src/routes/(unauthenticated)/api/projects/[id=idNumber]/token/+server.ts
@@ -209,6 +209,7 @@ export async function POST({ params, request, fetch }) {
       TransitionType: ProductTransitionType.ProjectAccess,
       InitialState: 'Project ' + use,
       WorkflowUserId: user[0].WorkflowUserId,
+      UserId: user[0].Id,
       DateTransition: new Date()
     }))
   });


### PR DESCRIPTION
This is something we discussed regarding transitioning away from DWKit.
The WorkflowUserId field is a string that holds a guid associated with the user profile in DWKit. As it currently is, that same field will also be on the associated User. Since we are moving away from DWKit, those fields should eventually be removed. This removal would also remove all links between transitions and the user responsible for the transitions, hence, this PR to add a UserId field that would reference Users.