### PR TITLE
Add wrapper functions for checking user roles

### DIFF
--- a/source/SIL.AppBuilder.Portal/src/lib/projects/common.server.ts
+++ b/source/SIL.AppBuilder.Portal/src/lib/projects/common.server.ts
@@ -1,3 +1,4 @@
+import { isAdminForOrg } from '$lib/utils';
 import type { Session } from '@auth/sveltekit';
 import type { Prisma } from '@prisma/client';
 import { DatabaseWrites, prisma } from 'sil.appbuilder.portal.common';
@@ -32,73 +33,73 @@ export function projectFilter(args: {
     OrganizationId: args.organizationId !== null ? args.organizationId : undefined,
     Language: args.langCode
       ? {
-        contains: args.langCode,
-        mode: 'insensitive'
-      }
+          contains: args.langCode,
+          mode: 'insensitive'
+        }
       : undefined,
     Products:
       args.productDefinitionId !== null
         ? {
-          some: {
-            ProductDefinitionId: args.productDefinitionId
+            some: {
+              ProductDefinitionId: args.productDefinitionId
+            }
           }
-        }
         : undefined,
     AND: [
       {
         OR:
           args.dateUpdatedRange && args.dateUpdatedRange[1]
             ? [
-              { DateUpdated: null },
-              {
-                DateUpdated: {
-                  gt: args.dateUpdatedRange[0],
-                  lt: args.dateUpdatedRange[1]
+                { DateUpdated: null },
+                {
+                  DateUpdated: {
+                    gt: args.dateUpdatedRange[0],
+                    lt: args.dateUpdatedRange[1]
+                  }
                 }
-              }
-            ]
+              ]
             : undefined
       },
       {
         OR: args.search
           ? [
-            {
-              Name: {
-                contains: args.search,
-                mode: 'insensitive'
-              }
-            },
-            {
-              Language: {
-                contains: args.search,
-                mode: 'insensitive'
-              }
-            },
-            {
-              Owner: {
+              {
                 Name: {
                   contains: args.search,
                   mode: 'insensitive'
                 }
-              }
-            },
-            {
-              Organization: {
-                Name: {
+              },
+              {
+                Language: {
                   contains: args.search,
                   mode: 'insensitive'
                 }
-              }
-            },
-            {
-              Group: {
-                Name: {
-                  contains: args.search,
-                  mode: 'insensitive'
+              },
+              {
+                Owner: {
+                  Name: {
+                    contains: args.search,
+                    mode: 'insensitive'
+                  }
+                }
+              },
+              {
+                Organization: {
+                  Name: {
+                    contains: args.search,
+                    mode: 'insensitive'
+                  }
+                }
+              },
+              {
+                Group: {
+                  Name: {
+                    contains: args.search,
+                    mode: 'insensitive'
+                  }
                 }
               }
-            }
-          ]
+            ]
           : undefined
       }
     ]
@@ -106,13 +107,9 @@ export function projectFilter(args: {
 }
 export async function verifyCanCreateProject(user: Session, orgId: number) {
   // Creating a project is allowed if the user is an OrgAdmin or AppBuilder for the organization or a SuperAdmin
-  const roles = user.user.roles
-    .filter(([org, role]) => org === orgId || role === RoleId.SuperAdmin)
-    .map(([org, role]) => role);
   return (
-    roles.includes(RoleId.AppBuilder) ||
-    roles.includes(RoleId.OrgAdmin) ||
-    roles.includes(RoleId.SuperAdmin)
+    isAdminForOrg(orgId, user.user.roles) ||
+    !!user.user.roles.find(([org, role]) => org === orgId && role === RoleId.AppBuilder)
   );
 }
 

--- a/source/SIL.AppBuilder.Portal/src/lib/projects/common.server.ts
+++ b/source/SIL.AppBuilder.Portal/src/lib/projects/common.server.ts
@@ -1,4 +1,4 @@
-import { isAdminForOrg } from '$lib/utils';
+import { hasRoleForOrg, isAdminForOrg } from '$lib/utils';
 import type { Session } from '@auth/sveltekit';
 import type { Prisma } from '@prisma/client';
 import { DatabaseWrites, prisma } from 'sil.appbuilder.portal.common';
@@ -109,7 +109,7 @@ export async function verifyCanCreateProject(user: Session, orgId: number) {
   // Creating a project is allowed if the user is an OrgAdmin or AppBuilder for the organization or a SuperAdmin
   return (
     isAdminForOrg(orgId, user.user.roles) ||
-    !!user.user.roles.find(([org, role]) => org === orgId && role === RoleId.AppBuilder)
+    hasRoleForOrg(RoleId.AppBuilder, orgId, user.user.roles)
   );
 }
 

--- a/source/SIL.AppBuilder.Portal/src/lib/utils.ts
+++ b/source/SIL.AppBuilder.Portal/src/lib/utils.ts
@@ -1,3 +1,5 @@
+import { RoleId } from 'sil.appbuilder.portal.common/prisma';
+
 export function bytesToHumanSize(bytes: bigint | null) {
   if (bytes === null) {
     return '--';
@@ -20,4 +22,39 @@ interface NamedEntity {
 
 export function sortByName(a: NamedEntity, b: NamedEntity, languageTag: string): number {
   return a.Name?.localeCompare(b.Name ?? '', languageTag) ?? 0;
+}
+
+/** returns true if user is a SuperAdmin, or is an OrgAdmin for the specified organization
+ * @param roles [RoleId, OrganizationId][]
+ */
+export function isAdminForOrg(orgId: number, roles?: [number, number][]): boolean {
+  return !!roles?.find(
+    (r) => r[0] === RoleId.SuperAdmin || (r[0] === RoleId.OrgAdmin && r[1] === orgId)
+  );
+}
+/** returns true if user is a SuperAdmin, or is an OrgAdmin for any of the provided orgs
+ * @param roles [RoleId, OrganizationId][]
+ */
+export function isAdminForOrgs(orgs: number[], roles?: [number, number][]): boolean {
+  return !!roles?.find(
+    (r) => r[0] === RoleId.SuperAdmin || (r[0] === RoleId.OrgAdmin && orgs.includes(r[1]))
+  );
+}
+/** returns true if user is a SuperAdmin, or is an OrgAdmin for any organization
+ * @param roles [RoleId, OrganizationId][]
+ */
+export function isAdmin(roles?: [number, number][]): boolean {
+  return !!roles?.find((r) => r[0] === RoleId.SuperAdmin || r[0] === RoleId.OrgAdmin);
+}
+/** returns true if user is a SuperAdmin
+ * @param roles [RoleId, OrganizationId][]
+ */
+export function isSuperAdmin(roles?: [number, number][]): boolean {
+  return !!roles?.find((r) => r[0] === RoleId.SuperAdmin);
+}
+/** returns a list of organizations where the user has the specified role 
+ * @param roles [RoleId, OrganizationId][]
+*/
+export function orgsForRole(role: RoleId, roles?: [number, number][]): number[] {
+  return roles?.filter((r) => r[0] === role).map((r) => r[1]) ?? [];
 }

--- a/source/SIL.AppBuilder.Portal/src/lib/utils.ts
+++ b/source/SIL.AppBuilder.Portal/src/lib/utils.ts
@@ -52,7 +52,17 @@ export function isAdmin(roles?: [number, number][]): boolean {
 export function isSuperAdmin(roles?: [number, number][]): boolean {
   return !!roles?.find((r) => r[0] === RoleId.SuperAdmin);
 }
+/** returns true if user has specified role in specified org
+ * 
+ * IS NOT SHORT-CIRCUITED by SuperAdmin
+ * @param roles [RoleId, OrganizationId][]
+ */
+export function hasRoleForOrg(role: RoleId, orgId: number, roles?: [number, number][]): boolean {
+  return !!roles?.find((r) => r[0] === role && r[1] === orgId);
+}
 /** returns a list of organizations where the user has the specified role 
+ * 
+ * IS NOT SHORT-CIRCUITED by SuperAdmin
  * @param roles [RoleId, OrganizationId][]
 */
 export function orgsForRole(role: RoleId, roles?: [number, number][]): number[] {

--- a/source/SIL.AppBuilder.Portal/src/routes/(authenticated)/+layout.svelte
+++ b/source/SIL.AppBuilder.Portal/src/routes/(authenticated)/+layout.svelte
@@ -5,8 +5,8 @@
   import LanguageSelector from '$lib/components/LanguageSelector.svelte';
   import { HamburgerIcon } from '$lib/icons';
   import * as m from '$lib/paraglide/messages';
+  import { isAdmin, isSuperAdmin } from '$lib/utils';
   import { signOut } from '@auth/sveltekit/client';
-  import { RoleId } from 'sil.appbuilder.portal.common/prisma';
   import type { LayoutData } from './$types';
 
   interface Props {
@@ -134,7 +134,7 @@
               {m.sidebar_organizationProjects()}
             </a>
           </li>
-          {#if !!$page.data.session?.user.roles.find((r) => r[1] === RoleId.SuperAdmin || r[1] === RoleId.OrgAdmin)}
+          {#if isAdmin($page.data.session?.user.roles)}
             <li>
               <a
                 class="rounded-none"
@@ -166,7 +166,7 @@
               </a>
             </li>
           {/if}
-          {#if !!$page.data.session?.user.roles.find((r) => r[1] === RoleId.SuperAdmin)}
+          {#if isSuperAdmin($page.data.session?.user.roles)}
             <li>
               <a
                 class="rounded-none"

--- a/source/SIL.AppBuilder.Portal/src/routes/(authenticated)/organizations/+page.server.ts
+++ b/source/SIL.AppBuilder.Portal/src/routes/(authenticated)/organizations/+page.server.ts
@@ -1,17 +1,11 @@
+import { isSuperAdmin } from '$lib/utils';
 import { redirect } from '@sveltejs/kit';
 import { prisma } from 'sil.appbuilder.portal.common';
-import { RoleId } from 'sil.appbuilder.portal.common/prisma';
 import type { PageServerLoad } from './$types';
 
 export const load = (async (event) => {
-  const auth = await event.locals.auth();
-  const user = await prisma.users.findUnique({
-    where: {
-      Id: auth?.user.userId
-    },
-    include: { UserRoles: true, Organizations: true }
-  });
-  const organizations = user?.UserRoles.find((roleDef) => roleDef.RoleId === RoleId.SuperAdmin)
+  const user = (await event.locals.auth())!.user;
+  const organizations = isSuperAdmin(user.roles)
     ? await prisma.organizations.findMany({
       include: {
         Owner: true
@@ -21,7 +15,7 @@ export const load = (async (event) => {
       where: {
         OrganizationMemberships: {
           every: {
-            UserId: auth?.user.userId
+            UserId: user.userId
           }
         }
       },

--- a/source/SIL.AppBuilder.Portal/src/routes/(authenticated)/projects/[id=idNumber]/+page.svelte
+++ b/source/SIL.AppBuilder.Portal/src/routes/(authenticated)/projects/[id=idNumber]/+page.svelte
@@ -10,8 +10,7 @@
   import ProductDetails from '$lib/products/components/ProductDetails.svelte';
   import ProjectActionMenu from '$lib/projects/components/ProjectActionMenu.svelte';
   import { getRelativeTime } from '$lib/timeUtils';
-  import { sortByName } from '$lib/utils';
-  import { RoleId } from 'sil.appbuilder.portal.common/prisma';
+  import { isAdminForOrg, isSuperAdmin, sortByName } from '$lib/utils';
   import { ProductType } from 'sil.appbuilder.portal.common/workflow';
   import { superForm } from 'sveltekit-superforms';
   import type { PageData } from './$types';
@@ -343,7 +342,7 @@
                             {m.project_productFiles()}
                           </a>
                         </li>
-                        {#if data.session?.user.roles.find((role) => role[0] === data.project?.Organization.Id && role[1] === RoleId.OrgAdmin)}
+                        {#if isAdminForOrg(data.project?.Organization.Id, data.session?.user.roles)}
                           <li class="w-full rounded-none">
                             <span class="text-nowrap">
                               <!-- TODO: figure out Publishing Properties -->
@@ -351,7 +350,7 @@
                             </span>
                           </li>
                         {/if}
-                        {#if data.session?.user.roles.find((role) => role[1] === RoleId.SuperAdmin) && !!product.WorkflowInstance}
+                        {#if isSuperAdmin(data.session?.user.roles) && !!product.WorkflowInstance}
                           <li class="w-full-rounded-none">
                             <a href="/workflow-instances/{product.Id}">
                               {m.common_workflow()}

--- a/source/SIL.AppBuilder.Portal/src/routes/(authenticated)/users/+page.server.ts
+++ b/source/SIL.AppBuilder.Portal/src/routes/(authenticated)/users/+page.server.ts
@@ -1,4 +1,5 @@
 import { paginateSchema } from '$lib/table';
+import { isSuperAdmin } from '$lib/utils';
 import { idSchema } from '$lib/valibot';
 import type { Prisma } from '@prisma/client';
 import { error, redirect } from '@sveltejs/kit';
@@ -85,7 +86,7 @@ export const load = (async (event) => {
   const userId = userInfo?.userId;
   if (!userId) return redirect(302, '/');
 
-  const isSuper = !!userInfo.roles.find((r) => r[1] === RoleId.SuperAdmin);
+  const isSuper = isSuperAdmin(userInfo.roles);
 
   const organizations = await prisma.organizations.findMany({
     where: isSuper
@@ -180,7 +181,7 @@ export const actions: Actions = {
     const form = await superValidate(event, valibot(userSchema));
     if (!form.valid) return { form, ok: false };
 
-    const isSuper = !!session.user.roles.find((r) => r[1] === RoleId.SuperAdmin);
+    const isSuper = isSuperAdmin(session.user.roles);
 
     const organizations = await prisma.organizations.findMany({
       where:

--- a/source/SIL.AppBuilder.Portal/src/routes/(authenticated)/users/+page.svelte
+++ b/source/SIL.AppBuilder.Portal/src/routes/(authenticated)/users/+page.svelte
@@ -4,7 +4,7 @@
   import Pagination from '$lib/components/Pagination.svelte';
   import SearchBar from '$lib/components/SearchBar.svelte';
   import * as m from '$lib/paraglide/messages';
-  import { RoleId } from 'sil.appbuilder.portal.common/prisma';
+  import { isAdmin } from '$lib/utils';
   import { superForm, type FormResult } from 'sveltekit-superforms';
   import type { PageData } from './$types';
   import type { MinifiedUser } from './common';
@@ -42,7 +42,7 @@
   <div class="flex flex-row place-content-between w-full flex-wrap items-center">
     <div class="flex flex-row items-center">
       <h1>{m.users_title()}</h1>
-      {#if data.session?.user.roles.find((r) => r[1] === RoleId.SuperAdmin || r[1] === RoleId.OrgAdmin)}
+      {#if isAdmin(data.session?.user.roles)}
         <a href="/users/invite" class="btn btn-outline">
           <IconContainer icon="mdi:user-add" width="20" />
           <span>{m.organizationMembership_invite_create_inviteUserButtonTitle()}</span>

--- a/source/SIL.AppBuilder.Portal/src/routes/(authenticated)/workflow-instances/[product_id]/+page.server.ts
+++ b/source/SIL.AppBuilder.Portal/src/routes/(authenticated)/workflow-instances/[product_id]/+page.server.ts
@@ -1,6 +1,6 @@
+import { isSuperAdmin } from '$lib/utils';
 import { error } from '@sveltejs/kit';
 import { prisma, Workflow } from 'sil.appbuilder.portal.common';
-import { RoleId } from 'sil.appbuilder.portal.common/prisma';
 import { WorkflowAction, type WorkflowState } from 'sil.appbuilder.portal.common/workflow';
 import { fail, superValidate } from 'sveltekit-superforms';
 import { valibot } from 'sveltekit-superforms/adapters';
@@ -97,7 +97,7 @@ export const load: PageServerLoad = async ({ params }) => {
 
 export const actions = {
   default: async ({ request, params, locals }) => {
-    if (!(await locals.auth())?.user.roles.find((r) => r[1] === RoleId.SuperAdmin)) {
+    if (!isSuperAdmin((await locals.auth())?.user.roles)) {
       return error(403);
     }
 


### PR DESCRIPTION
I was tired of trying to remember which array index on session was the user role and which was the organization. These functions simplify all of that.

Functions added:
- `isAdminForOrg`: returns true if user is a SuperAdmin, or is an OrgAdmin for the specified organization
- `isAdminForOrgs`: returns true if user is a SuperAdmin, or is an OrgAdmin for any of the provided orgs
- `isAdmin`: returns true if user is a SuperAdmin, or is an OrgAdmin for any organization
- `isSuperAdmin`: returns true if user is a SuperAdmin
- `hasRoleForOrg`: returns true if user has specified role in specified org
- `orgsForRole`: returns a list of organizations where the user has the specified role 