### PR TITLE
Remove deprecated features from Svelte 5

### DIFF
--- a/source/SIL.AppBuilder.Portal/src/lib/components/Dropdown.svelte
+++ b/source/SIL.AppBuilder.Portal/src/lib/components/Dropdown.svelte
@@ -2,26 +2,32 @@
 @component
 A simple dropdown menu from DaisyUI.
 -->
+<!-- TODO: this component isn't used anywhere... -->
 <script lang="ts">
-  import { createEventDispatcher } from 'svelte';
-  export let cols = 6;
-  const dispatch = createEventDispatcher();
+  interface Props {
+    cols?: number;
+    label?: import('svelte').Snippet;
+    content?: import('svelte').Snippet;
+    onNavEnd?: () => void;
+  }
+
+  let { cols = 6, label, content, onNavEnd }: Props = $props();
 </script>
 
 <div class="dropdown">
   <!-- When .dropdown is focused, .dropdown-content is revealed making this actually interactive -->
-  <!-- svelte-ignore a11y-no-noninteractive-tabindex -->
+  <!-- svelte-ignore a11y_no_noninteractive_tabindex -->
   <label tabindex="0" class="btn btn-ghost p-0.5 no-animation flex-nowrap">
-    <slot name="label" />
+    {@render label?.()}
     <div
       role="button"
       tabindex="0"
       class="dropdown-content menu drop-shadow-lg mt-2.5 bg-base-100 z-10"
       class:min-w-[21rem]={cols == 6}
       class:min-w-[17.25rem]={cols == 5}
-      on:blur={() => dispatch('nav-end')}
+      onblur={() => onNavEnd?.()}
     >
-      <slot name="content" />
+      {@render content?.()}
     </div>
   </label>
 </div>

--- a/source/SIL.AppBuilder.Portal/src/lib/components/Dropdown.svelte
+++ b/source/SIL.AppBuilder.Portal/src/lib/components/Dropdown.svelte
@@ -4,10 +4,11 @@ A simple dropdown menu from DaisyUI.
 -->
 <!-- TODO: this component isn't used anywhere... -->
 <script lang="ts">
+  import type { Snippet } from 'svelte';
   interface Props {
     cols?: number;
-    label?: import('svelte').Snippet;
-    content?: import('svelte').Snippet;
+    label?: Snippet;
+    content?: Snippet;
     onNavEnd?: () => void;
   }
 

--- a/source/SIL.AppBuilder.Portal/src/lib/components/LanguageCodeTypeahead.svelte
+++ b/source/SIL.AppBuilder.Portal/src/lib/components/LanguageCodeTypeahead.svelte
@@ -5,7 +5,6 @@
 
   import * as m from '$lib/paraglide/messages';
   import type { FuseResultMatch } from 'fuse.js';
-  import { createEventDispatcher } from 'svelte';
   import TypeaheadInput from './TypeaheadInput.svelte';
 
   // https://www.fusejs.io/api/options.html
@@ -59,13 +58,15 @@
     langCode: string;
     dropdownClasses?: string;
     inputClasses?: string;
+    onLangCodeSelected?: (langCode: string) => void;
   }
 
-  let { langCode = $bindable(), dropdownClasses = '', inputClasses = '' }: Props = $props();
-
-  const dispatch = createEventDispatcher<{
-    langCodeSelected: string;
-  }>();
+  let {
+    langCode = $bindable(),
+    dropdownClasses = '',
+    inputClasses = '',
+    onLangCodeSelected
+  }: Props = $props();
 </script>
 
 {#snippet colorValueForKeyMatch(
@@ -104,9 +105,9 @@
   getList={(search) => fuzzySearch.search(search).slice(0, 5)}
   classes="pr-20 {inputClasses}"
   bind:search={langCode}
-  on:itemClicked={(item) => {
-    langCode = item.detail.item.tag;
-    dispatch('langCodeSelected', langCode);
+  onItemClicked={(item) => {
+    langCode = item.item.tag;
+    onLangCodeSelected?.(langCode);
   }}
   {dropdownClasses}
   bind:inputElement={typeaheadInput}
@@ -115,10 +116,7 @@
   <!-- svelte-ignore a11y_click_events_have_key_events -->
   <!-- svelte-ignore a11y_no_static_element_interactions -->
   {#snippet custom()}
-    <span
-      class="absolute right-4 italic [line-height:3rem]"
-      onclick={() => typeaheadInput?.focus()}
-    >
+    <span class="absolute right-4 italic [line-height:3rem]" onclick={() => typeaheadInput?.focus()}>
       {langtagList.find((l) => l.tag === langCode)?.name ?? ''}
     </span>
   {/snippet}

--- a/source/SIL.AppBuilder.Portal/src/lib/components/LanguageSelector.svelte
+++ b/source/SIL.AppBuilder.Portal/src/lib/components/LanguageSelector.svelte
@@ -1,13 +1,13 @@
 <script lang="ts">
   import { goto } from '$app/navigation';
-  import { page } from '$app/stores';
+  import { page } from '$app/state';
   import { i18n } from '$lib/i18n';
   import { LanguageIcon } from '$lib/icons';
   import { languageTag, type AvailableLanguageTag } from '$lib/paraglide/runtime';
   import Icon from '@iconify/svelte';
 
   function switchToLanguage(newLanguage: AvailableLanguageTag) {
-    const canonicalPath = i18n.route($page.url.pathname);
+    const canonicalPath = i18n.route(page.url.pathname);
     const localizedPath = i18n.resolveRoute(canonicalPath, newLanguage);
     goto(localizedPath);
   }

--- a/source/SIL.AppBuilder.Portal/src/lib/components/OrganizationSelector.svelte
+++ b/source/SIL.AppBuilder.Portal/src/lib/components/OrganizationSelector.svelte
@@ -1,25 +1,22 @@
 <script lang="ts">
   import type { Prisma } from '@prisma/client';
-  import { createEventDispatcher } from 'svelte';
   interface Props {
     organizations: Prisma.OrganizationsGetPayload<{
-    include: {
-      Owner: true;
-    };
-  }>[];
+      include: {
+        Owner: true;
+      };
+    }>[];
+    onSelect?: (id: number) => void;
   }
 
-  let { organizations }: Props = $props();
-  const dispatch = createEventDispatcher<{
-    select: { id: number };
-  }>();
+  let { organizations, onSelect }: Props = $props();
 </script>
 
 <div class="w-full px-4">
   <table class="w-full">
     <thead>
       <tr class="text-left">
-        <!-- i18n -->
+        <!-- TODO: i18n -->
         <th>Organization</th>
         <th>Owner</th>
         <!-- <th>Projects</th> -->
@@ -29,7 +26,7 @@
       {#each organizations as org}
         <tr
           class="h-16 border-y hover:bg-base-200 cursor-pointer"
-          onclick={() => dispatch('select', { id: org.Id })}
+          onclick={() => onSelect?.(org.Id)}
         >
           <td>
             {#if org.LogoUrl}

--- a/source/SIL.AppBuilder.Portal/src/lib/components/OrganizationSelector.svelte
+++ b/source/SIL.AppBuilder.Portal/src/lib/components/OrganizationSelector.svelte
@@ -6,7 +6,7 @@
         Owner: true;
       };
     }>[];
-    onSelect?: (id: number) => void;
+    onSelect: (id: number) => void;
   }
 
   let { organizations, onSelect }: Props = $props();
@@ -26,7 +26,7 @@
       {#each organizations as org}
         <tr
           class="h-16 border-y hover:bg-base-200 cursor-pointer"
-          onclick={() => onSelect?.(org.Id)}
+          onclick={() => onSelect(org.Id)}
         >
           <td>
             {#if org.LogoUrl}

--- a/source/SIL.AppBuilder.Portal/src/lib/components/SortTable.svelte
+++ b/source/SIL.AppBuilder.Portal/src/lib/components/SortTable.svelte
@@ -5,37 +5,33 @@
 <script lang="ts">
   import { ArrowDownIcon, ArrowUpIcon } from '$lib/icons';
   import { languageTag } from '$lib/paraglide/runtime';
-  import { createEventDispatcher } from 'svelte';
-  
-  
-  
+
   interface Props {
     data: Record<string, any>[];
     /** Definition of the columns for the table */
     columns: {
-    /** Internal id, used for determining which column is being sorted */
-    id: string;
-    /** User-facing string for column headers */
-    header: string;
-    /** Accessor method to get the desired data */
-    data: (i: any) => any;
-    /** Renders the data to an HTML string */
-    render?: (d: any) => string;
-    /** Will not sort a field if this is false or undefined */
-    sortable?: boolean;
-  }[];
-    className?: string;
+      /** Internal id, used for determining which column is being sorted */
+      id: string;
+      /** User-facing string for column headers */
+      header: string;
+      /** Accessor method to get the desired data */
+      data: (i: any) => any;
+      /** Renders the data to an HTML string */
+      render?: (d: any) => string;
+      /** Will not sort a field if this is false or undefined */
+      sortable?: boolean;
+    }[];
+    className: string;
     /** If this is true, will defer sorting to the server instead */
     serverSide?: boolean;
     /** If this is defined, will handle a click on a row */
-    onRowClick?: 
-    | undefined
-    | ((
-        rowData: (typeof data)[0],
-        event: MouseEvent & {
-          currentTarget: EventTarget & HTMLTableRowElement;
-        }
-      ) => void);
+    onRowClick?: (
+      rowData: (typeof data)[0],
+      event: MouseEvent & {
+        currentTarget: EventTarget & HTMLTableRowElement;
+      }
+    ) => void;
+    onSort?: (field: string, direction: 'asc' | 'desc') => void;
   }
 
   let {
@@ -43,7 +39,8 @@
     columns,
     className = '',
     serverSide = false,
-    onRowClick = undefined
+    onRowClick,
+    onSort
   }: Props = $props();
 
   /** Current field being sorted. Defaults to first field where `sortable === true` */
@@ -69,7 +66,7 @@
       }
     }
     if (serverSide) {
-      sendSortEvent('sort', { field: current.id, direction: descending ? 'desc' : 'asc' });
+      onSort?.(current.id, descending ? 'desc' : 'asc');
     } else {
       // sort based on current field
       // if blank, sort first field
@@ -95,13 +92,6 @@
             });
     }
   }
-
-  const sendSortEvent = createEventDispatcher<{
-    sort: {
-      field: string;
-      direction: 'asc' | 'desc';
-    };
-  }>();
 </script>
 
 <div class="overflow-y {className}">
@@ -139,7 +129,7 @@
       {#each data as d}
         <tr
           onclick={(e) => {
-            if (onRowClick) onRowClick(d, e);
+            onRowClick?.(d, e);
           }}
         >
           {#each columns as c}

--- a/source/SIL.AppBuilder.Portal/src/lib/components/TypeaheadInput.svelte
+++ b/source/SIL.AppBuilder.Portal/src/lib/components/TypeaheadInput.svelte
@@ -1,10 +1,5 @@
 <script lang="ts" generics="T">
-  import { createEventDispatcher } from 'svelte';
   import type { HTMLInputAttributes } from 'svelte/elements';
-
-  const dispatch = createEventDispatcher<{
-    itemClicked: T;
-  }>();
 
   let selectedIndex = $state(-1);
   let inputFocused = $state(false);
@@ -17,6 +12,7 @@
     inputElement?: HTMLInputElement;
     custom?: import('svelte').Snippet;
     listElement?: import('svelte').Snippet<[any]>;
+    onItemClicked?: (item: T) => void;
   }
 
   let {
@@ -27,7 +23,8 @@
     search = $bindable(''),
     inputElement = $bindable(undefined!),
     custom,
-    listElement
+    listElement,
+    onItemClicked
   }: Props = $props();
 
   function keypress(event: KeyboardEvent) {
@@ -52,7 +49,7 @@
     // input should stay selected and further keypresses should reopen the menu
     inputElement.focus();
     inputFocused = false;
-    dispatch('itemClicked', item);
+    onItemClicked?.(item);
   }
   function onFocus() {
     selectedIndex = -1;
@@ -88,7 +85,7 @@
           onmouseover={() => (selectedIndex = i)}
           onfocus={() => (selectedIndex = i)}
         >
-          {@render listElement?.({ item, })}
+          {@render listElement?.({ item })}
         </li>
       {/each}
     </ul>

--- a/source/SIL.AppBuilder.Portal/src/lib/components/settings/DataDisplayBox.svelte
+++ b/source/SIL.AppBuilder.Portal/src/lib/components/settings/DataDisplayBox.svelte
@@ -1,13 +1,11 @@
 <!--
     @component
-    A container box with a title and rows of internationalized information
-    
+    A container box with a title and rows of internationalized information   
 -->
 <script lang="ts" generics="T extends Record<string, unknown>">
   import type { ValidI13nKey } from '$lib/i18n';
   import * as m from '$lib/paraglide/messages';
   import Icon from '@iconify/svelte';
-  import { createEventDispatcher } from 'svelte';
 
   interface Props {
     title: string | null;
@@ -19,19 +17,17 @@
     }[];
     editable?: boolean;
     children?: import('svelte').Snippet;
+    onEdit?: () => void;
   }
 
-  let { title, data, fields, editable = false, children }: Props = $props();
-  const dispatch = createEventDispatcher<{
-    edit: null;
-  }>();
+  let { title, data, fields, editable = false, children, onEdit }: Props = $props();
 </script>
 
 <div class="flex flex-row border border-slate-600 p-2 mx-4 m-1 rounded-md">
   <div class="relative w-full">
     <h3>{title}</h3>
     {#if editable}
-      <button title="Edit" class="absolute right-2 top-2" onclick={() => dispatch('edit')}>
+      <button title="Edit" class="absolute right-2 top-2" onclick={() => onEdit?.()}>
         <Icon width="24" icon="mdi:pencil" />
       </button>
     {/if}

--- a/source/SIL.AppBuilder.Portal/src/lib/components/settings/TabbedMenu.svelte
+++ b/source/SIL.AppBuilder.Portal/src/lib/components/settings/TabbedMenu.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { page } from '$app/stores';
+  import { page } from '$app/state';
   import IconContainer from '../IconContainer.svelte';
 
   interface Props {
@@ -26,7 +26,7 @@
   }: Props = $props();
 
   function isActive(menuRoute: string) {
-    return $page.route.id?.replace(routeId, '').startsWith('/' + menuRoute);
+    return page.route.id?.replace(routeId, '').startsWith('/' + menuRoute);
   }
 </script>
 
@@ -44,7 +44,7 @@
           <div class="flex place-content-between">
             <span>
               {menuItems.find((item) =>
-                $page.route.id?.split(routeId + '/')[1]?.startsWith(item.route)
+                page.route.id?.split(routeId + '/')[1]?.startsWith(item.route)
               )?.text}
             </span>
             <IconContainer icon="gridicons:dropdown" width="24" />
@@ -65,7 +65,7 @@
       </div>
       <ul class="menu p-0 rounded border border-slate-600 sm:flex hidden">
         <!-- Desktop side menu -->
-        {#key $page.route.id}
+        {#key page.route.id}
           {#each menuItems as item}
             <li class="w-60 border-t border-slate-600 w-full [top:-1px]">
               <a

--- a/source/SIL.AppBuilder.Portal/src/lib/projects/components/ProjectActionMenu.svelte
+++ b/source/SIL.AppBuilder.Portal/src/lib/projects/components/ProjectActionMenu.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { page } from '$app/stores';
+  import { page } from '$app/state';
   import IconContainer from '$lib/components/IconContainer.svelte';
   import * as m from '$lib/paraglide/messages';
   import type { Infer, SuperValidated } from 'sveltekit-superforms';
@@ -40,11 +40,11 @@
 
   function canClaimOwnership(project: Omit<ProjectForAction, 'Id' | 'Name'>): boolean {
     return (
-      project.OwnerId !== $page.data.session?.user.userId &&
+      project.OwnerId !== page.data.session?.user.userId &&
       canClaimProject(
-        $page.data.session,
+        page.data.session,
         project.OwnerId,
-        parseInt($page.params.id),
+        parseInt(page.params.id),
         project.GroupId,
         userGroups
       )
@@ -73,7 +73,7 @@
     <form method="POST" action="?/{endpoint}" use:enhance>
       <input type="hidden" name="singleId" value={project.Id} />
       <ul class="menu menu-compact overflow-hidden rounded-md">
-        {#if allowActions && canArchive(project, $page.data.session, parseInt($page.params.id))}
+        {#if allowActions && canArchive(project, page.data.session, parseInt(page.params.id))}
           <li class="w-full rounded-none">
             <label class="text-nowrap">
               {m.common_archive()}
@@ -81,7 +81,7 @@
             </label>
           </li>
         {/if}
-        {#if allowReactivate && canReactivate(project, $page.data.session, parseInt($page.params.id))}
+        {#if allowReactivate && canReactivate(project, page.data.session, parseInt(page.params.id))}
           <li class="w-full rounded-none">
             <label class="text-nowrap">
               {m.common_reactivate()}

--- a/source/SIL.AppBuilder.Portal/src/lib/projects/components/ProjectFilterSelector.svelte
+++ b/source/SIL.AppBuilder.Portal/src/lib/projects/components/ProjectFilterSelector.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { page } from '$app/stores';
+  import { page } from '$app/state';
   import * as m from '$lib/paraglide/messages';
   import Icon from '@iconify/svelte';
 
@@ -17,7 +17,7 @@
   <!-- svelte-ignore a11y_no_noninteractive_tabindex -->
   <h1 tabindex="0" class="p-4 pl-6 cursor-pointer">
     <div class="flex flex-row items-center">
-      {textsForPaths.get($page.params.filter)}
+      {textsForPaths.get(page.params.filter)}
       <div class="dropdown-icon">
         <Icon width="24" class="dropdown-icon" icon="gridicons:dropdown" />
       </div>
@@ -27,8 +27,8 @@
     <div class="p-2 border m-2 rounded-md bg-base-200 px-4">
       {#each textsForPaths as route}
         <a
-          href="/projects/{route[0]}{$page.params.id ? '/' + $page.params.id : ''}"
-          class:font-extrabold={$page.params.filter === route[0]}
+          href="/projects/{route[0]}{page.params.id ? '/' + page.params.id : ''}"
+          class:font-extrabold={page.params.filter === route[0]}
           class="p-1 text-nowrap block"
         >
           {route[1]}

--- a/source/SIL.AppBuilder.Portal/src/routes/(authenticated)/+layout.svelte
+++ b/source/SIL.AppBuilder.Portal/src/routes/(authenticated)/+layout.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
   import { dev } from '$app/environment';
   import { base } from '$app/paths';
-  import { page } from '$app/stores';
+  import { page } from '$app/state';
   import LanguageSelector from '$lib/components/LanguageSelector.svelte';
   import { HamburgerIcon } from '$lib/icons';
   import * as m from '$lib/paraglide/messages';
@@ -22,7 +22,7 @@
   }
 
   let orgMenuOpen = false;
-  // $: console.log($page.data);
+  // $: console.log(page.data);
 
   function isActive(currentRoute: string | null, menuRoute: string) {
     return currentRoute?.startsWith(`${base}/(authenticated)${menuRoute}`);
@@ -56,7 +56,7 @@
     <div class="dropdown dropdown-end">
       <div role="button" class="btn btn-ghost m-2 p-2 rounded-xl" tabindex="0">
         <img
-          src={$page.data.session?.user?.image}
+          src={page.data.session?.user?.image}
           alt="User profile"
           referrerpolicy="no-referrer"
           class="h-full rounded-xl"
@@ -65,7 +65,7 @@
       <div class="dropdown-content w-36 z-10 bg-base-200 rounded-md overflow-y-auto">
         <ul class="menu menu-compact gap-1 p-2">
           <li>
-            <a href="/users/{$page.data.session?.user?.userId ?? ''}/settings/profile">
+            <a href="/users/{page.data.session?.user?.userId ?? ''}/settings/profile">
               {m.header_myProfile()}
             </a>
           </li>
@@ -105,7 +105,7 @@
           <li>
             <a
               class="rounded-none"
-              class:active-menu-item={isActive($page.route.id, '/tasks')}
+              class:active-menu-item={isActive(page.route.id, '/tasks')}
               href="{base}/tasks"
               onclick={closeDrawer}
             >
@@ -117,7 +117,7 @@
           <li>
             <a
               class="rounded-none"
-              class:active-menu-item={isUrlActive($page.url.pathname, '/projects/own')}
+              class:active-menu-item={isUrlActive(page.url.pathname, '/projects/own')}
               href="{base}/projects/own"
               onclick={closeDrawer}
             >
@@ -127,18 +127,18 @@
           <li>
             <a
               class="rounded-none"
-              class:active-menu-item={isUrlActive($page.url.pathname, '/projects/organization')}
+              class:active-menu-item={isUrlActive(page.url.pathname, '/projects/organization')}
               href="{base}/projects/organization"
               onclick={closeDrawer}
             >
               {m.sidebar_organizationProjects()}
             </a>
           </li>
-          {#if isAdmin($page.data.session?.user.roles)}
+          {#if isAdmin(page.data.session?.user.roles)}
             <li>
               <a
                 class="rounded-none"
-                class:active-menu-item={isUrlActive($page.url.pathname, '/projects/active')}
+                class:active-menu-item={isUrlActive(page.url.pathname, '/projects/active')}
                 href="{base}/projects/active"
                 onclick={closeDrawer}
               >
@@ -148,7 +148,7 @@
             <li>
               <a
                 class="rounded-none"
-                class:active-menu-item={isActive($page.route.id, '/users')}
+                class:active-menu-item={isActive(page.route.id, '/users')}
                 href="{base}/users"
                 onclick={closeDrawer}
               >
@@ -158,7 +158,7 @@
             <li>
               <a
                 class="rounded-none"
-                class:active-menu-item={isActive($page.route.id, '/organizations')}
+                class:active-menu-item={isActive(page.route.id, '/organizations')}
                 href="{base}/organizations/"
                 onclick={closeDrawer}
               >
@@ -166,11 +166,11 @@
               </a>
             </li>
           {/if}
-          {#if isSuperAdmin($page.data.session?.user.roles)}
+          {#if isSuperAdmin(page.data.session?.user.roles)}
             <li>
               <a
                 class="rounded-none"
-                class:active-menu-item={isActive($page.route.id, '/admin/settings')}
+                class:active-menu-item={isActive(page.route.id, '/admin/settings')}
                 href="{base}/admin/settings/organizations"
                 onclick={closeDrawer}
               >
@@ -189,7 +189,7 @@
             </li>
             <li>
               <a
-                class:active-menu-item={isActive($page.route.id, '/workflow-instances')}
+                class:active-menu-item={isActive(page.route.id, '/workflow-instances')}
                 href="{base}/workflow-instances"
                 onclick={closeDrawer}
               >
@@ -200,7 +200,7 @@
           <li class="menu-item-divider-top menu-item-divider-bottom">
             <a
               class="rounded-none"
-              class:active-menu-item={isActive($page.route.id, '/directory')}
+              class:active-menu-item={isActive(page.route.id, '/directory')}
               href="{base}/directory"
               onclick={closeDrawer}
             >
@@ -210,7 +210,7 @@
           <li>
             <a
               class="rounded-none mt-10"
-              class:active-menu-item={isActive($page.route.id, '/open-source')}
+              class:active-menu-item={isActive(page.route.id, '/open-source')}
               href="{base}/open-source"
               onclick={closeDrawer}
             >

--- a/source/SIL.AppBuilder.Portal/src/routes/(authenticated)/+layout.svelte
+++ b/source/SIL.AppBuilder.Portal/src/routes/(authenticated)/+layout.svelte
@@ -22,7 +22,6 @@
   }
 
   let orgMenuOpen = false;
-  // $: console.log(page.data);
 
   function isActive(currentRoute: string | null, menuRoute: string) {
     return currentRoute?.startsWith(`${base}/(authenticated)${menuRoute}`);

--- a/source/SIL.AppBuilder.Portal/src/routes/(authenticated)/admin/settings/organizations/+page.svelte
+++ b/source/SIL.AppBuilder.Portal/src/routes/(authenticated)/admin/settings/organizations/+page.svelte
@@ -21,7 +21,7 @@
   {#each data.organizations.sort((a, b) => sortByName(a, b, languageTag())) as organization}
     <DataDisplayBox
       editable
-      on:edit={() => goto('/admin/settings/organizations/edit?id=' + organization.Id)}
+      onEdit={() => goto('/admin/settings/organizations/edit?id=' + organization.Id)}
       title={organization.Name}
       fields={[
         { key: 'admin_settings_organizations_owner', value: organization.Owner.Name },

--- a/source/SIL.AppBuilder.Portal/src/routes/(authenticated)/admin/settings/product-definitions/+page.svelte
+++ b/source/SIL.AppBuilder.Portal/src/routes/(authenticated)/admin/settings/product-definitions/+page.svelte
@@ -22,7 +22,7 @@
   {#each data.productDefinitions.sort((a, b) => sortByName(a, b, languageTag())) as pD}
     <DataDisplayBox
       editable
-      on:edit={() => goto(base + '/admin/settings/product-definitions/edit?id=' + pD.Id)}
+      onEdit={() => goto(base + '/admin/settings/product-definitions/edit?id=' + pD.Id)}
       title={pD.Name}
       fields={[
         {

--- a/source/SIL.AppBuilder.Portal/src/routes/(authenticated)/admin/settings/store-types/+page.svelte
+++ b/source/SIL.AppBuilder.Portal/src/routes/(authenticated)/admin/settings/store-types/+page.svelte
@@ -21,7 +21,7 @@
   {#each data.storeTypes.sort((a, b) => sortByName(a, b, languageTag())) as storeType}
     <DataDisplayBox
       editable
-      on:edit={() => goto('/admin/settings/store-types/edit?id=' + storeType.Id)}
+      onEdit={() => goto('/admin/settings/store-types/edit?id=' + storeType.Id)}
       title={storeType.Name}
       fields={[{ key: 'stores_attributes_description', value: storeType.Description }]}
     />

--- a/source/SIL.AppBuilder.Portal/src/routes/(authenticated)/admin/settings/stores/+page.svelte
+++ b/source/SIL.AppBuilder.Portal/src/routes/(authenticated)/admin/settings/stores/+page.svelte
@@ -21,7 +21,7 @@
   {#each data.stores.sort((a, b) => sortByName(a, b, languageTag())) as store}
     <DataDisplayBox
       editable
-      on:edit={() => goto('/admin/settings/stores/edit?id=' + store.Id)}
+      onEdit={() => goto('/admin/settings/stores/edit?id=' + store.Id)}
       title={store.Name}
       fields={[
         { key: 'stores_attributes_description', value: store.Description },

--- a/source/SIL.AppBuilder.Portal/src/routes/(authenticated)/admin/settings/workflow-definitions/+page.svelte
+++ b/source/SIL.AppBuilder.Portal/src/routes/(authenticated)/admin/settings/workflow-definitions/+page.svelte
@@ -21,7 +21,7 @@
   {#each data.workflowDefinitions.sort((a, b) => sortByName(a, b, languageTag())) as wd}
     <DataDisplayBox
       editable
-      on:edit={() => goto('/admin/settings/workflow-definitions/edit?id=' + wd.Id)}
+      onEdit={() => goto('/admin/settings/workflow-definitions/edit?id=' + wd.Id)}
       title={wd.Name}
       fields={[
         {

--- a/source/SIL.AppBuilder.Portal/src/routes/(authenticated)/directory/+page.svelte
+++ b/source/SIL.AppBuilder.Portal/src/routes/(authenticated)/directory/+page.svelte
@@ -9,7 +9,7 @@
   import type { FormResult } from 'sveltekit-superforms';
   import { superForm } from 'sveltekit-superforms';
   import type { PageData } from './$types';
-
+  
   interface Props {
     data: PageData;
   }
@@ -75,7 +75,7 @@
       <div class="mobile-sizing">
         <LanguageCodeTypeahead
           bind:langCode={$form.langCode}
-          on:langCodeSelected={() => submit()}
+          onLangCodeSelected={() => submit()}
           inputClasses="w-full max-w-xs"
         />
       </div>

--- a/source/SIL.AppBuilder.Portal/src/routes/(authenticated)/organizations/+page.svelte
+++ b/source/SIL.AppBuilder.Portal/src/routes/(authenticated)/organizations/+page.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
   import { goto } from '$app/navigation';
-  import { page } from '$app/stores';
+  import { page } from '$app/state';
   import OrganizationSelector from '$lib/components/OrganizationSelector.svelte';
   import * as m from '$lib/paraglide/messages';
   import type { PageData } from './$types';
@@ -16,6 +16,6 @@
   <h1 class="pl-7">{m.org_settingsTitle()}</h1>
   <OrganizationSelector
     organizations={data.organizations}
-    onSelect={(id) => goto($page.url.pathname + '/' + id + '/settings/info')}
+    onSelect={(id) => goto(page.url.pathname + '/' + id + '/settings/info')}
   />
 </div>

--- a/source/SIL.AppBuilder.Portal/src/routes/(authenticated)/organizations/+page.svelte
+++ b/source/SIL.AppBuilder.Portal/src/routes/(authenticated)/organizations/+page.svelte
@@ -16,6 +16,6 @@
   <h1 class="pl-7">{m.org_settingsTitle()}</h1>
   <OrganizationSelector
     organizations={data.organizations}
-    on:select={({ detail }) => goto($page.url.pathname + '/' + detail.id + '/settings/info')}
+    onSelect={(id) => goto($page.url.pathname + '/' + id + '/settings/info')}
   />
 </div>

--- a/source/SIL.AppBuilder.Portal/src/routes/(authenticated)/organizations/[id]/settings/+layout.svelte
+++ b/source/SIL.AppBuilder.Portal/src/routes/(authenticated)/organizations/[id]/settings/+layout.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
   import { base } from '$app/paths';
-  import { page } from '$app/stores';
+  import { page } from '$app/state';
   import TabbedMenu from '$lib/components/settings/TabbedMenu.svelte';
   import {
     org_basicTitle,
@@ -21,7 +21,7 @@
 </script>
 
 <TabbedMenu
-  base="{base}/organizations/{$page.params.id}/settings"
+  base="{base}/organizations/{page.params.id}/settings"
   routeId="/(authenticated)/organizations/[id]/settings"
   menuItems={[
     {

--- a/source/SIL.AppBuilder.Portal/src/routes/(authenticated)/projects/[filter=projectSelector]/+page.svelte
+++ b/source/SIL.AppBuilder.Portal/src/routes/(authenticated)/projects/[filter=projectSelector]/+page.svelte
@@ -12,6 +12,6 @@
   <!-- <h1 class="pl-7">{m.projects_switcher_dropdown_orgProjects()}</h1> -->
   <OrganizationSelector
     organizations={$page.data.organizations}
-    on:select={(id) => goto($page.url.pathname + '/' + id.detail.id)}
+    onSelect={(id) => goto($page.url.pathname + '/' + id)}
   />
 </div>

--- a/source/SIL.AppBuilder.Portal/src/routes/(authenticated)/projects/[filter=projectSelector]/+page.svelte
+++ b/source/SIL.AppBuilder.Portal/src/routes/(authenticated)/projects/[filter=projectSelector]/+page.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
   import { goto } from '$app/navigation';
-  import { page } from '$app/stores';
+  import { page } from '$app/state';
   import OrganizationSelector from '$lib/components/OrganizationSelector.svelte';
   import ProjectFilterSelector from '$lib/projects/components/ProjectFilterSelector.svelte';
 </script>
@@ -11,7 +11,7 @@
   </div>
   <!-- <h1 class="pl-7">{m.projects_switcher_dropdown_orgProjects()}</h1> -->
   <OrganizationSelector
-    organizations={$page.data.organizations}
-    onSelect={(id) => goto($page.url.pathname + '/' + id)}
+    organizations={page.data.organizations}
+    onSelect={(id) => goto(page.url.pathname + '/' + id)}
   />
 </div>

--- a/source/SIL.AppBuilder.Portal/src/routes/(authenticated)/projects/[filter=projectSelector]/[id]/+page.svelte
+++ b/source/SIL.AppBuilder.Portal/src/routes/(authenticated)/projects/[filter=projectSelector]/[id]/+page.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
   import { afterNavigate, goto } from '$app/navigation';
-  import { page } from '$app/stores';
+  import { page } from '$app/state';
   import IconContainer from '$lib/components/IconContainer.svelte';
   import Pagination from '$lib/components/Pagination.svelte';
   import SearchBar from '$lib/components/SearchBar.svelte';
@@ -87,10 +87,10 @@
   });
 
   let canArchiveSelected = $derived(
-    selectedProjects.every((p) => canArchive(p, $page.data.session, parseInt($page.params.id)))
+    selectedProjects.every((p) => canArchive(p, page.data.session, parseInt(page.params.id)))
   );
   let canReactivateSelected = $derived(
-    selectedProjects.every((p) => canReactivate(p, $page.data.session, parseInt($page.params.id)))
+    selectedProjects.every((p) => canReactivate(p, page.data.session, parseInt(page.params.id)))
   );
 
   const {
@@ -298,7 +298,7 @@
         <button>close</button>
       </form>
     </dialog>
-    {#if $page.params.filter === 'own'}
+    {#if page.params.filter === 'own'}
       <div class="flex flex-row flex-wrap mobile-sizing gap-1 mx-4">
         <a class="action btn btn-outline" href="/projects/import/{$pageForm.organizationId}">
           {m.project_importProjects()}

--- a/source/SIL.AppBuilder.Portal/src/routes/(authenticated)/projects/[id=idNumber]/+page.svelte
+++ b/source/SIL.AppBuilder.Portal/src/routes/(authenticated)/projects/[id=idNumber]/+page.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
   import { enhance } from '$app/forms';
-  import { page } from '$app/stores';
+  import { page } from '$app/state';
   import IconContainer from '$lib/components/IconContainer.svelte';
   import Tooltip from '$lib/components/Tooltip.svelte';
   import { i18n } from '$lib/i18n';
@@ -71,7 +71,7 @@
       formData.append('productId', productId);
       formData.append('productAction', action);
 
-      const response = await fetch(`${$page.url.pathname}?/productAction`, {
+      const response = await fetch(`${page.url.pathname}?/productAction`, {
         method: 'POST',
         body: formData
       });
@@ -398,7 +398,7 @@
                     activityName: product.ActiveTransition?.InitialState ?? ''
                     // activityName appears to show up blank primarily at the very startup of a new product?
                   })}
-                  {#if product.UserTasks.slice(-1)[0]?.UserId === $page.data.session?.user.userId}
+                  {#if product.UserTasks.slice(-1)[0]?.UserId === page.data.session?.user.userId}
                     <a class="link mx-2" href="/tasks/{product.Id}">
                       {m.common_continue()}
                     </a>

--- a/source/SIL.AppBuilder.Portal/src/routes/(authenticated)/projects/[id=idNumber]/edit/+page.svelte
+++ b/source/SIL.AppBuilder.Portal/src/routes/(authenticated)/projects/[id=idNumber]/edit/+page.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
   import { goto } from '$app/navigation';
-  import { page } from '$app/stores';
+  import { page } from '$app/state';
   import LanguageCodeTypeahead from '$lib/components/LanguageCodeTypeahead.svelte';
   import * as m from '$lib/paraglide/messages';
   import { superForm } from 'sveltekit-superforms';
@@ -15,7 +15,7 @@
     dataType: 'json',
     onUpdated(event) {
       if (event.form.valid) {
-        goto('/projects/' + $page.params.id);
+        goto('/projects/' + page.params.id);
       }
     }
   });
@@ -63,7 +63,7 @@
       </label>
     </div>
     <div class="flex place-content-end space-x-2">
-      <a href="/projects/{$page.params.id}" class="btn">{m.common_cancel()}</a>
+      <a href="/projects/{page.params.id}" class="btn">{m.common_cancel()}</a>
       <button class="btn btn-primary" type="submit">{m.common_save()}</button>
     </div>
   </form>

--- a/source/SIL.AppBuilder.Portal/src/routes/(authenticated)/projects/import/[id=idNumber]/+page.svelte
+++ b/source/SIL.AppBuilder.Portal/src/routes/(authenticated)/projects/import/[id=idNumber]/+page.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { page } from '$app/stores';
+  import { page } from '$app/state';
   import * as m from '$lib/paraglide/messages';
   import { importJSONSchema } from '$lib/projects/common';
   import { onMount } from 'svelte';
@@ -155,7 +155,7 @@
       </ul>
     {/if}
     <div class="flex flex-wrap place-content-center gap-4 p-4">
-      <a href="/projects/own/{$page.params.id}" class="btn w-full max-w-xs">{m.common_cancel()}</a>
+      <a href="/projects/own/{page.params.id}" class="btn w-full max-w-xs">{m.common_cancel()}</a>
       <button class="btn btn-primary w-full max-w-xs" disabled={!canSubmit} type="submit">
         {m.common_save()}
       </button>

--- a/source/SIL.AppBuilder.Portal/src/routes/(authenticated)/projects/new/[id=idNumber]/+page.svelte
+++ b/source/SIL.AppBuilder.Portal/src/routes/(authenticated)/projects/new/[id=idNumber]/+page.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { page } from '$app/stores';
+  import { page } from '$app/state';
   import LanguageCodeTypeahead from '$lib/components/LanguageCodeTypeahead.svelte';
   import * as m from '$lib/paraglide/messages';
   import { superForm } from 'sveltekit-superforms';
@@ -94,7 +94,7 @@
       </ul>
     {/if}
     <div class="flex flex-wrap place-content-center gap-4 p-4">
-      <a href="/projects/own/{$page.params.id}" class="btn w-full max-w-xs">{m.common_cancel()}</a>
+      <a href="/projects/own/{page.params.id}" class="btn w-full max-w-xs">{m.common_cancel()}</a>
       <button
         class="btn btn-primary w-full max-w-xs"
         class:btn-disabled={!($form.Name.length && $form.Language.length)}

--- a/source/SIL.AppBuilder.Portal/src/routes/(authenticated)/users/[id=idNumber]/settings/+layout.svelte
+++ b/source/SIL.AppBuilder.Portal/src/routes/(authenticated)/users/[id=idNumber]/settings/+layout.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
   import { base } from '$app/paths';
-  import { page } from '$app/stores';
+  import { page } from '$app/state';
   import TabbedMenu from '$lib/components/settings/TabbedMenu.svelte';
   import * as m from '$lib/paraglide/messages';
   import type { LayoutData } from './$types';
@@ -24,7 +24,7 @@
 {#if data.canEdit}
   <TabbedMenu
     routeId="/(authenticated)/users/[id=idNumber]/settings"
-    base="{base}/users/{$page.params.id}/settings"
+    base="{base}/users/{page.params.id}/settings"
     titleString={m.users_settingsTitle() + ': ' + data.username}
     menuItems={userSettingsLinks}
   >

--- a/source/SIL.AppBuilder.Portal/src/routes/(authenticated)/users/[id=idNumber]/settings/profile/+page.svelte
+++ b/source/SIL.AppBuilder.Portal/src/routes/(authenticated)/users/[id=idNumber]/settings/profile/+page.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { page } from '$app/stores';
+  import { page } from '$app/state';
   import LabeledFormInput from '$lib/components/settings/LabeledFormInput.svelte';
   import TypeaheadInput from '$lib/components/TypeaheadInput.svelte';
   import * as m from '$lib/paraglide/messages';
@@ -153,7 +153,7 @@
         type="checkbox"
         id="active"
         class="toggle toggle-accent ml-4"
-        disabled={$page.data.session?.user.userId === data.form.data.id}
+        disabled={page.data.session?.user.userId === data.form.data.id}
         bind:checked={$form.active}
       />
     </div>

--- a/source/SIL.AppBuilder.Portal/src/routes/(authenticated)/users/[id=idNumber]/settings/profile/+page.svelte
+++ b/source/SIL.AppBuilder.Portal/src/routes/(authenticated)/users/[id=idNumber]/settings/profile/+page.svelte
@@ -87,10 +87,12 @@
       <TypeaheadInput
         inputElProps={{ placeholder: m.profile_timezonePlaceholder() }}
         getList={(search) => fuzzySearch.search(search).slice(0, 7)}
-        on:itemClicked={(item) => {
+        onItemClicked={(item) => {
           // Not strictly necessary because it will be set onSubmit but here anyways
-          $form.timezone = item.detail.item.key;
-          tzValue = item.detail.item.value;
+          // @ts-expect-error the property key should always exist in our use case
+          $form.timezone = item.key;
+          // @ts-expect-error the property value should always exist in our use case
+          tzValue = item.value;
         }}
         bind:search={tzValue}
         classes="w-full {!tzValue || timeZoneMap.has(tzValue) ? '' : 'select-error'}"

--- a/source/SIL.AppBuilder.Portal/src/routes/(authenticated)/workflow-instances/+page.svelte
+++ b/source/SIL.AppBuilder.Portal/src/routes/(authenticated)/workflow-instances/+page.svelte
@@ -123,7 +123,8 @@
         ]}
         serverSide={true}
         className="max-h-full"
-        on:sort={(e) => form.update((data) => ({ ...data, sort: e.detail }))}
+        onSort={(field, direction) =>
+          form.update((data) => ({ ...data, sort: { field, direction } }))}
       />
     {:else}
       <p class="m-8">{m.workflowInstances_empty()}</p>

--- a/source/SIL.AppBuilder.Portal/src/routes/+error.svelte
+++ b/source/SIL.AppBuilder.Portal/src/routes/+error.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { page } from '$app/stores';
+  import { page } from '$app/state';
 </script>
 
-<h1>{$page.status}: {$page.error?.message}</h1>
+<h1>{page.status}: {page.error?.message}</h1>


### PR DESCRIPTION
Svelte 5 deprecated some features that we were using but otherwise still work:

`createEventDispatcher` is superseded by event props

`$app/stores` is superseded by `$app/state`