### PR TITLE
Remove unneeded try-catch in form submissions

### DIFF
--- a/source/SIL.AppBuilder.Portal/src/routes/(authenticated)/admin/settings/organizations/edit/+page.server.ts
+++ b/source/SIL.AppBuilder.Portal/src/routes/(authenticated)/admin/settings/organizations/edit/+page.server.ts
@@ -67,49 +67,31 @@ export const load = (async ({ url }) => {
 }) satisfies PageServerLoad;
 
 export const actions = {
-  async edit({ cookies, request }) {
+  async edit({ request }) {
     const form = await superValidate(request, valibot(editSchema));
     if (!form.valid) {
       return fail(400, { form, ok: false, errors: form.errors });
     }
-    // return { ok: true, form };
-    try {
-      const {
-        id,
-        name,
-        buildEngineAccessToken,
-        buildEngineURL,
-        logoURL,
-        useDefaultBuildEngine,
-        owner,
-        publicByDefault,
-        websiteURL,
-        stores
-      } = form.data;
-      await DatabaseWrites.organizations.update({
-        where: {
-          Id: id
-        },
-        data: {
-          Name: name,
-          BuildEngineApiAccessToken: buildEngineAccessToken,
-          BuildEngineUrl: buildEngineURL,
-          LogoUrl: logoURL,
-          UseDefaultBuildEngine: useDefaultBuildEngine,
-          OwnerId: owner,
-          PublicByDefault: publicByDefault,
-          WebsiteUrl: websiteURL
-        }
-      });
-      await DatabaseWrites.organizationStores.updateOrganizationStores(
-        id,
-        stores.filter((s) => s.enabled).map((s) => s.storeId)
-      );
+    await DatabaseWrites.organizations.update({
+      where: {
+        Id: form.data.id
+      },
+      data: {
+        Name: form.data.name,
+        BuildEngineApiAccessToken: form.data.buildEngineAccessToken,
+        BuildEngineUrl: form.data.buildEngineURL,
+        LogoUrl: form.data.logoURL,
+        OwnerId: form.data.owner,
+        PublicByDefault: form.data.publicByDefault,
+        UseDefaultBuildEngine: form.data.useDefaultBuildEngine,
+        WebsiteUrl: form.data.websiteURL
+      }
+    });
+    await DatabaseWrites.organizationStores.updateOrganizationStores(
+      form.data.id,
+      form.data.stores.filter((s) => s.enabled).map((s) => s.storeId)
+    );
 
-      return { ok: true, form };
-    } catch (e) {
-      if (e instanceof v.ValiError) return { form, ok: false, errors: e.issues };
-      throw e;
-    }
+    return { ok: true, form };
   }
 } satisfies Actions;

--- a/source/SIL.AppBuilder.Portal/src/routes/(authenticated)/admin/settings/organizations/edit/+page.svelte
+++ b/source/SIL.AppBuilder.Portal/src/routes/(authenticated)/admin/settings/organizations/edit/+page.svelte
@@ -22,10 +22,6 @@
       }
     }
   });
-
-  let getStoreInfo = $derived((store: (typeof $form)['stores'][0]) =>
-    data.options.stores.find((s) => s.Id === store.storeId)
-  );
 </script>
 
 <!-- <SuperDebug data={superForm} /> -->
@@ -115,10 +111,11 @@
   <!-- TODO: sort this. I think this will need a refactor of MultiselectBox -->
   <MultiselectBox header={m.org_storeSelectTitle()}>
     {#each $form.stores as store}
+      {@const storeInfo = data.options.stores.find((s) => s.Id === store.storeId)}
       <MultiselectBoxElement
         bind:checked={store.enabled}
-        title={getStoreInfo(store)?.Name ?? ''}
-        description={getStoreInfo(store)?.Description ?? ''}
+        title={storeInfo?.Name ?? ''}
+        description={storeInfo?.Description ?? ''}
       />
     {/each}
   </MultiselectBox>

--- a/source/SIL.AppBuilder.Portal/src/routes/(authenticated)/admin/settings/organizations/edit/+page.svelte
+++ b/source/SIL.AppBuilder.Portal/src/routes/(authenticated)/admin/settings/organizations/edit/+page.svelte
@@ -14,11 +14,7 @@
   }
 
   let { data }: Props = $props();
-  const {
-    form: superFormData,
-    enhance,
-    allErrors
-  } = superForm(data.form, {
+  const { form, enhance, allErrors } = superForm(data.form, {
     dataType: 'json',
     onUpdated(event) {
       if (event.form.valid) {
@@ -27,23 +23,19 @@
     }
   });
 
-  let getStoreInfo = $derived((store: (typeof $superFormData)['stores'][0]) =>
-    data.options.stores.find((s) => s.Id === store.storeId));
+  let getStoreInfo = $derived((store: (typeof $form)['stores'][0]) =>
+    data.options.stores.find((s) => s.Id === store.storeId)
+  );
 </script>
 
 <!-- <SuperDebug data={superForm} /> -->
 <form class="m-4" method="post" action="?/edit" use:enhance>
-  <input type="hidden" name="id" value={$superFormData.id} />
+  <input type="hidden" name="id" value={$form.id} />
   <LabeledFormInput name="admin_settings_organizations_name">
-    <input
-      class="input w-full input-bordered"
-      type="text"
-      name="name"
-      bind:value={$superFormData.name}
-    />
+    <input class="input w-full input-bordered" type="text" name="name" bind:value={$form.name} />
   </LabeledFormInput>
   <LabeledFormInput name="admin_settings_organizations_owner">
-    <select class="select select-bordered" name="owner" bind:value={$superFormData.owner}>
+    <select class="select select-bordered" name="owner" bind:value={$form.owner}>
       {#each data.options.users.toSorted((a, b) => byName(a, b, languageTag())) as option}
         <option value={option.Id}>{option.Name}</option>
       {/each}
@@ -54,7 +46,7 @@
       name="websiteURL"
       class="input input-bordered w-full"
       type="text"
-      bind:value={$superFormData.websiteURL}
+      bind:value={$form.websiteURL}
     />
   </LabeledFormInput>
   <div>
@@ -69,18 +61,18 @@
           name="useDefaultBuildEngine"
           class="toggle toggle-accent"
           type="checkbox"
-          bind:checked={$superFormData.useDefaultBuildEngine}
+          bind:checked={$form.useDefaultBuildEngine}
         />
       </div>
     </label>
   </div>
-  {#if !$superFormData.useDefaultBuildEngine}
+  {#if !$form.useDefaultBuildEngine}
     <LabeledFormInput name="admin_settings_organizations_buildEngineURL">
       <input
         type="text"
         name="buildEngineURL"
         class="input input-bordered w-full"
-        bind:value={$superFormData.buildEngineURL}
+        bind:value={$form.buildEngineURL}
       />
     </LabeledFormInput>
     <LabeledFormInput name="admin_settings_organizations_accessToken">
@@ -88,7 +80,7 @@
         type="text"
         name="buildEngineAccessToken"
         class="input input-bordered w-full"
-        bind:value={$superFormData.buildEngineAccessToken}
+        bind:value={$form.buildEngineAccessToken}
       />
     </LabeledFormInput>
   {/if}
@@ -97,7 +89,7 @@
       name="logoURL"
       class="input input-bordered w-full"
       type="text"
-      bind:value={$superFormData.logoURL}
+      bind:value={$form.logoURL}
     />
   </LabeledFormInput>
   <div>
@@ -115,14 +107,14 @@
           name="publicByDefault"
           class="toggle toggle-accent"
           type="checkbox"
-          bind:checked={$superFormData.publicByDefault}
+          bind:checked={$form.publicByDefault}
         />
       </div>
     </label>
   </div>
   <!-- TODO: sort this. I think this will need a refactor of MultiselectBox -->
   <MultiselectBox header={m.org_storeSelectTitle()}>
-    {#each $superFormData.stores as store}
+    {#each $form.stores as store}
       <MultiselectBoxElement
         bind:checked={store.enabled}
         title={getStoreInfo(store)?.Name ?? ''}

--- a/source/SIL.AppBuilder.Portal/src/routes/(authenticated)/admin/settings/organizations/new/+page.server.ts
+++ b/source/SIL.AppBuilder.Portal/src/routes/(authenticated)/admin/settings/organizations/new/+page.server.ts
@@ -31,33 +31,18 @@ export const actions = {
     if (!form.valid) {
       return fail(400, { form, ok: false, errors: form.errors });
     }
-    try {
-      const {
-        buildEngineAccessToken,
-        buildEngineURL,
-        logoURL,
-        name,
-        owner,
-        publicByDefault,
-        useDefaultBuildEngine,
-        websiteURL
-      } = form.data;
-      await DatabaseWrites.organizations.create({
-        data: {
-          Name: name,
-          BuildEngineApiAccessToken: buildEngineAccessToken,
-          BuildEngineUrl: buildEngineURL,
-          LogoUrl: logoURL,
-          OwnerId: owner,
-          PublicByDefault: publicByDefault,
-          UseDefaultBuildEngine: useDefaultBuildEngine,
-          WebsiteUrl: websiteURL
-        }
-      });
-      return { ok: true, form };
-    } catch (e) {
-      if (e instanceof v.ValiError) return { form, ok: false, errors: e.issues };
-      throw e;
-    }
+    await DatabaseWrites.organizations.create({
+      data: {
+        Name: form.data.name,
+        BuildEngineApiAccessToken: form.data.buildEngineAccessToken,
+        BuildEngineUrl: form.data.buildEngineURL,
+        LogoUrl: form.data.logoURL,
+        OwnerId: form.data.owner,
+        PublicByDefault: form.data.publicByDefault,
+        UseDefaultBuildEngine: form.data.useDefaultBuildEngine,
+        WebsiteUrl: form.data.websiteURL
+      }
+    });
+    return { ok: true, form };
   }
 } satisfies Actions;

--- a/source/SIL.AppBuilder.Portal/src/routes/(authenticated)/admin/settings/product-definitions/edit/+page.server.ts
+++ b/source/SIL.AppBuilder.Portal/src/routes/(authenticated)/admin/settings/product-definitions/edit/+page.server.ts
@@ -49,48 +49,25 @@ export const load = (async ({ url }) => {
 }) satisfies PageServerLoad;
 
 export const actions = {
-  async edit({ cookies, request }) {
+  async edit({ request }) {
     const form = await superValidate(request, valibot(editSchema));
     if (!form.valid) {
       return fail(400, { form, ok: false, errors: form.errors });
     }
-    try {
-      const {
-        id,
-        name,
-        applicationType,
-        workflow,
-        rebuildWorkflow,
-        republishWorkflow,
-        description,
-        properties
-      } = form.data;
-      await DatabaseWrites.productDefinitions.update({
-        where: {
-          Id: id
-        },
-        data: {
-          TypeId: applicationType,
-          Name: name,
-          WorkflowId: workflow,
-          RebuildWorkflowId: rebuildWorkflow,
-          RepublishWorkflowId: republishWorkflow,
-          Description: description,
-          Properties: properties
-        }
-      });
-      return { ok: true, form };
-    } catch (e) {
-      if (e instanceof v.ValiError) return { form, ok: false, errors: e.issues };
-      throw e;
-    }
-    // const Id = data.get('id');
-    // const name = data.get('name');
-    // const applicationType = data.get('applicationType');
-    // const workflow = data.get('workflow');
-    // const rebuildWorkflow = data.get('rebuildWorkflow');
-    // const republishWorkflow = data.get('republishWorkflow');
-    // const description = data.get('description');
-    // const properties = data.get('properties');
+    await DatabaseWrites.productDefinitions.update({
+      where: {
+        Id: form.data.id
+      },
+      data: {
+        TypeId: form.data.applicationType,
+        Name: form.data.name,
+        WorkflowId: form.data.workflow,
+        RebuildWorkflowId: form.data.rebuildWorkflow,
+        RepublishWorkflowId: form.data.republishWorkflow,
+        Description: form.data.description,
+        Properties: form.data.properties
+      }
+    });
+    return { ok: true, form };
   }
 } satisfies Actions;

--- a/source/SIL.AppBuilder.Portal/src/routes/(authenticated)/admin/settings/product-definitions/edit/+page.svelte
+++ b/source/SIL.AppBuilder.Portal/src/routes/(authenticated)/admin/settings/product-definitions/edit/+page.svelte
@@ -12,11 +12,7 @@
   }
 
   let { data }: Props = $props();
-  const {
-    form: superFormData,
-    enhance,
-    allErrors
-  } = superForm(data.form, {
+  const { form, enhance, allErrors } = superForm(data.form, {
     onUpdated(event) {
       if (event.form.valid) {
         goto('/admin/settings/product-definitions');
@@ -39,20 +35,15 @@
 
 <!-- <SuperDebug data={superForm} /> -->
 <form class="m-4" method="post" action="?/edit" use:enhance>
-  <input type="hidden" name="id" value={$superFormData.id} />
+  <input type="hidden" name="id" value={$form.id} />
   <LabeledFormInput name="admin_settings_productDefinitions_name">
-    <input
-      class="input w-full input-bordered"
-      type="text"
-      name="name"
-      bind:value={$superFormData.name}
-    />
+    <input class="input w-full input-bordered" type="text" name="name" bind:value={$form.name} />
   </LabeledFormInput>
   <LabeledFormInput name="admin_settings_productDefinitions_type">
     <select
       class="select select-bordered"
       name="applicationType"
-      bind:value={$superFormData.applicationType}
+      bind:value={$form.applicationType}
     >
       {#each data.options.applicationTypes.toSorted((a, b) => byName(a, b, langTag)) as type}
         <option value={type.Id}>{type.Name}</option>
@@ -60,7 +51,7 @@
     </select>
   </LabeledFormInput>
   <LabeledFormInput name="admin_settings_productDefinitions_workflow">
-    <select class="select select-bordered" name="workflow" bind:value={$superFormData.workflow}>
+    <select class="select select-bordered" name="workflow" bind:value={$form.workflow}>
       {#each workflows as workflow}
         <option value={workflow.Id}>{workflow.Name}</option>
       {/each}
@@ -70,7 +61,7 @@
     <select
       class="select select-bordered"
       name="rebuildWorkflow"
-      bind:value={$superFormData.rebuildWorkflow}
+      bind:value={$form.rebuildWorkflow}
     >
       <option value={null}>{m.admin_settings_productDefinitions_noWorkflow()}</option>
       {#each rebuildWorkflows as workflow}
@@ -82,7 +73,7 @@
     <select
       class="select select-bordered"
       name="republishWorkflow"
-      bind:value={$superFormData.republishWorkflow}
+      bind:value={$form.republishWorkflow}
     >
       <option value={null}>{m.admin_settings_productDefinitions_noWorkflow()}</option>
       {#each republishWorkflows as workflow}
@@ -94,14 +85,14 @@
     <textarea
       name="description"
       class="textarea textarea-bordered w-full"
-      bind:value={$superFormData.description}
+      bind:value={$form.description}
     ></textarea>
   </LabeledFormInput>
   <LabeledFormInput name="admin_settings_productDefinitions_properties">
     <textarea
       name="properties"
       class="textarea textarea-bordered w-full"
-      bind:value={$superFormData.properties}
+      bind:value={$form.properties}
     ></textarea>
   </LabeledFormInput>
   {#if $allErrors.length}

--- a/source/SIL.AppBuilder.Portal/src/routes/(authenticated)/admin/settings/product-definitions/new/+page.server.ts
+++ b/source/SIL.AppBuilder.Portal/src/routes/(authenticated)/admin/settings/product-definitions/new/+page.server.ts
@@ -30,31 +30,17 @@ export const actions = {
     if (!form.valid) {
       return fail(400, { form, ok: false, errors: form.errors });
     }
-    try {
-      const {
-        name,
-        applicationType,
-        workflow,
-        rebuildWorkflow,
-        republishWorkflow,
-        description,
-        properties
-      } = form.data;
-      await DatabaseWrites.productDefinitions.create({
-        data: {
-          Name: name,
-          TypeId: applicationType,
-          WorkflowId: workflow,
-          RebuildWorkflowId: rebuildWorkflow,
-          RepublishWorkflowId: republishWorkflow,
-          Description: description,
-          Properties: properties
-        }
-      });
-      return { ok: true, form };
-    } catch (e) {
-      if (e instanceof v.ValiError) return { form, ok: false, errors: e.issues };
-      throw e;
-    }
+    await DatabaseWrites.productDefinitions.create({
+      data: {
+        Name: form.data.name,
+        TypeId: form.data.applicationType,
+        WorkflowId: form.data.workflow,
+        RebuildWorkflowId: form.data.rebuildWorkflow,
+        RepublishWorkflowId: form.data.republishWorkflow,
+        Description: form.data.description,
+        Properties: form.data.properties
+      }
+    });
+    return { ok: true, form };
   }
 } satisfies Actions;

--- a/source/SIL.AppBuilder.Portal/src/routes/(authenticated)/admin/settings/store-types/edit/+page.server.ts
+++ b/source/SIL.AppBuilder.Portal/src/routes/(authenticated)/admin/settings/store-types/edit/+page.server.ts
@@ -35,26 +35,20 @@ export const load = (async ({ url }) => {
 }) satisfies PageServerLoad;
 
 export const actions = {
-  async edit({ cookies, request }) {
+  async edit({ request }) {
     const form = await superValidate(request, valibot(editSchema));
     if (!form.valid) {
       return fail(400, { form, ok: false, errors: form.errors });
     }
-    try {
-      const { id, name, description } = form.data;
-      await DatabaseWrites.storeTypes.update({
-        where: {
-          Id: id
-        },
-        data: {
-          Name: name,
-          Description: description
-        }
-      });
-      return { ok: true, form };
-    } catch (e) {
-      if (e instanceof v.ValiError) return { form, ok: false, errors: e.issues };
-      throw e;
-    }
+    await DatabaseWrites.storeTypes.update({
+      where: {
+        Id: form.data.id
+      },
+      data: {
+        Name: form.data.name,
+        Description: form.data.description
+      }
+    });
+    return { ok: true, form };
   }
 } satisfies Actions;

--- a/source/SIL.AppBuilder.Portal/src/routes/(authenticated)/admin/settings/store-types/edit/+page.svelte
+++ b/source/SIL.AppBuilder.Portal/src/routes/(authenticated)/admin/settings/store-types/edit/+page.svelte
@@ -9,11 +9,7 @@
   }
 
   let { data }: Props = $props();
-  const {
-    form: superFormData,
-    enhance,
-    allErrors
-  } = superForm(data.form, {
+  const { form, enhance, allErrors } = superForm(data.form, {
     onUpdated(event) {
       if (event.form.valid) {
         goto('/admin/settings/store-types');
@@ -24,20 +20,15 @@
 
 <!-- <SuperDebug data={superForm} /> -->
 <form class="m-4" method="post" action="?/edit" use:enhance>
-  <input type="hidden" name="id" value={$superFormData.id} />
+  <input type="hidden" name="id" value={$form.id} />
   <LabeledFormInput name="admin_settings_storeTypes_name">
-    <input
-      class="input w-full input-bordered"
-      type="text"
-      name="name"
-      bind:value={$superFormData.name}
-    />
+    <input class="input w-full input-bordered" type="text" name="name" bind:value={$form.name} />
   </LabeledFormInput>
   <LabeledFormInput name="admin_settings_storeTypes_description">
     <textarea
       name="description"
       class="textarea textarea-bordered w-full"
-      bind:value={$superFormData.description}
+      bind:value={$form.description}
     ></textarea>
   </LabeledFormInput>
   {#if $allErrors.length}

--- a/source/SIL.AppBuilder.Portal/src/routes/(authenticated)/admin/settings/store-types/new/+page.server.ts
+++ b/source/SIL.AppBuilder.Portal/src/routes/(authenticated)/admin/settings/store-types/new/+page.server.ts
@@ -16,23 +16,17 @@ export const load = (async ({ url }) => {
 }) satisfies PageServerLoad;
 
 export const actions = {
-  async new({ cookies, request }) {
+  async new({ request }) {
     const form = await superValidate(request, valibot(createSchema));
     if (!form.valid) {
       return fail(400, { form, ok: false, errors: form.errors });
     }
-    try {
-      const { name, description } = form.data;
-      await DatabaseWrites.storeTypes.create({
-        data: {
-          Name: name,
-          Description: description
-        }
-      });
-      return { ok: true, form };
-    } catch (e) {
-      if (e instanceof v.ValiError) return { form, ok: false, errors: e.issues };
-      throw e;
-    }
+    await DatabaseWrites.storeTypes.create({
+      data: {
+        Name: form.data.name,
+        Description: form.data.description
+      }
+    });
+    return { ok: true, form };
   }
 } satisfies Actions;

--- a/source/SIL.AppBuilder.Portal/src/routes/(authenticated)/admin/settings/stores/edit/+page.server.ts
+++ b/source/SIL.AppBuilder.Portal/src/routes/(authenticated)/admin/settings/stores/edit/+page.server.ts
@@ -38,27 +38,21 @@ export const load = (async ({ url }) => {
 }) satisfies PageServerLoad;
 
 export const actions = {
-  async edit({ cookies, request }) {
+  async edit({ request }) {
     const form = await superValidate(request, valibot(editSchema));
     if (!form.valid) {
       return fail(400, { form, ok: false, errors: form.errors });
     }
-    try {
-      const { id, name, description, storeType } = form.data;
-      await DatabaseWrites.stores.update({
-        where: {
-          Id: id
-        },
-        data: {
-          Name: name,
-          StoreTypeId: storeType,
-          Description: description
-        }
-      });
-      return { ok: true, form };
-    } catch (e) {
-      if (e instanceof v.ValiError) return { form, ok: false, errors: e.issues };
-      throw e;
-    }
+    await DatabaseWrites.stores.update({
+      where: {
+        Id: form.data.id
+      },
+      data: {
+        Name: form.data.name,
+        StoreTypeId: form.data.storeType,
+        Description: form.data.description
+      }
+    });
+    return { ok: true, form };
   }
 } satisfies Actions;

--- a/source/SIL.AppBuilder.Portal/src/routes/(authenticated)/admin/settings/stores/edit/+page.svelte
+++ b/source/SIL.AppBuilder.Portal/src/routes/(authenticated)/admin/settings/stores/edit/+page.svelte
@@ -11,11 +11,7 @@
   }
 
   let { data }: Props = $props();
-  const {
-    form: superFormData,
-    enhance,
-    allErrors
-  } = superForm(data.form, {
+  const { form, enhance, allErrors } = superForm(data.form, {
     onUpdated(event) {
       if (event.form.valid) {
         goto('/admin/settings/stores');
@@ -26,24 +22,19 @@
 
 <!-- <SuperDebug data={superForm} /> -->
 <form class="m-4" method="post" action="?/edit" use:enhance>
-  <input type="hidden" name="id" value={$superFormData.id} />
+  <input type="hidden" name="id" value={$form.id} />
   <LabeledFormInput name="stores_attributes_name">
-    <input
-      class="input w-full input-bordered"
-      type="text"
-      name="name"
-      bind:value={$superFormData.name}
-    />
+    <input class="input w-full input-bordered" type="text" name="name" bind:value={$form.name} />
   </LabeledFormInput>
   <LabeledFormInput name="stores_attributes_description">
     <textarea
       name="description"
       class="textarea textarea-bordered w-full"
-      bind:value={$superFormData.description}
+      bind:value={$form.description}
     ></textarea>
   </LabeledFormInput>
   <LabeledFormInput name="storeTypes_name">
-    <select class="select select-bordered" name="storeType" bind:value={$superFormData.storeType}>
+    <select class="select select-bordered" name="storeType" bind:value={$form.storeType}>
       {#each data.options.toSorted((a, b) => byName(a, b, languageTag())) as option}
         <option value={option.Id}>{option.Name}</option>
       {/each}

--- a/source/SIL.AppBuilder.Portal/src/routes/(authenticated)/admin/settings/stores/new/+page.server.ts
+++ b/source/SIL.AppBuilder.Portal/src/routes/(authenticated)/admin/settings/stores/new/+page.server.ts
@@ -20,24 +20,18 @@ export const load = (async ({ url }) => {
 }) satisfies PageServerLoad;
 
 export const actions = {
-  async new({ cookies, request }) {
+  async new({ request }) {
     const form = await superValidate(request, valibot(createSchema));
     if (!form.valid) {
       return fail(400, { form, ok: false, errors: form.errors });
     }
-    try {
-      const { name, description, storeType } = form.data;
-      await DatabaseWrites.stores.create({
-        data: {
-          Name: name,
-          Description: description,
-          StoreTypeId: storeType
-        }
-      });
-      return { ok: true, form };
-    } catch (e) {
-      if (e instanceof v.ValiError) return { form, ok: false, errors: e.issues };
-      throw e;
-    }
+    await DatabaseWrites.stores.create({
+      data: {
+        Name: form.data.name,
+        Description: form.data.description,
+        StoreTypeId: form.data.storeType
+      }
+    });
+    return { ok: true, form };
   }
 } satisfies Actions;

--- a/source/SIL.AppBuilder.Portal/src/routes/(authenticated)/admin/settings/workflow-definitions/edit/+page.server.ts
+++ b/source/SIL.AppBuilder.Portal/src/routes/(authenticated)/admin/settings/workflow-definitions/edit/+page.server.ts
@@ -5,8 +5,8 @@ import { DatabaseWrites, prisma } from 'sil.appbuilder.portal.common';
 import { superValidate } from 'sveltekit-superforms';
 import { valibot } from 'sveltekit-superforms/adapters';
 import * as v from 'valibot';
-import type { Actions, PageServerLoad } from './$types';
 import { workflowDefinitionSchemaBase } from '../common';
+import type { Actions, PageServerLoad } from './$types';
 
 const editSchema = v.object({
   id: idSchema,
@@ -24,7 +24,7 @@ export const load = (async ({ url }) => {
   });
   if (!data) return redirect(302, base + '/admin/settings/workflow-definitions');
   const storeTypes = await prisma.storeTypes.findMany();
-  const schemes = await prisma.workflowScheme.findMany({ select: { Code: true }});
+  const schemes = await prisma.workflowScheme.findMany({ select: { Code: true } });
   const form = await superValidate(
     {
       id: data.Id,
@@ -45,46 +45,28 @@ export const load = (async ({ url }) => {
 }) satisfies PageServerLoad;
 
 export const actions = {
-  async edit({ cookies, request }) {
+  async edit({ request }) {
     const form = await superValidate(request, valibot(editSchema));
     if (!form.valid) {
       return fail(400, { form, ok: false, errors: form.errors });
     }
-    try {
-      const {
-        id,
-        name,
-        description,
-        properties,
-        enabled,
-        storeType,
-        workflowBusinessFlow,
-        workflowScheme,
-        workflowType,
-        options,
-        productType
-      } = form.data;
-      await DatabaseWrites.workflowDefinitions.update({
-        where: {
-          Id: id
-        },
-        data: {
-          Type: workflowType,
-          Name: name,
-          WorkflowScheme: workflowScheme,
-          WorkflowBusinessFlow: workflowBusinessFlow,
-          StoreTypeId: storeType,
-          Description: description,
-          Properties: properties,
-          Enabled: enabled,
-          ProductType: productType,
-          WorkflowOptions: options
-        }
-      });
-      return { ok: true, form };
-    } catch (e) {
-      if (e instanceof v.ValiError) return { form, ok: false, errors: e.issues };
-      throw e;
-    }
+    await DatabaseWrites.workflowDefinitions.update({
+      where: {
+        Id: form.data.id
+      },
+      data: {
+        Type: form.data.workflowType,
+        Name: form.data.name,
+        WorkflowScheme: form.data.workflowScheme,
+        WorkflowBusinessFlow: form.data.workflowBusinessFlow,
+        StoreTypeId: form.data.storeType,
+        Description: form.data.description,
+        Properties: form.data.properties,
+        Enabled: form.data.enabled,
+        ProductType: form.data.productType,
+        WorkflowOptions: form.data.options
+      }
+    });
+    return { ok: true, form };
   }
 } satisfies Actions;

--- a/source/SIL.AppBuilder.Portal/src/routes/(authenticated)/admin/settings/workflow-definitions/edit/+page.svelte
+++ b/source/SIL.AppBuilder.Portal/src/routes/(authenticated)/admin/settings/workflow-definitions/edit/+page.svelte
@@ -14,11 +14,7 @@
   }
 
   let { data }: Props = $props();
-  const {
-    form: superFormData,
-    enhance,
-    allErrors
-  } = superForm(data.form, {
+  const { form, enhance, allErrors } = superForm(data.form, {
     dataType: 'json',
     onUpdated(event) {
       if (event.form.valid) {
@@ -45,28 +41,19 @@
 
 <!-- <SuperDebug data={superForm} /> -->
 <form class="m-4" method="post" action="?/edit" use:enhance>
-  <input type="hidden" name="id" value={$superFormData.id} />
+  <input type="hidden" name="id" value={$form.id} />
   <LabeledFormInput name="admin_settings_workflowDefinitions_name">
-    <input
-      class="input w-full input-bordered"
-      type="text"
-      name="name"
-      bind:value={$superFormData.name}
-    />
+    <input class="input w-full input-bordered" type="text" name="name" bind:value={$form.name} />
   </LabeledFormInput>
   <LabeledFormInput name="admin_settings_workflowDefinitions_storeType">
-    <select class="select select-bordered" name="storeType" bind:value={$superFormData.storeType}>
+    <select class="select select-bordered" name="storeType" bind:value={$form.storeType}>
       {#each data.storeTypes.toSorted((a, b) => byName(a, b, languageTag())) as storeType}
         <option value={storeType.Id}>{storeType.Name}</option>
       {/each}
     </select>
   </LabeledFormInput>
   <LabeledFormInput name="admin_settings_workflowDefinitions_productType">
-    <select
-      class="select select-bordered"
-      name="productType"
-      bind:value={$superFormData.productType}
-    >
+    <select class="select select-bordered" name="productType" bind:value={$form.productType}>
       <option value={ProductType.Android_GooglePlay}>Android GooglePlay</option>
       <option value={ProductType.Android_S3}>Android S3</option>
       <option value={ProductType.AssetPackage}>
@@ -78,11 +65,7 @@
     </select>
   </LabeledFormInput>
   <LabeledFormInput name="admin_settings_workflowDefinitions_workflowType">
-    <select
-      class="select select-bordered"
-      name="workflowType"
-      bind:value={$superFormData.workflowType}
-    >
+    <select class="select select-bordered" name="workflowType" bind:value={$form.workflowType}>
       <option value={1}>{m.admin_settings_workflowDefinitions_workflowTypes_1()}</option>
       <option value={2}>{m.admin_settings_workflowDefinitions_workflowTypes_2()}</option>
       <option value={3}>{m.admin_settings_workflowDefinitions_workflowTypes_3()}</option>
@@ -92,14 +75,14 @@
     <textarea
       name="description"
       class="textarea textarea-bordered w-full"
-      bind:value={$superFormData.description}
+      bind:value={$form.description}
     ></textarea>
   </LabeledFormInput>
   <LabeledFormInput name="admin_settings_workflowDefinitions_workflowScheme">
     <select
       class="select select-bordered"
       name="workflowScheme"
-      bind:value={$superFormData.workflowScheme}
+      bind:value={$form.workflowScheme}
     >
       {#each data.schemes.toSorted((a, b) => byString(a.Code, b.Code, languageTag())) as scheme}
         <option value={scheme.Code}>{scheme.Code}</option>
@@ -110,7 +93,7 @@
     <select
       class="select select-bordered"
       name="workflowBusinessFlow"
-      bind:value={$superFormData.workflowBusinessFlow}
+      bind:value={$form.workflowBusinessFlow}
     >
       {#each businessFlows as flow}
         <option value={flow}>{flow}</option>
@@ -121,7 +104,7 @@
     <textarea
       name="properties"
       class="textarea textarea-bordered w-full"
-      bind:value={$superFormData.properties}
+      bind:value={$form.properties}
     ></textarea>
   </LabeledFormInput>
   <LabeledFormInput
@@ -138,7 +121,7 @@
         <input
           class="toggle toggle-warning border-warning"
           type="checkbox"
-          bind:group={$superFormData.options}
+          bind:group={$form.options}
           value={opt.value}
         />
       </div>
@@ -159,7 +142,7 @@
           name="enabled"
           class="toggle toggle-accent"
           type="checkbox"
-          bind:checked={$superFormData.enabled}
+          bind:checked={$form.enabled}
         />
       </div>
     </label>

--- a/source/SIL.AppBuilder.Portal/src/routes/(authenticated)/admin/settings/workflow-definitions/new/+page.server.ts
+++ b/source/SIL.AppBuilder.Portal/src/routes/(authenticated)/admin/settings/workflow-definitions/new/+page.server.ts
@@ -2,9 +2,8 @@ import { fail } from '@sveltejs/kit';
 import { DatabaseWrites, prisma } from 'sil.appbuilder.portal.common';
 import { superValidate } from 'sveltekit-superforms';
 import { valibot } from 'sveltekit-superforms/adapters';
-import * as v from 'valibot';
-import type { Actions, PageServerLoad } from './$types';
 import { workflowDefinitionSchemaBase } from '../common';
+import type { Actions, PageServerLoad } from './$types';
 
 const createSchema = workflowDefinitionSchemaBase;
 
@@ -12,49 +11,32 @@ export const load = (async ({ url }) => {
   const form = await superValidate(valibot(createSchema));
   const options = {
     storeType: await prisma.storeTypes.findMany(),
-    schemes: await prisma.workflowScheme.findMany({ select: { Code: true }})
+    schemes: await prisma.workflowScheme.findMany({ select: { Code: true } })
   };
 
   return { form, options };
 }) satisfies PageServerLoad;
 
 export const actions = {
-  async new({ cookies, request }) {
+  async new({ request }) {
     const form = await superValidate(request, valibot(createSchema));
     if (!form.valid) {
       return fail(400, { form, ok: false, errors: form.errors });
     }
-    try {
-      const {
-        name,
-        description,
-        properties,
-        enabled,
-        storeType,
-        workflowBusinessFlow,
-        workflowScheme,
-        workflowType,
-        productType,
-        options
-      } = form.data;
-      await DatabaseWrites.workflowDefinitions.create({
-        data: {
-          Name: name,
-          Description: description,
-          Properties: properties,
-          Enabled: enabled,
-          StoreTypeId: storeType,
-          WorkflowBusinessFlow: workflowBusinessFlow,
-          WorkflowScheme: workflowScheme,
-          Type: workflowType,
-          ProductType: productType,
-          WorkflowOptions: options
-        }
-      });
-      return { ok: true, form };
-    } catch (e) {
-      if (e instanceof v.ValiError) return { form, ok: false, errors: e.issues };
-      throw e;
-    }
+    await DatabaseWrites.workflowDefinitions.create({
+      data: {
+        Name: form.data.name,
+        Description: form.data.description,
+        Properties: form.data.properties,
+        Enabled: form.data.enabled,
+        StoreTypeId: form.data.storeType,
+        WorkflowBusinessFlow: form.data.workflowBusinessFlow,
+        WorkflowScheme: form.data.workflowScheme,
+        Type: form.data.workflowType,
+        ProductType: form.data.productType,
+        WorkflowOptions: form.data.options
+      }
+    });
+    return { ok: true, form };
   }
 } satisfies Actions;

--- a/source/SIL.AppBuilder.Portal/src/routes/(authenticated)/organizations/[id]/settings/groups/+page.server.ts
+++ b/source/SIL.AppBuilder.Portal/src/routes/(authenticated)/organizations/[id]/settings/groups/+page.server.ts
@@ -35,24 +35,12 @@ export const actions = {
   async addGroup(event) {
     const form = await superValidate(event.request, valibot(addGroupSchema));
     if (!form.valid) return fail(400, { form, ok: false, errors: form.errors });
-    try {
-      const { id, name, abbreviation } = form.data;
-      await DatabaseWrites.groups.createGroup(name, abbreviation, id);
-      return { form, ok: true };
-    } catch (e) {
-      if (e instanceof v.ValiError) return { form, ok: false, errors: e.issues };
-      throw e;
-    }
+    await DatabaseWrites.groups.createGroup(form.data.name, form.data.abbreviation, form.data.id);
+    return { form, ok: true };
   },
   async deleteGroup(event) {
     const form = await superValidate(event.request, valibot(deleteGroupSchema));
     if (!form.valid) return fail(400, { form, ok: false, errors: form.errors });
-    try {
-      const { id } = form.data;
-      return { form, ok: await DatabaseWrites.groups.deleteGroup(id) };
-    } catch (e) {
-      if (e instanceof v.ValiError) return { form, ok: false, errors: e.issues };
-      throw e;
-    }
+    return { form, ok: await DatabaseWrites.groups.deleteGroup(form.data.id) };
   }
 } satisfies Actions;

--- a/source/SIL.AppBuilder.Portal/src/routes/(authenticated)/organizations/[id]/settings/groups/+page.svelte
+++ b/source/SIL.AppBuilder.Portal/src/routes/(authenticated)/organizations/[id]/settings/groups/+page.svelte
@@ -11,7 +11,6 @@
   }
 
   let { data }: Props = $props();
-  // export let form: ActionData;
   const { form: addForm, enhance: addEnhance, allErrors } = superForm(data.addForm);
   const { form: deleteForm, enhance: deleteEnhance } = superForm(data.deleteForm);
 </script>

--- a/source/SIL.AppBuilder.Portal/src/routes/(authenticated)/organizations/[id]/settings/info/+page.server.ts
+++ b/source/SIL.AppBuilder.Portal/src/routes/(authenticated)/organizations/[id]/settings/info/+page.server.ts
@@ -35,22 +35,15 @@ export const actions = {
   async default(event) {
     const form = await superValidate(event.request, valibot(editInfoSchema));
     if (!form.valid) return fail(400, { form, ok: false, errors: form.errors });
-    try {
-      const { id, name, logoUrl } = form.data;
-      await DatabaseWrites.organizations.update({
-        where: {
-          Id: id
-        },
-        data: {
-          Name: name,
-          LogoUrl: logoUrl
-        }
-      });
-      return { form, ok: true };
-    } catch (e) {
-      if (e instanceof v.ValiError) return { form, ok: false, errors: e.issues };
-      throw e;
-    }
+    await DatabaseWrites.organizations.update({
+      where: {
+        Id: form.data.id
+      },
+      data: {
+        Name: form.data.name,
+        LogoUrl: form.data.logoUrl
+      }
+    });
     return { form, ok: true };
   }
 } satisfies Actions;

--- a/source/SIL.AppBuilder.Portal/src/routes/(authenticated)/organizations/[id]/settings/info/+page.svelte
+++ b/source/SIL.AppBuilder.Portal/src/routes/(authenticated)/organizations/[id]/settings/info/+page.svelte
@@ -9,12 +9,11 @@
   }
 
   let { data }: Props = $props();
-  // export let form: ActionData;
-  const { form: superFormData, enhance, allErrors } = superForm(data.form, { resetForm: false });
+  const { form, enhance, allErrors } = superForm(data.form, { resetForm: false });
 </script>
 
 <form action="" class="m-4" method="post" use:enhance>
-  <input type="hidden" name="id" value={$superFormData.id} />
+  <input type="hidden" name="id" value={$form.id} />
   <div class="flex flex-row">
     <div>
       <LabeledFormInput name="org_orgName">
@@ -22,7 +21,7 @@
           type="text"
           name="name"
           class="input w-full input-bordered"
-          bind:value={$superFormData.name}
+          bind:value={$form.name}
         />
       </LabeledFormInput>
       <LabeledFormInput name="org_logoUrl">
@@ -30,13 +29,13 @@
           type="text"
           name="logoUrl"
           class="input w-full input-bordered"
-          bind:value={$superFormData.logoUrl}
+          bind:value={$form.logoUrl}
         />
         <span>{org_noteLogUrl()}</span>
       </LabeledFormInput>
     </div>
     <div class="w-1/3 ml-4">
-      <img src={$superFormData.logoUrl} alt="Logo" class="object-contain" />
+      <img src={$form.logoUrl} alt="Logo" class="object-contain" />
     </div>
   </div>
   <div class="my-4">

--- a/source/SIL.AppBuilder.Portal/src/routes/(authenticated)/organizations/[id]/settings/infrastructure/+page.server.ts
+++ b/source/SIL.AppBuilder.Portal/src/routes/(authenticated)/organizations/[id]/settings/infrastructure/+page.server.ts
@@ -37,22 +37,16 @@ export const actions = {
   async default(event) {
     const form = await superValidate(event.request, valibot(infrastructureSchema));
     if (!form.valid) return fail(400, { form, ok: false, errors: form.errors });
-    try {
-      const { id, buildEngineApiAccessToken, buildEngineUrl, useDefaultBuildEngine } = form.data;
-      await DatabaseWrites.organizations.update({
-        where: {
-          Id: id
-        },
-        data: {
-          BuildEngineApiAccessToken: buildEngineApiAccessToken,
-          BuildEngineUrl: buildEngineUrl,
-          UseDefaultBuildEngine: useDefaultBuildEngine
-        }
-      });
-      return { form, ok: true };
-    } catch (e) {
-      if (e instanceof v.ValiError) return { form, ok: false, errors: e.issues };
-      throw e;
-    }
+    await DatabaseWrites.organizations.update({
+      where: {
+        Id: form.data.id
+      },
+      data: {
+        BuildEngineApiAccessToken: form.data.buildEngineApiAccessToken,
+        BuildEngineUrl: form.data.buildEngineUrl,
+        UseDefaultBuildEngine: form.data.useDefaultBuildEngine
+      }
+    });
+    return { form, ok: true };
   }
 } satisfies Actions;

--- a/source/SIL.AppBuilder.Portal/src/routes/(authenticated)/organizations/[id]/settings/infrastructure/+page.svelte
+++ b/source/SIL.AppBuilder.Portal/src/routes/(authenticated)/organizations/[id]/settings/infrastructure/+page.svelte
@@ -9,11 +9,11 @@
   }
 
   let { data }: Props = $props();
-  const { form: superFormData, enhance, allErrors } = superForm(data.form, { resetForm: false });
+  const { form, enhance, allErrors } = superForm(data.form, { resetForm: false });
 </script>
 
 <form action="" class="m-4" method="post" use:enhance>
-  <input type="hidden" name="id" value={$superFormData.id} />
+  <input type="hidden" name="id" value={$form.id} />
   <div class="flex flex-row">
     <div class="w-full">
       <div>
@@ -28,18 +28,18 @@
               name="useDefaultBuildEngine"
               class="toggle toggle-accent"
               type="checkbox"
-              bind:checked={$superFormData.useDefaultBuildEngine}
+              bind:checked={$form.useDefaultBuildEngine}
             />
           </div>
         </label>
       </div>
-      {#if !$superFormData.useDefaultBuildEngine}
+      {#if !$form.useDefaultBuildEngine}
         <LabeledFormInput name="org_buildEngineUrl">
           <input
             type="text"
             name="buildEngineUrl"
             class="input w-full input-bordered"
-            bind:value={$superFormData.buildEngineUrl}
+            bind:value={$form.buildEngineUrl}
           />
         </LabeledFormInput>
         <LabeledFormInput name="org_buildEngineApiAccessToken">
@@ -47,7 +47,7 @@
             type="text"
             name="buildEngineApiAccessToken"
             class="input w-full input-bordered"
-            bind:value={$superFormData.buildEngineApiAccessToken}
+            bind:value={$form.buildEngineApiAccessToken}
           />
         </LabeledFormInput>
       {/if}

--- a/source/SIL.AppBuilder.Portal/src/routes/(authenticated)/organizations/[id]/settings/products/+page.server.ts
+++ b/source/SIL.AppBuilder.Portal/src/routes/(authenticated)/organizations/[id]/settings/products/+page.server.ts
@@ -53,24 +53,18 @@ export const actions = {
   async default(event) {
     const form = await superValidate(event.request, valibot(editProductsSchema));
     if (!form.valid) return fail(400, { form, ok: false, errors: form.errors });
-    try {
-      const { id, publicByDefault, products } = form.data;
-      await DatabaseWrites.organizationProductDefinitions.updateOrganizationProductDefinitions(
-        id,
-        products.filter((p) => p.enabled).map((p) => p.productId)
-      );
-      await DatabaseWrites.organizations.update({
-        where: {
-          Id: id
-        },
-        data: {
-          PublicByDefault: publicByDefault // TODO: what are we doing with this? Should projects be
-        }
-      });
-      return { ok: true, form };
-    } catch (e) {
-      if (e instanceof v.ValiError) return { form, ok: false, errors: e.issues };
-      throw e;
-    }
+    await DatabaseWrites.organizationProductDefinitions.updateOrganizationProductDefinitions(
+      form.data.id,
+      form.data.products.filter((p) => p.enabled).map((p) => p.productId)
+    );
+    await DatabaseWrites.organizations.update({
+      where: {
+        Id: form.data.id
+      },
+      data: {
+        PublicByDefault: form.data.publicByDefault // TODO: what are we doing with this?
+      }
+    });
+    return { ok: true, form };
   }
 } satisfies Actions;

--- a/source/SIL.AppBuilder.Portal/src/routes/(authenticated)/organizations/[id]/settings/products/+page.svelte
+++ b/source/SIL.AppBuilder.Portal/src/routes/(authenticated)/organizations/[id]/settings/products/+page.svelte
@@ -10,11 +10,7 @@
 
   let { data }: Props = $props();
 
-  const {
-    form: superFormData,
-    enhance,
-    allErrors
-  } = superForm(data.form, {
+  const { form, enhance, allErrors } = superForm(data.form, {
     dataType: 'json',
     resetForm: false
   });
@@ -39,14 +35,14 @@
           name="publicByDefault"
           class="toggle toggle-accent"
           type="checkbox"
-          bind:checked={$superFormData.publicByDefault}
+          bind:checked={$form.publicByDefault}
         />
       </div>
     </label>
   </div>
   <!-- TODO: sort this. I think this will need a refactor of MultiselectBox -->
   <MultiselectBox header={m.org_productSelectTitle()}>
-    {#each $superFormData.products as productDef}
+    {#each $form.products as productDef}
       {@const pdLook = allProductDefs.get(productDef.productId)}
       <MultiselectBoxElement
         title={pdLook?.Name ?? ''}

--- a/source/SIL.AppBuilder.Portal/src/routes/(authenticated)/organizations/[id]/settings/stores/+page.server.ts
+++ b/source/SIL.AppBuilder.Portal/src/routes/(authenticated)/organizations/[id]/settings/stores/+page.server.ts
@@ -49,16 +49,10 @@ export const actions = {
   async default(event) {
     const form = await superValidate(event.request, valibot(editStoresSchema));
     if (!form.valid) return fail(400, { form, ok: false, errors: form.errors });
-    try {
-      const { id, stores } = form.data;
-      await DatabaseWrites.organizationStores.updateOrganizationStores(
-        id,
-        stores.filter((s) => s.enabled).map((s) => s.storeId)
-      );
-      return { ok: true, form };
-    } catch (e) {
-      if (e instanceof v.ValiError) return { form, ok: false, errors: e.issues };
-      throw e;
-    }
+    await DatabaseWrites.organizationStores.updateOrganizationStores(
+      form.data.id,
+      form.data.stores.filter((s) => s.enabled).map((s) => s.storeId)
+    );
+    return { ok: true, form };
   }
 } satisfies Actions;

--- a/source/SIL.AppBuilder.Portal/src/routes/(authenticated)/organizations/[id]/settings/stores/+page.svelte
+++ b/source/SIL.AppBuilder.Portal/src/routes/(authenticated)/organizations/[id]/settings/stores/+page.svelte
@@ -10,11 +10,7 @@
 
   let { data }: Props = $props();
 
-  const {
-    form: superFormData,
-    enhance,
-    allErrors
-  } = superForm(data.form, {
+  const { form, enhance, allErrors } = superForm(data.form, {
     dataType: 'json',
     resetForm: false
   });
@@ -27,7 +23,7 @@
   <!-- TODO: sort this. I think this will need a refactor of MultiselectBox -->
   <MultiselectBox header={m.org_storeSelectTitle()}>
     <div>
-      {#each $superFormData.stores as store}
+      {#each $form.stores as store}
         {@const storeLook = allStores.get(store.storeId)}
         <MultiselectBoxElement
           title={storeLook?.Name ?? ''}

--- a/source/SIL.AppBuilder.Portal/src/routes/(authenticated)/users/invite/+page.server.ts
+++ b/source/SIL.AppBuilder.Portal/src/routes/(authenticated)/users/invite/+page.server.ts
@@ -48,22 +48,17 @@ export const actions = {
     }
     const user = await locals.auth();
     if (!user || !isAdminForOrg(form.data.organizationId, user.user.roles)) return fail(401);
-    try {
-      const { email, organizationId, roles, groups } = form.data;
-      const inviteToken = await DatabaseWrites.organizationMemberships.createOrganizationInvite(
-        email,
-        organizationId,
-        user.user.userId,
-        roles,
-        groups
-      );
-      const inviteLink = `${url.origin}/invitations/organization-membership?t=${inviteToken}`;
-      // TODO: send email- log instead
-      console.log(inviteLink, email);
-      return { ok: true, form };
-    } catch (e) {
-      if (e instanceof v.ValiError) return { form, ok: false, errors: e.issues };
-      throw e;
-    }
+    const { email, organizationId, roles, groups } = form.data;
+    const inviteToken = await DatabaseWrites.organizationMemberships.createOrganizationInvite(
+      email,
+      organizationId,
+      user.user.userId,
+      roles,
+      groups
+    );
+    const inviteLink = `${url.origin}/invitations/organization-membership?t=${inviteToken}`;
+    // TODO: send email- log instead
+    console.log(inviteLink, email);
+    return { ok: true, form };
   }
 } satisfies Actions;


### PR DESCRIPTION
Several of the server side form submission handlers were wrapped in a try-catch that was looking for `ValiError`s. None of the functions in any of those handlers will ever throw a `ValiError`.

I also shortened the variable name `superFormData` to `form` in several locations. (this is an artifact from when we used the `form` variable from sveltekit to trigger a redirect. I changed that in Svelte 5 to instead be triggered in the client-side form handler method).