### PR TITLE
Refactor SortTable to use Generics

### DIFF
--- a/source/SIL.AppBuilder.Portal/src/lib/components/SortTable.svelte
+++ b/source/SIL.AppBuilder.Portal/src/lib/components/SortTable.svelte
@@ -2,12 +2,12 @@
   A table that can be sorted by column.
   @component
 -->
-<script lang="ts" generics="T extends Record<string, unknown>">
+<script lang="ts" generics="RowItem extends Record<string, unknown>">
   import { ArrowDownIcon, ArrowUpIcon } from '$lib/icons';
   import type { Snippet } from 'svelte';
 
   interface Props {
-    data: T[];
+    data: RowItem[];
     /** Definition of the columns for the table */
     columns: {
       /** Internal id, used for determining which column is being sorted. Also dispatched to `onSort` */
@@ -18,13 +18,13 @@
        *
        * If `serverSide` is `true`, just use a dummy function like `() => 0`
        */
-      compare?: (a: T, b: T) => number;
+      compare?: (a: RowItem, b: RowItem) => number;
     }[];
     class?: string;
     /** If this is true, will defer sorting to the server instead */
     serverSide?: boolean;
     onSort?: (field: string, direction: 'asc' | 'desc') => void;
-    row: Snippet<[T]>;
+    row: Snippet<[RowItem]>;
   }
 
   let {

--- a/source/SIL.AppBuilder.Portal/src/lib/components/SortTable.svelte
+++ b/source/SIL.AppBuilder.Portal/src/lib/components/SortTable.svelte
@@ -20,7 +20,7 @@
        */
       compare?: (a: RowItem, b: RowItem) => number;
     }[];
-    class?: string;
+    className?: string;
     /** If this is true, will defer sorting to the server instead */
     serverSide?: boolean;
     onSort?: (field: string, direction: 'asc' | 'desc') => void;
@@ -30,7 +30,7 @@
   let {
     data = $bindable(),
     columns,
-    class: className = '',
+    className = '',
     serverSide = false,
     onSort,
     row

--- a/source/SIL.AppBuilder.Portal/src/lib/components/SortTable.svelte
+++ b/source/SIL.AppBuilder.Portal/src/lib/components/SortTable.svelte
@@ -35,12 +35,10 @@
     row
   }: Props = $props();
 
-  function firstSortable() {
-    return columns.find((c) => c.compare !== undefined)!;
-  }
+  let firstSortable = $derived(columns.find((c) => c.compare !== undefined)!)
 
-  /** Current field being sorted. Defaults to first field where `sortable === true` */
-  let current = $state(firstSortable());
+  /** Current field being sorted. Defaults to first field that can be sorted */
+  let current = $state(columns.find((c) => c.compare !== undefined)!);
   let descending = $state(false);
 
   function sortColByDirection(key: (typeof columns)[0]) {
@@ -51,8 +49,8 @@
     } else {
       if (descending) {
         // reset to sort default field
-        if (current.id !== firstSortable().id) {
-          sortColByDirection(firstSortable());
+        if (current.id !== firstSortable.id) {
+          sortColByDirection(firstSortable);
           return; //don't sort twice
         } else {
           descending = false;
@@ -66,7 +64,7 @@
     } else {
       // sort based on current field
       // if blank, sort first field
-      const compare = current.compare || firstSortable().compare;
+      const compare = current.compare || firstSortable.compare;
       data = data.sort((a, b) => {
         return descending ? (compare?.(b, a) ?? 0) : (compare?.(a, b) ?? 0);
       });

--- a/source/SIL.AppBuilder.Portal/src/lib/components/SortTable.svelte
+++ b/source/SIL.AppBuilder.Portal/src/lib/components/SortTable.svelte
@@ -4,7 +4,8 @@
 -->
 <script lang="ts" generics="T extends Record<string, unknown>">
   import { ArrowDownIcon, ArrowUpIcon } from '$lib/icons';
-  
+  import type { Snippet } from 'svelte';
+
   interface Props {
     data: T[];
     /** Definition of the columns for the table */
@@ -14,7 +15,7 @@
       /** User-facing string for column headers */
       header: string;
       /** comparison function. Will not sort a field if this is undefined, even if `serverSide` is `true`.
-       * 
+       *
        * If `serverSide` is `true`, just use a dummy function like `() => 0`
        */
       compare?: (a: T, b: T) => number;
@@ -23,7 +24,7 @@
     /** If this is true, will defer sorting to the server instead */
     serverSide?: boolean;
     onSort?: (field: string, direction: 'asc' | 'desc') => void;
-    row: import('svelte').Snippet<[T]>;
+    row: Snippet<[T]>;
   }
 
   let {
@@ -35,7 +36,7 @@
     row
   }: Props = $props();
 
-  let firstSortable = $derived(columns.find((c) => c.compare !== undefined)!)
+  let firstSortable = $derived(columns.find((c) => c.compare !== undefined)!);
 
   /** Current field being sorted. Defaults to first field that can be sorted */
   let current = $state(columns.find((c) => c.compare !== undefined)!);

--- a/source/SIL.AppBuilder.Portal/src/lib/components/SortTable.svelte
+++ b/source/SIL.AppBuilder.Portal/src/lib/components/SortTable.svelte
@@ -2,49 +2,42 @@
   A table that can be sorted by column.
   @component
 -->
-<script lang="ts">
+<script lang="ts" generics="T extends Record<string, unknown>">
   import { ArrowDownIcon, ArrowUpIcon } from '$lib/icons';
-  import { languageTag } from '$lib/paraglide/runtime';
-
+  
   interface Props {
-    data: Record<string, any>[];
+    data: T[];
     /** Definition of the columns for the table */
     columns: {
       /** Internal id, used for determining which column is being sorted */
       id: string;
       /** User-facing string for column headers */
       header: string;
-      /** Accessor method to get the desired data */
-      data: (i: any) => any;
-      /** Renders the data to an HTML string */
-      render?: (d: any) => string;
-      /** Will not sort a field if this is false or undefined */
-      sortable?: boolean;
+      /** Accessor method to get the desired data, will not sort a field if this is undefined */
+      compare?: (a: T, b: T) => number;
     }[];
-    className: string;
+    class: string;
     /** If this is true, will defer sorting to the server instead */
     serverSide?: boolean;
-    /** If this is defined, will handle a click on a row */
-    onRowClick?: (
-      rowData: (typeof data)[0],
-      event: MouseEvent & {
-        currentTarget: EventTarget & HTMLTableRowElement;
-      }
-    ) => void;
     onSort?: (field: string, direction: 'asc' | 'desc') => void;
+    row: import('svelte').Snippet<[T]>;
   }
 
   let {
     data = $bindable(),
     columns,
-    className = '',
+    class: className = '',
     serverSide = false,
-    onRowClick,
-    onSort
+    onSort,
+    row
   }: Props = $props();
 
+  function firstSortable() {
+    return columns.find((c) => c.compare !== undefined)!;
+  }
+
   /** Current field being sorted. Defaults to first field where `sortable === true` */
-  let current = $state(columns.find((c) => c.sortable)!);
+  let current = $state(firstSortable());
   let descending = $state(false);
 
   function sortColByDirection(key: (typeof columns)[0]) {
@@ -55,8 +48,8 @@
     } else {
       if (descending) {
         // reset to sort default field
-        if (current.id !== columns.find((c) => c.sortable)!.id) {
-          sortColByDirection(columns.find((c) => c.sortable)!);
+        if (current.id !== firstSortable().id) {
+          sortColByDirection(firstSortable());
           return; //don't sort twice
         } else {
           descending = false;
@@ -70,26 +63,10 @@
     } else {
       // sort based on current field
       // if blank, sort first field
-      const cell = current.data || columns.find((c) => c.sortable)!.data;
-      const langTag = languageTag();
-      data =
-        typeof cell(data[0]) === 'string'
-          ? // sort strings
-            data.sort((a, b) => {
-              return descending
-                ? cell(b).localeCompare(cell(a), langTag)
-                : cell(a).localeCompare(cell(b), langTag);
-            })
-          : // sort non-strings (i.e. numbers)
-            data.sort((a, b) => {
-              if (cell(a) === cell(b)) {
-                return 0;
-              } else if (cell(a) > cell(b)) {
-                return descending ? -1 : 1;
-              } else {
-                return descending ? 1 : -1;
-              }
-            });
+      const compare = current.compare || firstSortable().compare;
+      data = data.sort((a, b) => {
+        return descending ? (compare?.(b, a) ?? 0) : (compare?.(a, b) ?? 0);
+      });
     }
   }
 </script>
@@ -101,7 +78,7 @@
         {#each columns as c}
           <th
             onclick={() => {
-              if (c.sortable) {
+              if (c.compare) {
                 sortColByDirection(c);
               }
             }}
@@ -110,7 +87,7 @@
             <label class="form-control flex-row">
               <span class="label-text">{c.header}</span>
               <span class="direction-arrow">
-                {#if current.id === c.id && c.sortable}
+                {#if current.id === c.id && c.compare}
                   {#if descending}
                     <ArrowDownIcon />
                   {:else}
@@ -127,21 +104,7 @@
     </thead>
     <tbody>
       {#each data as d}
-        <tr
-          onclick={(e) => {
-            onRowClick?.(d, e);
-          }}
-        >
-          {#each columns as c}
-            <td>
-              {#if c.render}
-                {@html c.render(c.data(d))}
-              {:else}
-                {c.data(d)}
-              {/if}
-            </td>
-          {/each}
-        </tr>
+        {@render row(d)}
       {/each}
     </tbody>
   </table>
@@ -150,9 +113,6 @@
 <style lang="postcss">
   tr {
     @apply cursor-pointer select-none;
-  }
-  tbody > tr:hover {
-    @apply bg-neutral;
   }
   thead {
     /* this helps prevent the vertical jankiness */
@@ -170,8 +130,7 @@
   label {
     @apply select-none cursor-pointer;
   }
-  th,
-  td {
+  th {
     @apply border;
   }
 </style>

--- a/source/SIL.AppBuilder.Portal/src/lib/components/SortTable.svelte
+++ b/source/SIL.AppBuilder.Portal/src/lib/components/SortTable.svelte
@@ -9,14 +9,17 @@
     data: T[];
     /** Definition of the columns for the table */
     columns: {
-      /** Internal id, used for determining which column is being sorted */
+      /** Internal id, used for determining which column is being sorted. Also dispatched to `onSort` */
       id: string;
       /** User-facing string for column headers */
       header: string;
-      /** Accessor method to get the desired data, will not sort a field if this is undefined */
+      /** comparison function. Will not sort a field if this is undefined, even if `serverSide` is `true`.
+       * 
+       * If `serverSide` is `true`, just use a dummy function like `() => 0`
+       */
       compare?: (a: T, b: T) => number;
     }[];
-    class: string;
+    class?: string;
     /** If this is true, will defer sorting to the server instead */
     serverSide?: boolean;
     onSort?: (field: string, direction: 'asc' | 'desc') => void;

--- a/source/SIL.AppBuilder.Portal/src/routes/(authenticated)/tasks/[product_id]/+page.svelte
+++ b/source/SIL.AppBuilder.Portal/src/routes/(authenticated)/tasks/[product_id]/+page.svelte
@@ -2,7 +2,8 @@
   import IconContainer from '$lib/components/IconContainer.svelte';
   import SortTable from '$lib/components/SortTable.svelte';
   import * as m from '$lib/paraglide/messages';
-  import { bytesToHumanSize } from '$lib/utils';
+  import { languageTag } from '$lib/paraglide/runtime';
+  import { byName, byNumber, byString, bytesToHumanSize } from '$lib/utils';
   import { superForm } from 'sveltekit-superforms';
   import type { PageData } from './$types';
   import { instructions } from './instructions';
@@ -217,59 +218,83 @@
     </div>
   {/if}
   {#if data?.files?.length}
+    {@const langTag = languageTag()}
     <h3>{m.products_files_title()}</h3>
     <div class="w-full overflow-x-auto">
       <SortTable
-        className="max-h-96"
+        class="max-h-96"
         data={data.files}
         columns={[
           {
             id: 'artifactType',
             header: m.project_type(),
-            data: (f) => f.ArtifactType,
-            sortable: true
+            compare: (a, b) => byString(a.ArtifactType, b.ArtifactType, langTag)
           },
           {
             id: 'fileSize',
             header: m.project_products_size(),
-            data: (f) => f.FileSize,
-            render: (s) => bytesToHumanSize(s),
-            sortable: true
+            compare: (a, b) => byNumber(a.FileSize, b.FileSize)
           },
           {
             id: 'url',
-            header: m.tasks_files_link(),
-            data: (f) => f.Url,
-            render: (u) => `<a class="link" href="${u}" target="_blank">${u}</a>`
+            header: m.tasks_files_link()
           }
         ]}
-        onRowClick={(data) => {
-          window.open(data.Url, '_blank')?.focus();
-        }}
-      />
+      >
+        {#snippet row(r: (typeof data.files)[0])}
+          <tr
+            class="cursor-pointer hover:bg-neutral"
+            onclick={() => {
+              if (r.Url) {
+                window.open(r.Url, '_blank')?.focus();
+              }
+            }}
+          >
+            <td class="border">
+              {r.ArtifactType}
+            </td>
+            <td class="border">
+              {bytesToHumanSize(r.FileSize)}
+            </td>
+            <td class="border">
+              <a class="link" href={r.Url} target="_blank">{r.Url}</a>
+            </td>
+          </tr>
+        {/snippet}
+      </SortTable>
     </div>
   {/if}
   {#if data?.reviewers?.length}
+    {@const langTag = languageTag()}
     <h3>{m.project_side_reviewers_title()}</h3>
     <div class="w-full overflow-x-auto">
       <SortTable
-        className="max-h-96"
+        class="max-h-96"
         data={data.reviewers}
         columns={[
           {
             id: 'name',
             header: m.common_name(),
-            data: (r) => r.Name,
-            sortable: true
+            compare: (a, b) => byName(a, b, langTag)
           },
           {
             id: 'email',
             header: m.profile_email(),
-            data: (r) => r.Email,
-            sortable: true
+            compare: (a, b) => byString(a.Email, b.Email, langTag)
           }
         ]}
-      />
+      >
+        {#snippet row(r: (typeof data.reviewers)[0])}
+          <tr class="cursor-pointer hover:bg-neutral">
+            <td class="border">
+              {r.Name}
+            </td>
+            <td class="border">
+              {r.Email}
+            </td>
+          </tr>
+        {/snippet}
+      </SortTable>
     </div>
   {/if}
 </div>

--- a/source/SIL.AppBuilder.Portal/src/routes/(authenticated)/tasks/[product_id]/+page.svelte
+++ b/source/SIL.AppBuilder.Portal/src/routes/(authenticated)/tasks/[product_id]/+page.svelte
@@ -241,23 +241,23 @@
           }
         ]}
       >
-        {#snippet row(r: (typeof data.files)[0])}
+        {#snippet row(file)}
           <tr
             class="cursor-pointer hover:bg-neutral"
             onclick={() => {
-              if (r.Url) {
-                window.open(r.Url, '_blank')?.focus();
+              if (file.Url) {
+                window.open(file.Url, '_blank')?.focus();
               }
             }}
           >
             <td class="border">
-              {r.ArtifactType}
+              {file.ArtifactType}
             </td>
             <td class="border">
-              {bytesToHumanSize(r.FileSize)}
+              {bytesToHumanSize(file.FileSize)}
             </td>
             <td class="border">
-              <a class="link" href={r.Url} target="_blank">{r.Url}</a>
+              <a class="link" href={file.Url} target="_blank">{file.Url}</a>
             </td>
           </tr>
         {/snippet}
@@ -284,13 +284,13 @@
           }
         ]}
       >
-        {#snippet row(r: (typeof data.reviewers)[0])}
+        {#snippet row(reviewer)}
           <tr class="cursor-pointer hover:bg-neutral">
             <td class="border">
-              {r.Name}
+              {reviewer.Name}
             </td>
             <td class="border">
-              {r.Email}
+              {reviewer.Email}
             </td>
           </tr>
         {/snippet}

--- a/source/SIL.AppBuilder.Portal/src/routes/(authenticated)/tasks/[product_id]/+page.svelte
+++ b/source/SIL.AppBuilder.Portal/src/routes/(authenticated)/tasks/[product_id]/+page.svelte
@@ -222,7 +222,7 @@
     <h3>{m.products_files_title()}</h3>
     <div class="w-full overflow-x-auto">
       <SortTable
-        class="max-h-96"
+        className="max-h-96"
         data={data.files}
         columns={[
           {
@@ -269,7 +269,7 @@
     <h3>{m.project_side_reviewers_title()}</h3>
     <div class="w-full overflow-x-auto">
       <SortTable
-        class="max-h-96"
+        className="max-h-96"
         data={data.reviewers}
         columns={[
           {

--- a/source/SIL.AppBuilder.Portal/src/routes/(authenticated)/workflow-instances/+page.server.ts
+++ b/source/SIL.AppBuilder.Portal/src/routes/(authenticated)/workflow-instances/+page.server.ts
@@ -141,19 +141,17 @@ export const actions: Actions = {
 
     const instances = await prisma.workflowInstances.findMany({
       orderBy:
-        form.data.sort?.field === 'product'
-          ? { ProductId: form.data.sort.direction }
-          : form.data.sort?.field === 'organization'
-            ? { Product: { Project: { Organization: { Name: form.data.sort.direction } } } }
-            : form.data.sort?.field === 'project'
-              ? { Product: { Project: { Name: form.data.sort.direction } } }
-              : form.data.sort?.field === 'definition'
-                ? { Product: { ProductDefinition: { Name: form.data.sort.direction } } }
-                : form.data.sort?.field === 'state'
-                  ? { State: form.data.sort.direction }
-                  : form.data.sort?.field === 'date'
-                    ? { DateUpdated: form.data.sort.direction }
-                    : undefined,
+        form.data.sort?.field === 'organization'
+          ? { Product: { Project: { Organization: { Name: form.data.sort.direction } } } }
+          : form.data.sort?.field === 'project'
+            ? { Product: { Project: { Name: form.data.sort.direction } } }
+            : form.data.sort?.field === 'definition'
+              ? { Product: { ProductDefinition: { Name: form.data.sort.direction } } }
+              : form.data.sort?.field === 'state'
+                ? { State: form.data.sort.direction }
+                : form.data.sort?.field === 'date'
+                  ? { DateUpdated: form.data.sort.direction }
+                  : undefined,
       where: where,
       select: {
         State: true,

--- a/source/SIL.AppBuilder.Portal/src/routes/(authenticated)/workflow-instances/+page.svelte
+++ b/source/SIL.AppBuilder.Portal/src/routes/(authenticated)/workflow-instances/+page.svelte
@@ -4,6 +4,7 @@
   import Pagination from '$lib/components/Pagination.svelte';
   import SearchBar from '$lib/components/SearchBar.svelte';
   import SortTable from '$lib/components/SortTable.svelte';
+  import Tooltip from '$lib/components/Tooltip.svelte';
   import * as m from '$lib/paraglide/messages';
   import { languageTag } from '$lib/paraglide/runtime';
   import { getRelativeTime } from '$lib/timeUtils';
@@ -11,7 +12,6 @@
   import type { FormResult } from 'sveltekit-superforms';
   import { superForm } from 'sveltekit-superforms';
   import type { PageData } from './$types';
-  import Tooltip from '$lib/components/Tooltip.svelte';
 
   interface Props {
     data: PageData;
@@ -63,7 +63,7 @@
       <div
         class="flex flex-row flex-wrap md:flex-nowrap place-content-end items-center gap-1 {mobileSizing}"
       >
-        <OrganizationDropdown 
+        <OrganizationDropdown
           className={mobileSizing}
           organizations={data.organizations}
           allowNull={true}
@@ -123,25 +123,28 @@
         onSort={(field, direction) =>
           form.update((data) => ({ ...data, sort: { field, direction } }))}
       >
-        {#snippet row(r: (typeof instances)[0])}
+        {#snippet row(instance)}
+          {@const project = instance.Product.Project}
+          {@const org = project.Organization}
+          {@const prodDef = instance.Product.ProductDefinition}
           <tr class="cursor-pointer hover:bg-neutral">
             <td class="border">
-              <a class="link" href="/projects/organization/{r.Product.Project.Organization.Id}">
-                {r.Product.Project.Organization.Name}
+              <a class="link" href="/projects/organization/{org.Id}">
+                {org.Name}
               </a>
             </td>
             <td class="border">
-              <a class="link" href="/projects/{r.Product.Project.Id}">{r.Product.Project.Name}</a>
+              <a class="link" href="/projects/{project.Id}">{project.Name}</a>
             </td>
             <td class="border">
-              <a class="link" href="/workflow-instances/{r.Product.Id}">
-                {r.Product.ProductDefinition.Name}
+              <a class="link" href="/workflow-instances/{instance.Product.Id}">
+                {prodDef.Name}
               </a>
             </td>
-            <td class="border">{r.State}</td>
+            <td class="border">{instance.State}</td>
             <td class="border">
-              <Tooltip className="text-left" tip={r.DateUpdated?.toLocaleString(langTag)}>
-                {getRelativeTime(r.DateUpdated)}
+              <Tooltip className="text-left" tip={instance.DateUpdated?.toLocaleString(langTag)}>
+                {getRelativeTime(instance.DateUpdated)}
               </Tooltip>
             </td>
           </tr>

--- a/source/SIL.AppBuilder.Portal/src/routes/(authenticated)/workflow-instances/+page.svelte
+++ b/source/SIL.AppBuilder.Portal/src/routes/(authenticated)/workflow-instances/+page.svelte
@@ -11,6 +11,7 @@
   import type { FormResult } from 'sveltekit-superforms';
   import { superForm } from 'sveltekit-superforms';
   import type { PageData } from './$types';
+  import Tooltip from '$lib/components/Tooltip.svelte';
 
   interface Props {
     data: PageData;
@@ -86,6 +87,7 @@
   </form>
   <div class="m-4 relative mt-1 w-full overflow-x-auto">
     {#if instances.length > 0}
+      {@const langTag = languageTag()}
       <SortTable
         data={instances}
         columns={[
@@ -93,45 +95,58 @@
             // This will not sort by locale... need a good solution...
             id: 'organization',
             header: m.project_side_organization(),
-            data: (i) => i.Product.Project.Organization,
-            render: (o) => `<a class="link" href="/projects/organization/${o.Id}">${o.Name}</a>`,
-            sortable: true
+            compare: () => 0
           },
           {
             id: 'project',
             header: m.project_title(),
-            data: (i) => i.Product.Project,
-            render: (c) => `<a class="link" href="/projects/${c.Id}">${c.Name}</a>`,
-            sortable: true
+            compare: () => 0
           },
           {
-            id: 'product',
+            id: 'definition',
             header: m.tasks_product(),
-            data: (i) => i.Product,
-            render: (c) =>
-              `<a class="link" href="/workflow-instances/${c.Id}">${c.ProductDefinition.Name}</a>`,
-            sortable: true
+            compare: () => 0
           },
           {
             id: 'state',
             header: m.project_products_transitions_state(),
-            data: (i) => i.State,
-            sortable: true
+            compare: () => 0
           },
           {
             id: 'date',
             header: m.common_updated(),
-            data: (i) => i.DateUpdated,
-            // TODO: tooltip will need to wait until Svelte 5
-            render: (c) => `${getRelativeTime(c)}`,
-            sortable: true
+            compare: () => 0
           }
         ]}
         serverSide={true}
-        className="max-h-full"
+        class="max-h-full"
         onSort={(field, direction) =>
           form.update((data) => ({ ...data, sort: { field, direction } }))}
-      />
+      >
+        {#snippet row(r: (typeof instances)[0])}
+          <tr class="cursor-pointer hover:bg-neutral">
+            <td class="border">
+              <a class="link" href="/projects/organization/{r.Product.Project.Organization.Id}">
+                {r.Product.Project.Organization.Name}
+              </a>
+            </td>
+            <td class="border">
+              <a class="link" href="/projects/{r.Product.Project.Id}">{r.Product.Project.Name}</a>
+            </td>
+            <td class="border">
+              <a class="link" href="/workflow-instances/{r.Product.Id}">
+                {r.Product.ProductDefinition.Name}
+              </a>
+            </td>
+            <td class="border">{r.State}</td>
+            <td class="border">
+              <Tooltip className="text-left" tip={r.DateUpdated?.toLocaleString(langTag)}>
+                {getRelativeTime(r.DateUpdated)}
+              </Tooltip>
+            </td>
+          </tr>
+        {/snippet}
+      </SortTable>
     {:else}
       <p class="m-8">{m.workflowInstances_empty()}</p>
     {/if}

--- a/source/SIL.AppBuilder.Portal/src/routes/(authenticated)/workflow-instances/+page.svelte
+++ b/source/SIL.AppBuilder.Portal/src/routes/(authenticated)/workflow-instances/+page.svelte
@@ -119,7 +119,7 @@
           }
         ]}
         serverSide={true}
-        class="max-h-full"
+        className="max-h-full"
         onSort={(field, direction) =>
           form.update((data) => ({ ...data, sort: { field, direction } }))}
       >


### PR DESCRIPTION
Massive improvements of SortTable.svelte taking full advantage of Svelte 5 (snippets) and TypeScript (Generics)