### PR TITLE
Use localizeHref function

### DIFF
--- a/source/SIL.AppBuilder.Portal/src/auth.ts
+++ b/source/SIL.AppBuilder.Portal/src/auth.ts
@@ -1,4 +1,5 @@
 import { checkInviteErrors } from '$lib/organizationInvites';
+import { localizeHref } from '$lib/paraglide/runtime';
 import { verifyCanViewAndEdit } from '$lib/projects/server';
 import { isAdmin, isAdminForOrg, isSuperAdmin } from '$lib/utils/roles';
 import type { Session } from '@auth/express';
@@ -123,11 +124,11 @@ export const checkUserExistsHandle: Handle = async ({ event, resolve }) => {
   });
   if (!user || (user.OrganizationMemberships.length === 0 && !event.cookies.get('inviteToken'))) {
     event.cookies.set('authjs.session-token', '', { path: '/' });
-    return redirect(302, '/login/no-organization');
+    return redirect(302, localizeHref('/login/no-organization'));
   }
   if (user.IsLocked) {
     event.cookies.set('authjs.session-token', '', { path: '/' });
-    return redirect(302, '/login/locked');
+    return redirect(302, localizeHref('/login/locked'));
   }
   return resolve(event);
 };
@@ -164,7 +165,7 @@ export const localRouteHandle: Handle = async ({ event, resolve }) => {
     event.route.id !== null
   ) {
     const session = await event.locals.auth();
-    if (!session) return redirect(302, '/login');
+    if (!session) return redirect(302, localizeHref('/login'));
     if (!(await validateRouteForAuthenticatedUser(session, event.route.id, event.params)))
       return error(403);
   }
@@ -188,8 +189,7 @@ async function validateRouteForAuthenticatedUser(
       // Must be org admin or super admin for some organization
       if (!isAdmin(session?.user?.roles)) return false;
       // Must be org admin or super admin for this organization
-      if (params.id)
-        return isAdminForOrg(parseInt(params.id!), session?.user?.roles);
+      if (params.id) return isAdminForOrg(parseInt(params.id!), session?.user?.roles);
       return true;
     } else if (path[1] === 'products') {
       // TODO not sure, probably based on ownership of the project

--- a/source/SIL.AppBuilder.Portal/src/lib/components/settings/TabbedMenu.svelte
+++ b/source/SIL.AppBuilder.Portal/src/lib/components/settings/TabbedMenu.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
   import { page } from '$app/state';
+  import { localizeHref } from '$lib/paraglide/runtime';
   import type { Snippet } from 'svelte';
   import IconContainer from '../IconContainer.svelte';
 
@@ -56,7 +57,7 @@
             {#each menuItems as item}
               <a
                 class="bg-base-200 border-t border-slate-600 p-3 w-full block"
-                href="{base}/{item.route}"
+                href={localizeHref(`${base}/${item.route}`)}
               >
                 {item.text}
               </a>
@@ -72,7 +73,7 @@
               <a
                 class="rounded-none bg-base-200 p-3"
                 class:active={isActive(item.route)}
-                href="{base}/{item.route}"
+                href={localizeHref(`${base}/${item.route}`)}
               >
                 {item.text}
               </a>

--- a/source/SIL.AppBuilder.Portal/src/lib/projects/components/ProjectCard.svelte
+++ b/source/SIL.AppBuilder.Portal/src/lib/projects/components/ProjectCard.svelte
@@ -2,7 +2,7 @@
   import IconContainer from '$lib/components/IconContainer.svelte';
   import { getIcon } from '$lib/icons/productDefinitionIcon';
   import { m } from '$lib/paraglide/messages';
-  import { getLocale } from '$lib/paraglide/runtime';
+  import { getLocale, localizeHref } from '$lib/paraglide/runtime';
   import type { PrunedProject } from '$lib/projects';
   import { byString } from '$lib/utils/sorting';
   import { getTimeDateString } from '$lib/utils/time';
@@ -23,7 +23,7 @@
     <span class="flex flex-row">
       {@render select?.()}
       <div class="flex flex-row flex-wrap grow">
-        <a href="/{route}/{project.Id}">
+        <a href={localizeHref(`/${route}/${project.Id}`)}>
           <b class="[color:#55f]">
             {project.Name}
           </b>

--- a/source/SIL.AppBuilder.Portal/src/lib/projects/components/ProjectFilterSelector.svelte
+++ b/source/SIL.AppBuilder.Portal/src/lib/projects/components/ProjectFilterSelector.svelte
@@ -2,6 +2,7 @@
   import { page } from '$app/state';
   import Dropdown from '$lib/components/Dropdown.svelte';
   import { m } from '$lib/paraglide/messages';
+  import { localizeHref } from '$lib/paraglide/runtime';
   import Icon from '@iconify/svelte';
 
   const textsForPaths = new Map([
@@ -34,7 +35,7 @@
     <div class="px-4">
       {#each textsForPaths as route}
         <a
-          href="/projects/{route[0]}{page.params.id ? '/' + page.params.id : ''}"
+          href={localizeHref(`/projects/${route[0]}${page.params.id ? '/' + page.params.id : ''}`)}
           class:font-extrabold={page.params.filter === route[0]}
           class="p-1 text-nowrap block"
         >

--- a/source/SIL.AppBuilder.Portal/src/routes/(authenticated)/+layout.svelte
+++ b/source/SIL.AppBuilder.Portal/src/routes/(authenticated)/+layout.svelte
@@ -6,7 +6,7 @@
   import LanguageSelector from '$lib/components/LanguageSelector.svelte';
   import { HamburgerIcon } from '$lib/icons';
   import { m } from '$lib/paraglide/messages';
-  import { localizeHref } from '$lib/paraglide/runtime';
+  import { deLocalizeUrl, localizeHref } from '$lib/paraglide/runtime';
   import { isAdmin, isSuperAdmin } from '$lib/utils/roles';
   import { signOut } from '@auth/sveltekit/client';
   import type { Snippet } from 'svelte';
@@ -24,13 +24,8 @@
     drawerToggle.click();
   }
 
-  let orgMenuOpen = false;
-
-  function isActive(currentRoute: string | null, menuRoute: string) {
-    return currentRoute?.startsWith(`${base}/(authenticated)${menuRoute}`);
-  }
-  function isUrlActive(currentUrl: string | null, route: string) {
-    return currentUrl?.startsWith(`${base}${route}`);
+  function isUrlActive(route: string) {
+    return deLocalizeUrl(page.url).pathname?.startsWith(`${base}${route}`);
   }
 </script>
 
@@ -113,7 +108,7 @@
           <li>
             <a
               class="rounded-none"
-              class:active-menu-item={isActive(page.route.id, '/tasks')}
+              class:active-menu-item={isUrlActive('/tasks')}
               href={localizeHref('/tasks')}
               onclick={closeDrawer}
             >
@@ -123,7 +118,7 @@
           <li>
             <a
               class="rounded-none"
-              class:active-menu-item={isUrlActive(page.url.pathname, '/projects/own')}
+              class:active-menu-item={isUrlActive('/projects/own')}
               href={localizeHref('/projects/own')}
               onclick={closeDrawer}
             >
@@ -133,7 +128,7 @@
           <li>
             <a
               class="rounded-none"
-              class:active-menu-item={isUrlActive(page.url.pathname, '/projects/organization')}
+              class:active-menu-item={isUrlActive('/projects/organization')}
               href={localizeHref('/projects/organization')}
               onclick={closeDrawer}
             >
@@ -144,7 +139,7 @@
             <li>
               <a
                 class="rounded-none"
-                class:active-menu-item={isUrlActive(page.url.pathname, '/projects/active')}
+                class:active-menu-item={isUrlActive('/projects/active')}
                 href={localizeHref('/projects/active')}
                 onclick={closeDrawer}
               >
@@ -154,7 +149,7 @@
             <li>
               <a
                 class="rounded-none"
-                class:active-menu-item={isActive(page.route.id, '/users')}
+                class:active-menu-item={isUrlActive('/users')}
                 href={localizeHref('/users')}
                 onclick={closeDrawer}
               >
@@ -164,7 +159,7 @@
             <li>
               <a
                 class="rounded-none"
-                class:active-menu-item={isActive(page.route.id, '/organizations')}
+                class:active-menu-item={isUrlActive('/organizations')}
                 href={localizeHref('/organizations')}
                 onclick={closeDrawer}
               >
@@ -176,7 +171,7 @@
             <li>
               <a
                 class="rounded-none"
-                class:active-menu-item={isActive(page.route.id, '/admin/settings')}
+                class:active-menu-item={isUrlActive('/admin/settings')}
                 href={localizeHref('/admin/settings/organizations')}
                 onclick={closeDrawer}
               >
@@ -195,7 +190,8 @@
             </li>
             <li>
               <a
-                class:active-menu-item={isActive(page.route.id, '/workflow-instances')}
+                class="rounded-none"
+                class:active-menu-item={isUrlActive('/workflow-instances')}
                 href={localizeHref('/workflow-instances')}
                 onclick={closeDrawer}
               >
@@ -206,7 +202,7 @@
           <li class="menu-item-divider-top menu-item-divider-bottom">
             <a
               class="rounded-none"
-              class:active-menu-item={isActive(page.route.id, '/directory')}
+              class:active-menu-item={isUrlActive('/directory')}
               href={localizeHref('/directory')}
               onclick={closeDrawer}
             >
@@ -216,7 +212,7 @@
           <li>
             <a
               class="rounded-none mt-10"
-              class:active-menu-item={isActive(page.route.id, '/open-source')}
+              class:active-menu-item={isUrlActive('/open-source')}
               href={localizeHref('/open-source')}
               onclick={closeDrawer}
             >
@@ -246,7 +242,7 @@
   }
 
   .active-menu-item {
-    border-left: 5px solid #1c3258; /* Adjust the border color and width to your preferences */
+    border-left: 5px solid var(--color-accent); /* Adjust the border color and width to your preferences */
     font-weight: bold;
   }
   :global(.signOutButton > button) {

--- a/source/SIL.AppBuilder.Portal/src/routes/(authenticated)/+layout.svelte
+++ b/source/SIL.AppBuilder.Portal/src/routes/(authenticated)/+layout.svelte
@@ -6,6 +6,7 @@
   import LanguageSelector from '$lib/components/LanguageSelector.svelte';
   import { HamburgerIcon } from '$lib/icons';
   import { m } from '$lib/paraglide/messages';
+  import { localizeHref } from '$lib/paraglide/runtime';
   import { isAdmin, isSuperAdmin } from '$lib/utils/roles';
   import { signOut } from '@auth/sveltekit/client';
   import type { Snippet } from 'svelte';
@@ -68,7 +69,11 @@
       {#snippet content()}
         <ul class="menu menu-compact gap-1 p-2">
           <li>
-            <a href="/users/{page.data.session?.user?.userId ?? ''}/settings/profile">
+            <a
+              href={localizeHref(
+                `/users/${page.data.session?.user?.userId ?? ''}/settings/profile`
+              )}
+            >
               {m.header_myProfile()}
             </a>
           </li>
@@ -109,7 +114,7 @@
             <a
               class="rounded-none"
               class:active-menu-item={isActive(page.route.id, '/tasks')}
-              href="{base}/tasks"
+              href={localizeHref('/tasks')}
               onclick={closeDrawer}
             >
               {m.sidebar_myTasks({ count: data.numberOfTasks })}
@@ -119,7 +124,7 @@
             <a
               class="rounded-none"
               class:active-menu-item={isUrlActive(page.url.pathname, '/projects/own')}
-              href="{base}/projects/own"
+              href={localizeHref('/projects/own')}
               onclick={closeDrawer}
             >
               {m.sidebar_myProjects()}
@@ -129,7 +134,7 @@
             <a
               class="rounded-none"
               class:active-menu-item={isUrlActive(page.url.pathname, '/projects/organization')}
-              href="{base}/projects/organization"
+              href={localizeHref('/projects/organization')}
               onclick={closeDrawer}
             >
               {m.sidebar_organizationProjects()}
@@ -140,7 +145,7 @@
               <a
                 class="rounded-none"
                 class:active-menu-item={isUrlActive(page.url.pathname, '/projects/active')}
-                href="{base}/projects/active"
+                href={localizeHref('/projects/active')}
                 onclick={closeDrawer}
               >
                 {m.sidebar_activeProjects()}
@@ -150,7 +155,7 @@
               <a
                 class="rounded-none"
                 class:active-menu-item={isActive(page.route.id, '/users')}
-                href="{base}/users"
+                href={localizeHref('/users')}
                 onclick={closeDrawer}
               >
                 {m.sidebar_users()}
@@ -160,7 +165,7 @@
               <a
                 class="rounded-none"
                 class:active-menu-item={isActive(page.route.id, '/organizations')}
-                href="{base}/organizations/"
+                href={localizeHref('/organizations')}
                 onclick={closeDrawer}
               >
                 {m.sidebar_organizationSettings()}
@@ -172,7 +177,7 @@
               <a
                 class="rounded-none"
                 class:active-menu-item={isActive(page.route.id, '/admin/settings')}
-                href="{base}/admin/settings/organizations"
+                href={localizeHref('/admin/settings/organizations')}
                 onclick={closeDrawer}
               >
                 {m.sidebar_adminSettings()}
@@ -191,7 +196,7 @@
             <li>
               <a
                 class:active-menu-item={isActive(page.route.id, '/workflow-instances')}
-                href="{base}/workflow-instances"
+                href={localizeHref('/workflow-instances')}
                 onclick={closeDrawer}
               >
                 {m.workflowInstances_title()}
@@ -202,7 +207,7 @@
             <a
               class="rounded-none"
               class:active-menu-item={isActive(page.route.id, '/directory')}
-              href="{base}/directory"
+              href={localizeHref('/directory')}
               onclick={closeDrawer}
             >
               {m.sidebar_projectDirectory()}
@@ -212,7 +217,7 @@
             <a
               class="rounded-none mt-10"
               class:active-menu-item={isActive(page.route.id, '/open-source')}
-              href="{base}/open-source"
+              href={localizeHref('/open-source')}
               onclick={closeDrawer}
             >
               {m.opensource()}

--- a/source/SIL.AppBuilder.Portal/src/routes/(authenticated)/admin/settings/organizations/+page.svelte
+++ b/source/SIL.AppBuilder.Portal/src/routes/(authenticated)/admin/settings/organizations/+page.svelte
@@ -2,7 +2,7 @@
   import { goto } from '$app/navigation';
   import DataDisplayBox from '$lib/components/settings/DataDisplayBox.svelte';
   import { m } from '$lib/paraglide/messages';
-  import { getLocale } from '$lib/paraglide/runtime';
+  import { getLocale, localizeHref } from '$lib/paraglide/runtime';
   import { byName } from '$lib/utils/sorting';
   import type { PageData } from './$types';
 
@@ -11,9 +11,10 @@
   }
 
   let { data }: Props = $props();
+  const base = '/admin/settings/organizations';
 </script>
 
-<a href="organizations/new" class="btn btn-outline m-4 mt-0">
+<a href={localizeHref(`${base}/new`)} class="btn btn-outline m-4 mt-0">
   {m.admin_settings_organizations_add()}
 </a>
 
@@ -21,7 +22,7 @@
   {#each data.organizations.toSorted((a, b) => byName(a, b, getLocale())) as organization}
     <DataDisplayBox
       editable
-      onEdit={() => goto('/admin/settings/organizations/edit?id=' + organization.Id)}
+      onEdit={() => goto(localizeHref(`${base}/edit?id=${organization.Id}`))}
       title={organization.Name}
       fields={[
         { key: 'admin_settings_organizations_owner', value: organization.Owner.Name },

--- a/source/SIL.AppBuilder.Portal/src/routes/(authenticated)/admin/settings/organizations/edit/+page.server.ts
+++ b/source/SIL.AppBuilder.Portal/src/routes/(authenticated)/admin/settings/organizations/edit/+page.server.ts
@@ -1,4 +1,4 @@
-import { base } from '$app/paths';
+import { localizeHref } from '$lib/paraglide/runtime';
 import { idSchema } from '$lib/valibot';
 import { fail, redirect } from '@sveltejs/kit';
 import { DatabaseWrites, prisma } from 'sil.appbuilder.portal.common';
@@ -27,7 +27,7 @@ const editSchema = v.object({
 export const load = (async ({ url }) => {
   const id = parseInt(url.searchParams.get('id') ?? '');
   if (isNaN(id)) {
-    return redirect(302, base + '/admin/settings/organizations');
+    return redirect(302, localizeHref('/admin/settings/organizations'));
   }
   const data = await prisma.organizations.findUnique({
     where: {
@@ -39,7 +39,7 @@ export const load = (async ({ url }) => {
       OrganizationId: id
     }
   });
-  if (!data) return redirect(302, base + '/admin/settings/organizations');
+  if (!data) return redirect(302, localizeHref('/admin/settings/organizations'));
   const users = await prisma.users.findMany();
   const orgStoreNumList = new Set(orgStores.map((s) => s.StoreId));
   const stores = await prisma.stores.findMany();

--- a/source/SIL.AppBuilder.Portal/src/routes/(authenticated)/admin/settings/organizations/edit/+page.svelte
+++ b/source/SIL.AppBuilder.Portal/src/routes/(authenticated)/admin/settings/organizations/edit/+page.svelte
@@ -5,7 +5,7 @@
   import MultiselectBox from '$lib/components/settings/MultiselectBox.svelte';
   import MultiselectBoxElement from '$lib/components/settings/MultiselectBoxElement.svelte';
   import { m } from '$lib/paraglide/messages';
-  import { getLocale } from '$lib/paraglide/runtime';
+  import { getLocale, localizeHref } from '$lib/paraglide/runtime';
   import { byName } from '$lib/utils/sorting';
   import { superForm } from 'sveltekit-superforms';
   import type { PageData } from './$types';
@@ -15,11 +15,14 @@
   }
 
   let { data }: Props = $props();
+
+  const base = '/admin/settings/organizations';
+
   const { form, enhance, allErrors } = superForm(data.form, {
     dataType: 'json',
     onUpdated(event) {
       if (event.form.valid) {
-        goto('/admin/settings/organizations');
+        goto(localizeHref(base));
       }
     }
   });
@@ -122,6 +125,6 @@
   {/if}
   <div class="my-4">
     <input type="submit" class="btn btn-primary" value="Submit" />
-    <a class="btn" href="/admin/settings/organizations">Cancel</a>
+    <a class="btn" href={localizeHref(base)}>Cancel</a>
   </div>
 </form>

--- a/source/SIL.AppBuilder.Portal/src/routes/(authenticated)/admin/settings/organizations/new/+page.svelte
+++ b/source/SIL.AppBuilder.Portal/src/routes/(authenticated)/admin/settings/organizations/new/+page.svelte
@@ -3,7 +3,7 @@
   import InputWithMessage from '$lib/components/settings/InputWithMessage.svelte';
   import LabeledFormInput from '$lib/components/settings/LabeledFormInput.svelte';
   import { m } from '$lib/paraglide/messages';
-  import { getLocale } from '$lib/paraglide/runtime';
+  import { getLocale, localizeHref } from '$lib/paraglide/runtime';
   import { byName } from '$lib/utils/sorting';
   import { superForm } from 'sveltekit-superforms';
   import type { PageData } from './$types';
@@ -14,10 +14,12 @@
 
   let { data }: Props = $props();
 
+  const base = '/admin/settings/organizations';
+
   const { form, enhance, allErrors } = superForm(data.form, {
     onUpdated(event) {
       if (event.form.valid) {
-        goto('/admin/settings/organizations');
+        goto(localizeHref(base));
       }
     }
   });
@@ -109,6 +111,6 @@
   {/if}
   <div class="my-4">
     <input type="submit" class="btn btn-primary" value="Submit" />
-    <a class="btn" href="/admin/settings/organizations">Cancel</a>
+    <a class="btn" href={localizeHref(base)}>Cancel</a>
   </div>
 </form>

--- a/source/SIL.AppBuilder.Portal/src/routes/(authenticated)/admin/settings/product-definitions/+page.svelte
+++ b/source/SIL.AppBuilder.Portal/src/routes/(authenticated)/admin/settings/product-definitions/+page.svelte
@@ -1,9 +1,8 @@
 <script lang="ts">
   import { goto } from '$app/navigation';
-  import { base } from '$app/paths';
   import DataDisplayBox from '$lib/components/settings/DataDisplayBox.svelte';
   import { m } from '$lib/paraglide/messages';
-  import { getLocale } from '$lib/paraglide/runtime';
+  import { getLocale, localizeHref } from '$lib/paraglide/runtime';
   import { byName } from '$lib/utils/sorting';
   import type { PageData } from './$types';
 
@@ -12,9 +11,11 @@
   }
 
   let { data }: Props = $props();
+
+  const base = '/admin/settings/product-definitions';
 </script>
 
-<a href="product-definitions/new" class="btn btn-outline m-4 mt-0">
+<a href={localizeHref(`${base}/new`)} class="btn btn-outline m-4 mt-0">
   {m.admin_settings_productDefinitions_add()}
 </a>
 
@@ -22,7 +23,7 @@
   {#each data.productDefinitions.toSorted((a, b) => byName(a, b, getLocale())) as pD}
     <DataDisplayBox
       editable
-      onEdit={() => goto(base + '/admin/settings/product-definitions/edit?id=' + pD.Id)}
+      onEdit={() => goto(localizeHref(`${base}/edit?id=${pD.Id}`))}
       title={pD.Name}
       fields={[
         {

--- a/source/SIL.AppBuilder.Portal/src/routes/(authenticated)/admin/settings/product-definitions/edit/+page.server.ts
+++ b/source/SIL.AppBuilder.Portal/src/routes/(authenticated)/admin/settings/product-definitions/edit/+page.server.ts
@@ -1,4 +1,4 @@
-import { base } from '$app/paths';
+import { localizeHref } from '$lib/paraglide/runtime';
 import { idSchema } from '$lib/valibot';
 import { fail, redirect } from '@sveltejs/kit';
 import { DatabaseWrites, prisma } from 'sil.appbuilder.portal.common';
@@ -20,7 +20,7 @@ const editSchema = v.object({
 export const load = (async ({ url }) => {
   const id = parseInt(url.searchParams.get('id') ?? '');
   if (isNaN(id)) {
-    return redirect(302, base + '/admin/settings/product-definitions');
+    return redirect(302, localizeHref('/admin/settings/product-definitions'));
   }
   const options = {
     applicationTypes: await prisma.applicationTypes.findMany(),
@@ -31,7 +31,7 @@ export const load = (async ({ url }) => {
       Id: id
     }
   });
-  if (!data) return redirect(302, base + '/admin/settings/product-definitions');
+  if (!data) return redirect(302, localizeHref('/admin/settings/product-definitions'));
   const form = await superValidate(
     {
       id: data.Id,

--- a/source/SIL.AppBuilder.Portal/src/routes/(authenticated)/admin/settings/product-definitions/edit/+page.svelte
+++ b/source/SIL.AppBuilder.Portal/src/routes/(authenticated)/admin/settings/product-definitions/edit/+page.svelte
@@ -2,7 +2,7 @@
   import { goto } from '$app/navigation';
   import LabeledFormInput from '$lib/components/settings/LabeledFormInput.svelte';
   import { m } from '$lib/paraglide/messages';
-  import { getLocale } from '$lib/paraglide/runtime';
+  import { getLocale, localizeHref } from '$lib/paraglide/runtime';
   import { byName } from '$lib/utils/sorting';
   import { superForm } from 'sveltekit-superforms';
   import type { PageData } from './$types';
@@ -12,10 +12,13 @@
   }
 
   let { data }: Props = $props();
+
+  const base = '/admin/settings/product-definitions';
+
   const { form, enhance, allErrors } = superForm(data.form, {
     onUpdated(event) {
       if (event.form.valid) {
-        goto('/admin/settings/product-definitions');
+        goto(localizeHref(base));
       }
     }
   });
@@ -107,6 +110,6 @@
   {/if}
   <div class="my-4">
     <input type="submit" class="btn btn-primary" value="Submit" />
-    <a class="btn" href="/admin/settings/product-definitions">Cancel</a>
+    <a class="btn" href={localizeHref(base)}>Cancel</a>
   </div>
 </form>

--- a/source/SIL.AppBuilder.Portal/src/routes/(authenticated)/admin/settings/product-definitions/new/+page.svelte
+++ b/source/SIL.AppBuilder.Portal/src/routes/(authenticated)/admin/settings/product-definitions/new/+page.svelte
@@ -2,7 +2,7 @@
   import { goto } from '$app/navigation';
   import LabeledFormInput from '$lib/components/settings/LabeledFormInput.svelte';
   import { m } from '$lib/paraglide/messages';
-  import { getLocale } from '$lib/paraglide/runtime';
+  import { getLocale, localizeHref } from '$lib/paraglide/runtime';
   import { byName } from '$lib/utils/sorting';
   import { superForm } from 'sveltekit-superforms';
   import type { PageData } from './$types';
@@ -13,10 +13,12 @@
 
   let { data }: Props = $props();
 
+  const base = '/admin/settings/product-definitions';
+
   const { form, enhance, allErrors } = superForm(data.form, {
     onUpdated(event) {
       if (event.form.valid) {
-        goto('/admin/settings/product-definitions');
+        goto(localizeHref(base));
       }
     }
   });
@@ -110,6 +112,6 @@
   {/if}
   <div class="my-4">
     <input type="submit" class="btn btn-primary" value="Submit" />
-    <a class="btn" href="/admin/settings/product-definitions">Cancel</a>
+    <a class="btn" href={localizeHref(base)}>Cancel</a>
   </div>
 </form>

--- a/source/SIL.AppBuilder.Portal/src/routes/(authenticated)/admin/settings/store-types/+page.svelte
+++ b/source/SIL.AppBuilder.Portal/src/routes/(authenticated)/admin/settings/store-types/+page.svelte
@@ -2,7 +2,7 @@
   import { goto } from '$app/navigation';
   import DataDisplayBox from '$lib/components/settings/DataDisplayBox.svelte';
   import { m } from '$lib/paraglide/messages';
-  import { getLocale } from '$lib/paraglide/runtime';
+  import { getLocale, localizeHref } from '$lib/paraglide/runtime';
   import { byName } from '$lib/utils/sorting';
   import type { PageData } from './$types';
 
@@ -11,9 +11,11 @@
   }
 
   let { data }: Props = $props();
+
+  const base = '/admin/settings/store-types';
 </script>
 
-<a href="store-types/new" class="btn btn-outline m-4 mt-0">
+<a href={localizeHref(`${base}/new`)} class="btn btn-outline m-4 mt-0">
   {m.admin_settings_storeTypes_add()}
 </a>
 
@@ -21,7 +23,7 @@
   {#each data.storeTypes.toSorted((a, b) => byName(a, b, getLocale())) as storeType}
     <DataDisplayBox
       editable
-      onEdit={() => goto('/admin/settings/store-types/edit?id=' + storeType.Id)}
+      onEdit={() => goto(localizeHref(`${base}/edit?id=${storeType.Id}`))}
       title={storeType.Name}
       fields={[{ key: 'stores_attributes_description', value: storeType.Description }]}
     />

--- a/source/SIL.AppBuilder.Portal/src/routes/(authenticated)/admin/settings/store-types/edit/+page.server.ts
+++ b/source/SIL.AppBuilder.Portal/src/routes/(authenticated)/admin/settings/store-types/edit/+page.server.ts
@@ -1,4 +1,4 @@
-import { base } from '$app/paths';
+import { localizeHref } from '$lib/paraglide/runtime';
 import { idSchema } from '$lib/valibot';
 import { fail, redirect } from '@sveltejs/kit';
 import { DatabaseWrites, prisma } from 'sil.appbuilder.portal.common';
@@ -15,14 +15,14 @@ const editSchema = v.object({
 export const load = (async ({ url }) => {
   const id = parseInt(url.searchParams.get('id') ?? '');
   if (isNaN(id)) {
-    return redirect(302, base + '/admin/settings/store-types');
+    return redirect(302, localizeHref('/admin/settings/store-types'));
   }
   const data = await prisma.storeTypes.findFirst({
     where: {
       Id: id
     }
   });
-  if (!data) return redirect(302, base + '/admin/settings/store-types');
+  if (!data) return redirect(302, localizeHref('/admin/settings/store-types'));
   const form = await superValidate(
     {
       id: data.Id,

--- a/source/SIL.AppBuilder.Portal/src/routes/(authenticated)/admin/settings/store-types/edit/+page.svelte
+++ b/source/SIL.AppBuilder.Portal/src/routes/(authenticated)/admin/settings/store-types/edit/+page.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
   import { goto } from '$app/navigation';
   import LabeledFormInput from '$lib/components/settings/LabeledFormInput.svelte';
+  import { localizeHref } from '$lib/paraglide/runtime';
   import { superForm } from 'sveltekit-superforms';
   import type { PageData } from './$types';
 
@@ -9,10 +10,13 @@
   }
 
   let { data }: Props = $props();
+
+  const base = '/admin/settings/store-types';
+
   const { form, enhance, allErrors } = superForm(data.form, {
     onUpdated(event) {
       if (event.form.valid) {
-        goto('/admin/settings/store-types');
+        goto(localizeHref(base));
       }
     }
   });
@@ -43,6 +47,6 @@
   {/if}
   <div class="my-4">
     <input type="submit" class="btn btn-primary" value="Submit" />
-    <a class="btn" href="/admin/settings/store-types">Cancel</a>
+    <a class="btn" href={localizeHref(base)}>Cancel</a>
   </div>
 </form>

--- a/source/SIL.AppBuilder.Portal/src/routes/(authenticated)/admin/settings/store-types/new/+page.svelte
+++ b/source/SIL.AppBuilder.Portal/src/routes/(authenticated)/admin/settings/store-types/new/+page.svelte
@@ -2,6 +2,7 @@
   import { goto } from '$app/navigation';
   import LabeledFormInput from '$lib/components/settings/LabeledFormInput.svelte';
   import { m } from '$lib/paraglide/messages';
+  import { localizeHref } from '$lib/paraglide/runtime';
   import { superForm } from 'sveltekit-superforms';
   import type { PageData } from './$types';
 
@@ -11,10 +12,12 @@
 
   let { data }: Props = $props();
 
+  const base = '/admin/settings/store-types';
+
   const { form, enhance, allErrors } = superForm(data.form, {
     onUpdated(event) {
       if (event.form.valid) {
-        goto('/admin/settings/store-types');
+        goto(localizeHref(base));
       }
     }
   });
@@ -46,6 +49,6 @@
   {/if}
   <div class="my-4">
     <input type="submit" class="btn btn-primary" value="Submit" />
-    <a class="btn" href="/admin/settings/store-types">Cancel</a>
+    <a class="btn" href={localizeHref(base)}>Cancel</a>
   </div>
 </form>

--- a/source/SIL.AppBuilder.Portal/src/routes/(authenticated)/admin/settings/stores/+page.svelte
+++ b/source/SIL.AppBuilder.Portal/src/routes/(authenticated)/admin/settings/stores/+page.svelte
@@ -2,7 +2,7 @@
   import { goto } from '$app/navigation';
   import DataDisplayBox from '$lib/components/settings/DataDisplayBox.svelte';
   import { m } from '$lib/paraglide/messages';
-  import { getLocale } from '$lib/paraglide/runtime';
+  import { getLocale, localizeHref } from '$lib/paraglide/runtime';
   import { byName } from '$lib/utils/sorting';
   import type { PageData } from './$types';
 
@@ -11,9 +11,11 @@
   }
 
   let { data }: Props = $props();
+
+  const base = '/admin/settings/stores';
 </script>
 
-<a href="stores/new" class="btn btn-outline m-4 mt-0">
+<a href={localizeHref(`${base}/new`)} class="btn btn-outline m-4 mt-0">
   {m.models_add({ name: m.stores_name() })}
 </a>
 
@@ -21,7 +23,7 @@
   {#each data.stores.toSorted((a, b) => byName(a, b, getLocale())) as store}
     <DataDisplayBox
       editable
-      onEdit={() => goto('/admin/settings/stores/edit?id=' + store.Id)}
+      onEdit={() => goto(localizeHref(`${base}/edit?id=${store.Id}`))}
       title={store.Name}
       fields={[
         { key: 'stores_attributes_description', value: store.Description },

--- a/source/SIL.AppBuilder.Portal/src/routes/(authenticated)/admin/settings/stores/edit/+page.server.ts
+++ b/source/SIL.AppBuilder.Portal/src/routes/(authenticated)/admin/settings/stores/edit/+page.server.ts
@@ -1,4 +1,4 @@
-import { base } from '$app/paths';
+import { localizeHref } from '$lib/paraglide/runtime';
 import { idSchema } from '$lib/valibot';
 import { fail, redirect } from '@sveltejs/kit';
 import { DatabaseWrites, prisma } from 'sil.appbuilder.portal.common';
@@ -16,14 +16,14 @@ const editSchema = v.object({
 export const load = (async ({ url }) => {
   const id = parseInt(url.searchParams.get('id') ?? '');
   if (isNaN(id)) {
-    return redirect(302, base + '/admin/settings/stores');
+    return redirect(302, localizeHref('/admin/settings/stores'));
   }
   const data = await prisma.stores.findFirst({
     where: {
       Id: id
     }
   });
-  if (!data) return redirect(302, base + '/admin/settings/stores');
+  if (!data) return redirect(302, localizeHref('/admin/settings/stores'));
   const options = await prisma.storeTypes.findMany();
   const form = await superValidate(
     {

--- a/source/SIL.AppBuilder.Portal/src/routes/(authenticated)/admin/settings/stores/edit/+page.svelte
+++ b/source/SIL.AppBuilder.Portal/src/routes/(authenticated)/admin/settings/stores/edit/+page.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
   import { goto } from '$app/navigation';
   import LabeledFormInput from '$lib/components/settings/LabeledFormInput.svelte';
-  import { getLocale } from '$lib/paraglide/runtime';
+  import { getLocale, localizeHref } from '$lib/paraglide/runtime';
   import { byName } from '$lib/utils/sorting';
   import { superForm } from 'sveltekit-superforms';
   import type { PageData } from './$types';
@@ -11,10 +11,13 @@
   }
 
   let { data }: Props = $props();
+
+  const base = '/admin/settings/stores';
+
   const { form, enhance, allErrors } = superForm(data.form, {
     onUpdated(event) {
       if (event.form.valid) {
-        goto('/admin/settings/stores');
+        goto(localizeHref(base));
       }
     }
   });
@@ -52,6 +55,6 @@
   {/if}
   <div class="my-4">
     <input type="submit" class="btn btn-primary" value="Submit" />
-    <a class="btn" href="/admin/settings/stores">Cancel</a>
+    <a class="btn" href={localizeHref(base)}>Cancel</a>
   </div>
 </form>

--- a/source/SIL.AppBuilder.Portal/src/routes/(authenticated)/admin/settings/stores/new/+page.svelte
+++ b/source/SIL.AppBuilder.Portal/src/routes/(authenticated)/admin/settings/stores/new/+page.svelte
@@ -2,7 +2,7 @@
   import { goto } from '$app/navigation';
   import LabeledFormInput from '$lib/components/settings/LabeledFormInput.svelte';
   import { m } from '$lib/paraglide/messages';
-  import { getLocale } from '$lib/paraglide/runtime';
+  import { getLocale, localizeHref } from '$lib/paraglide/runtime';
   import { byName } from '$lib/utils/sorting';
   import { superForm } from 'sveltekit-superforms';
   import type { PageData } from './$types';
@@ -13,10 +13,12 @@
 
   let { data }: Props = $props();
 
+  const base = '/admin/settings/stores';
+
   const { form, enhance, allErrors } = superForm(data.form, {
     onUpdated(event) {
       if (event.form.valid) {
-        goto('/admin/settings/stores');
+        goto(localizeHref(base));
       }
     }
   });
@@ -56,6 +58,6 @@
 
   <div class="my-4">
     <input type="submit" class="btn btn-primary" value="Submit" />
-    <a class="btn" href="/admin/settings/stores">Cancel</a>
+    <a class="btn" href={localizeHref(base)}>Cancel</a>
   </div>
 </form>

--- a/source/SIL.AppBuilder.Portal/src/routes/(authenticated)/admin/settings/workflow-definitions/+page.svelte
+++ b/source/SIL.AppBuilder.Portal/src/routes/(authenticated)/admin/settings/workflow-definitions/+page.svelte
@@ -2,7 +2,7 @@
   import { goto } from '$app/navigation';
   import DataDisplayBox from '$lib/components/settings/DataDisplayBox.svelte';
   import { m } from '$lib/paraglide/messages';
-  import { getLocale } from '$lib/paraglide/runtime';
+  import { getLocale, localizeHref } from '$lib/paraglide/runtime';
   import { byName } from '$lib/utils/sorting';
   import type { PageData } from './$types';
 
@@ -11,9 +11,11 @@
   }
 
   let { data }: Props = $props();
+
+  const base = '/admin/settings/workflow-definitions';
 </script>
 
-<a href="workflow-definitions/new" class="btn btn-outline m-4 mt-0">
+<a href={localizeHref(`${base}/new`)} class="btn btn-outline m-4 mt-0">
   {m.admin_settings_workflowDefinitions_add()}
 </a>
 
@@ -21,7 +23,7 @@
   {#each data.workflowDefinitions.toSorted((a, b) => byName(a, b, getLocale())) as wd}
     <DataDisplayBox
       editable
-      onEdit={() => goto('/admin/settings/workflow-definitions/edit?id=' + wd.Id)}
+      onEdit={() => goto(localizeHref(`${base}/edit?id=${wd.Id}`))}
       title={wd.Name}
       fields={[
         {
@@ -49,7 +51,7 @@
             m.admin_settings_workflowDefinitions_workflowTypes_2(),
             m.admin_settings_workflowDefinitions_workflowTypes_3()
           ][wd.Type]
-        },
+        }
         // Do we want to show options here?
       ]}
     />

--- a/source/SIL.AppBuilder.Portal/src/routes/(authenticated)/admin/settings/workflow-definitions/edit/+page.server.ts
+++ b/source/SIL.AppBuilder.Portal/src/routes/(authenticated)/admin/settings/workflow-definitions/edit/+page.server.ts
@@ -1,4 +1,4 @@
-import { base } from '$app/paths';
+import { localizeHref } from '$lib/paraglide/runtime';
 import { idSchema } from '$lib/valibot';
 import { fail, redirect } from '@sveltejs/kit';
 import { DatabaseWrites, prisma } from 'sil.appbuilder.portal.common';
@@ -15,14 +15,14 @@ const editSchema = v.object({
 export const load = (async ({ url }) => {
   const id = parseInt(url.searchParams.get('id') ?? '');
   if (isNaN(id)) {
-    return redirect(302, base + '/admin/settings/workflow-definitions');
+    return redirect(302, localizeHref('/admin/settings/workflow-definitions'));
   }
   const data = await prisma.workflowDefinitions.findFirst({
     where: {
       Id: id
     }
   });
-  if (!data) return redirect(302, base + '/admin/settings/workflow-definitions');
+  if (!data) return redirect(302, localizeHref('/admin/settings/workflow-definitions'));
   const storeTypes = await prisma.storeTypes.findMany();
   const schemes = await prisma.workflowScheme.findMany({ select: { Code: true } });
   const form = await superValidate(

--- a/source/SIL.AppBuilder.Portal/src/routes/(authenticated)/admin/settings/workflow-definitions/edit/+page.svelte
+++ b/source/SIL.AppBuilder.Portal/src/routes/(authenticated)/admin/settings/workflow-definitions/edit/+page.svelte
@@ -4,7 +4,7 @@
   import LabeledFormInput from '$lib/components/settings/LabeledFormInput.svelte';
   import type { ValidI13nKey } from '$lib/i18n';
   import { m } from '$lib/paraglide/messages';
-  import { getLocale } from '$lib/paraglide/runtime';
+  import { getLocale, localizeHref } from '$lib/paraglide/runtime';
   import { byName, byString } from '$lib/utils/sorting';
   import { ProductType, WorkflowOptions } from 'sil.appbuilder.portal.common/workflow';
   import { superForm } from 'sveltekit-superforms';
@@ -16,11 +16,14 @@
   }
 
   let { data }: Props = $props();
+
+  const base = '/admin/settings/workflow-definitions';
+
   const { form, enhance, allErrors } = superForm(data.form, {
     dataType: 'json',
     onUpdated(event) {
       if (event.form.valid) {
-        goto('/admin/settings/workflow-definitions');
+        goto(localizeHref(base));
       }
     }
   });
@@ -152,7 +155,7 @@
   {/if}
   <div class="my-4">
     <input type="submit" class="btn btn-primary" value={m.common_save()} />
-    <a class="btn" href="/admin/settings/workflow-definitions">{m.common_cancel()}</a>
+    <a class="btn" href={localizeHref(base)}>{m.common_cancel()}</a>
   </div>
 </form>
 

--- a/source/SIL.AppBuilder.Portal/src/routes/(authenticated)/admin/settings/workflow-definitions/new/+page.svelte
+++ b/source/SIL.AppBuilder.Portal/src/routes/(authenticated)/admin/settings/workflow-definitions/new/+page.svelte
@@ -4,7 +4,7 @@
   import LabeledFormInput from '$lib/components/settings/LabeledFormInput.svelte';
   import type { ValidI13nKey } from '$lib/i18n';
   import { m } from '$lib/paraglide/messages';
-  import { getLocale } from '$lib/paraglide/runtime';
+  import { getLocale, localizeHref } from '$lib/paraglide/runtime';
   import { byName, byString } from '$lib/utils/sorting';
   import { ProductType, WorkflowOptions } from 'sil.appbuilder.portal.common/workflow';
   import { superForm } from 'sveltekit-superforms';
@@ -17,11 +17,13 @@
 
   let { data }: Props = $props();
 
+  const base = '/admin/settings/workflow-definitions';
+
   const { form, enhance, allErrors } = superForm(data.form, {
     dataType: 'json',
     onUpdated(event) {
       if (event.form.valid) {
-        goto('/admin/settings/workflow-definitions');
+        goto(localizeHref(base));
       }
     }
   });
@@ -155,7 +157,7 @@
   {/if}
   <div class="my-4">
     <input type="submit" class="btn btn-primary" value={m.common_save()} />
-    <a class="btn" href="/admin/settings/workflow-definitions">{m.common_cancel()}</a>
+    <a class="btn" href={localizeHref(base)}>{m.common_cancel()}</a>
   </div>
 </form>
 

--- a/source/SIL.AppBuilder.Portal/src/routes/(authenticated)/directory/[id]/+page.svelte
+++ b/source/SIL.AppBuilder.Portal/src/routes/(authenticated)/directory/[id]/+page.svelte
@@ -3,7 +3,7 @@
   import Tooltip from '$lib/components/Tooltip.svelte';
   import { getIcon } from '$lib/icons/productDefinitionIcon';
   import { m } from '$lib/paraglide/messages';
-  import { getLocale } from '$lib/paraglide/runtime';
+  import { getLocale, localizeHref } from '$lib/paraglide/runtime';
   import BuildArtifacts from '$lib/products/components/BuildArtifacts.svelte';
   import { canModifyProject } from '$lib/projects';
   import { byName } from '$lib/utils/sorting';
@@ -21,7 +21,7 @@
   <div class="flex flex-col p-6">
     <div>
       {#if canModifyProject(data.session, data.project.Owner.Id, data.project.Organization.Id)}
-        <a class="link" href="/projects/{data.project.Id}">
+        <a class="link" href={localizeHref(`/projects/${data.project.Id}`)}>
           <h1 class="p-0">
             {data.project?.Name} ({data.project.Language ?? ''})
           </h1>

--- a/source/SIL.AppBuilder.Portal/src/routes/(authenticated)/organizations/+page.server.ts
+++ b/source/SIL.AppBuilder.Portal/src/routes/(authenticated)/organizations/+page.server.ts
@@ -1,3 +1,4 @@
+import { localizeHref } from '$lib/paraglide/runtime';
 import { isSuperAdmin } from '$lib/utils/roles';
 import { redirect } from '@sveltejs/kit';
 import { prisma } from 'sil.appbuilder.portal.common';
@@ -24,7 +25,7 @@ export const load = (async (event) => {
       }
     });
   if (organizations.length === 1) {
-    return redirect(302, '/organizations/' + organizations[0].Id + '/settings');
+    return redirect(302, localizeHref(`/organizations/${organizations[0].Id}/settings`));
   }
   return { organizations };
 }) satisfies PageServerLoad;

--- a/source/SIL.AppBuilder.Portal/src/routes/(authenticated)/organizations/[id]/settings/+layout.server.ts
+++ b/source/SIL.AppBuilder.Portal/src/routes/(authenticated)/organizations/[id]/settings/+layout.server.ts
@@ -1,15 +1,16 @@
+import { localizeHref } from '$lib/paraglide/runtime';
 import { redirect } from '@sveltejs/kit';
 import { prisma } from 'sil.appbuilder.portal.common';
 import type { LayoutServerLoad } from './$types';
 
 export const load = (async (event) => {
   const id = parseInt(event.params.id);
-  if (isNaN(id)) return redirect(302, '/organizations');
+  if (isNaN(id)) return redirect(302, localizeHref('/organizations'));
   const organization = await prisma.organizations.findUnique({
     where: {
       Id: id
     }
   });
-  if (!organization) return redirect(302, '/organizations');
+  if (!organization) return redirect(302, localizeHref('/organizations'));
   return { organization };
 }) satisfies LayoutServerLoad;

--- a/source/SIL.AppBuilder.Portal/src/routes/(authenticated)/organizations/[id]/settings/groups/+page.svelte
+++ b/source/SIL.AppBuilder.Portal/src/routes/(authenticated)/organizations/[id]/settings/groups/+page.svelte
@@ -15,7 +15,7 @@
   const { form: deleteForm, enhance: deleteEnhance } = superForm(data.deleteForm);
 </script>
 
-{#each data.organization.Groups.toSorted((a, b) => byName(a, b, getLocale())) as group}
+{#each data.groups.toSorted((a, b) => byName(a, b, getLocale())) as group}
   <form action="?/deleteGroup" class="m-2" method="post" use:deleteEnhance>
     <input type="hidden" name="id" value={group.Id} />
     <div class="border w-full flex flex-row p-2 rounded-md items-center place-content-between">

--- a/source/SIL.AppBuilder.Portal/src/routes/(authenticated)/organizations/[id]/settings/info/+page.server.ts
+++ b/source/SIL.AppBuilder.Portal/src/routes/(authenticated)/organizations/[id]/settings/info/+page.server.ts
@@ -1,6 +1,5 @@
 import { idSchema } from '$lib/valibot';
-import { redirect } from '@sveltejs/kit';
-import { DatabaseWrites, prisma } from 'sil.appbuilder.portal.common';
+import { DatabaseWrites } from 'sil.appbuilder.portal.common';
 import { fail, superValidate } from 'sveltekit-superforms';
 import { valibot } from 'sveltekit-superforms/adapters';
 import * as v from 'valibot';
@@ -13,13 +12,7 @@ const editInfoSchema = v.object({
 });
 
 export const load = (async (event) => {
-  if (isNaN(parseInt(event.params.id))) return redirect(302, '/organizations');
-  const organization = await prisma.organizations.findUnique({
-    where: {
-      Id: parseInt(event.params.id)
-    }
-  });
-  if (!organization) return redirect(302, '/organizations');
+  const { organization } = await event.parent();
   const form = await superValidate(
     {
       id: organization.Id,
@@ -28,7 +21,7 @@ export const load = (async (event) => {
     },
     valibot(editInfoSchema)
   );
-  return { organization, form };
+  return { form };
 }) satisfies PageServerLoad;
 
 export const actions = {

--- a/source/SIL.AppBuilder.Portal/src/routes/(authenticated)/organizations/[id]/settings/infrastructure/+page.server.ts
+++ b/source/SIL.AppBuilder.Portal/src/routes/(authenticated)/organizations/[id]/settings/infrastructure/+page.server.ts
@@ -1,6 +1,5 @@
 import { idSchema } from '$lib/valibot';
-import { redirect } from '@sveltejs/kit';
-import { DatabaseWrites, prisma } from 'sil.appbuilder.portal.common';
+import { DatabaseWrites } from 'sil.appbuilder.portal.common';
 import { fail, superValidate } from 'sveltekit-superforms';
 import { valibot } from 'sveltekit-superforms/adapters';
 import * as v from 'valibot';
@@ -14,13 +13,7 @@ const infrastructureSchema = v.object({
 });
 
 export const load = (async (event) => {
-  if (isNaN(parseInt(event.params.id))) return redirect(302, '/organizations');
-  const organization = await prisma.organizations.findUnique({
-    where: {
-      Id: parseInt(event.params.id)
-    }
-  });
-  if (!organization) return redirect(302, '/organizations');
+  const { organization } = await event.parent();
   const form = await superValidate(
     {
       id: organization.Id,
@@ -30,7 +23,7 @@ export const load = (async (event) => {
     },
     valibot(infrastructureSchema)
   );
-  return { organization, form };
+  return { form };
 }) satisfies PageServerLoad;
 
 export const actions = {

--- a/source/SIL.AppBuilder.Portal/src/routes/(authenticated)/organizations/[id]/settings/stores/+page.server.ts
+++ b/source/SIL.AppBuilder.Portal/src/routes/(authenticated)/organizations/[id]/settings/stores/+page.server.ts
@@ -33,7 +33,7 @@ export const load = (async (event) => {
     },
     valibot(editStoresSchema)
   );
-  return { organization: organization, orgStores, allStores, form };
+  return { orgStores, allStores, form };
 }) satisfies PageServerLoad;
 
 export const actions = {

--- a/source/SIL.AppBuilder.Portal/src/routes/(authenticated)/products/[id]/files/+page.svelte
+++ b/source/SIL.AppBuilder.Portal/src/routes/(authenticated)/products/[id]/files/+page.svelte
@@ -3,6 +3,7 @@
   import Pagination from '$lib/components/Pagination.svelte';
   import { getIcon } from '$lib/icons/productDefinitionIcon';
   import { m } from '$lib/paraglide/messages';
+  import { localizeHref } from '$lib/paraglide/runtime';
   import BuildArtifacts from '$lib/products/components/BuildArtifacts.svelte';
   import { superForm, type FormResult } from 'sveltekit-superforms';
   import type { PageData } from './$types';
@@ -38,7 +39,7 @@
     <div class="breadcrumbs text-sm pl-4">
       <ul>
         <li>
-          <a class="link" href="/projects/{data.product?.Project.Id}">
+          <a class="link" href={localizeHref(`/projects/${data.product?.Project.Id}`)}>
             {data.product?.Project.Name}
           </a>
         </li>

--- a/source/SIL.AppBuilder.Portal/src/routes/(authenticated)/projects/[filter=projectSelector]/+page.server.ts
+++ b/source/SIL.AppBuilder.Portal/src/routes/(authenticated)/projects/[filter=projectSelector]/+page.server.ts
@@ -1,9 +1,10 @@
+import { localizeHref } from '$lib/paraglide/runtime';
 import { redirect } from '@sveltejs/kit';
 import type { PageServerLoad } from './$types';
 
 export const load = (async (event) => {
   const data = await event.parent();
   if (data.organizations.length === 1)
-    return redirect(302, event.url.pathname + '/' + data.organizations[0].Id);
+    return redirect(302, localizeHref(`/projects/${event.params.filter}/${data.organizations[0].Id}`));
   return {};
 }) satisfies PageServerLoad;

--- a/source/SIL.AppBuilder.Portal/src/routes/(authenticated)/projects/[filter=projectSelector]/[id]/+page.svelte
+++ b/source/SIL.AppBuilder.Portal/src/routes/(authenticated)/projects/[filter=projectSelector]/[id]/+page.svelte
@@ -7,7 +7,7 @@
   import SearchBar from '$lib/components/SearchBar.svelte';
   import { getIcon } from '$lib/icons/productDefinitionIcon';
   import { m } from '$lib/paraglide/messages';
-  import { getLocale } from '$lib/paraglide/runtime';
+  import { getLocale, localizeHref } from '$lib/paraglide/runtime';
   import type { ProjectForAction, PrunedProject } from '$lib/projects';
   import { canArchive, canReactivate } from '$lib/projects';
   import ProjectActionMenu from '$lib/projects/components/ProjectActionMenu.svelte';
@@ -309,11 +309,14 @@
       <div class="flex flex-row flex-wrap gap-1 mx-4 {mobileSizing}">
         <a
           class="btn btn-outline {mobileSizing}"
-          href="/projects/import/{$pageForm.organizationId}"
+          href={localizeHref(`/projects/import/${$pageForm.organizationId}`)}
         >
           {m.project_importProjects()}
         </a>
-        <a class="btn btn-outline {mobileSizing}" href="/projects/new/{$pageForm.organizationId}">
+        <a
+          class="btn btn-outline {mobileSizing}"
+          href={localizeHref(`/projects/new/${$pageForm.organizationId}`)}
+        >
           {m.sidebar_addProject()}
         </a>
       </div>

--- a/source/SIL.AppBuilder.Portal/src/routes/(authenticated)/projects/[id=idNumber]/+page.svelte
+++ b/source/SIL.AppBuilder.Portal/src/routes/(authenticated)/projects/[id=idNumber]/+page.svelte
@@ -7,7 +7,7 @@
   import { getIcon } from '$lib/icons/productDefinitionIcon';
   import langtags from '$lib/langtags.json';
   import { m } from '$lib/paraglide/messages';
-  import { getLocale, locales } from '$lib/paraglide/runtime';
+  import { getLocale, locales, localizeHref } from '$lib/paraglide/runtime';
   import ProductDetails from '$lib/products/components/ProductDetails.svelte';
   import ProjectActionMenu from '$lib/projects/components/ProjectActionMenu.svelte';
   import { isAdminForOrg, isSuperAdmin } from '$lib/utils/roles';
@@ -113,7 +113,10 @@
     </div>
     <div class="grow">
       <Tooltip className="tooltip-bottom" tip={m.project_editProject()}>
-        <a href="/projects/{data.project?.Id}/edit" title={m.project_editProject()}>
+        <a
+          href={localizeHref(`/projects/${data.project?.Id}/edit`)}
+          title={m.project_editProject()}
+        >
           <IconContainer width="24" icon="mdi:pencil" />
         </a>
       </Tooltip>
@@ -349,7 +352,10 @@
                           </button>
                         </li>
                         <li class="w-full rounded-none">
-                          <a href="/products/{product.Id}/files" class="text-nowrap">
+                          <a
+                            href={localizeHref(`/products/${product.Id}/files`)}
+                            class="text-nowrap"
+                          >
                             {m.project_productFiles()}
                           </a>
                         </li>
@@ -363,7 +369,7 @@
                         {/if}
                         {#if isSuperAdmin(data.session?.user.roles) && !!product.WorkflowInstance}
                           <li class="w-full-rounded-none">
-                            <a href="/workflow-instances/{product.Id}">
+                            <a href={localizeHref(`/workflow-instances/${product.Id}`)}>
                               {m.common_workflow()}
                             </a>
                           </li>
@@ -403,7 +409,7 @@
                     // activityName appears to show up blank primarily at the very startup of a new product?
                   })}
                   {#if product.UserTasks.slice(-1)[0]?.UserId === page.data.session?.user.userId}
-                    <a class="link mx-2" href="/tasks/{product.Id}">
+                    <a class="link mx-2" href={localizeHref(`/tasks/${product.Id}`)}>
                       {m.common_continue()}
                     </a>
                   {/if}
@@ -585,7 +591,7 @@
         <div class="p-2">
           {#if data.project.Authors.length}
             {@const locale = getLocale()}
-            {#each data.project.Authors.toSorted((a, b) => byName(a.Users, b.Users, locale)) as author}
+            {#each data.project.Authors.toSorted( (a, b) => byName(a.Users, b.Users, locale) ) as author}
               <div class="flex flex-row w-full place-content-between p-2">
                 <span>{author.Users.Name}</span>
                 <form action="?/deleteAuthor" method="post" use:authorDeleteEnhance>
@@ -743,7 +749,9 @@
     column-gap: 0.75rem;
   }
   /* source: https://github.com/saadeghi/daisyui/issues/3040#issuecomment-2250530354 */
-  :root:has(:global(:is(.modal-open, .modal:target, .modal-toggle:checked + .modal, .modal[open]))) {
+  :root:has(
+      :global(:is(.modal-open, .modal:target, .modal-toggle:checked + .modal, .modal[open]))
+    ) {
     scrollbar-gutter: unset;
   }
 </style>

--- a/source/SIL.AppBuilder.Portal/src/routes/(authenticated)/projects/[id=idNumber]/edit/+page.svelte
+++ b/source/SIL.AppBuilder.Portal/src/routes/(authenticated)/projects/[id=idNumber]/edit/+page.svelte
@@ -3,7 +3,7 @@
   import { page } from '$app/state';
   import LanguageCodeTypeahead from '$lib/components/LanguageCodeTypeahead.svelte';
   import { m } from '$lib/paraglide/messages';
-  import { getLocale } from '$lib/paraglide/runtime';
+  import { getLocale, localizeHref } from '$lib/paraglide/runtime';
   import { byName } from '$lib/utils/sorting';
   import { superForm } from 'sveltekit-superforms';
   import type { PageData } from './$types';
@@ -17,7 +17,7 @@
     dataType: 'json',
     onUpdated(event) {
       if (event.form.valid) {
-        goto('/projects/' + page.params.id);
+        goto(localizeHref(`/projects/${page.params.id}`));
       }
     }
   });
@@ -65,7 +65,7 @@
       </label>
     </div>
     <div class="flex place-content-end space-x-2">
-      <a href="/projects/{page.params.id}" class="btn">{m.common_cancel()}</a>
+      <a href={localizeHref(`/projects/${page.params.id}`)} class="btn">{m.common_cancel()}</a>
       <button class="btn btn-primary" type="submit">{m.common_save()}</button>
     </div>
   </form>

--- a/source/SIL.AppBuilder.Portal/src/routes/(authenticated)/projects/import/[id=idNumber]/+page.server.ts
+++ b/source/SIL.AppBuilder.Portal/src/routes/(authenticated)/projects/import/[id=idNumber]/+page.server.ts
@@ -1,3 +1,4 @@
+import { localizeHref } from '$lib/paraglide/runtime';
 import { importJSONSchema } from '$lib/projects';
 import { verifyCanCreateProject } from '$lib/projects/server';
 import { idSchema } from '$lib/valibot';
@@ -202,6 +203,6 @@ export const actions: Actions = {
       return fail(400, { form, ok: false, errors });
     }
 
-    return redirect(302, `/projects/own/${organizationId}`);
+    return redirect(302, localizeHref(`/projects/own/${organizationId}`));
   }
 };

--- a/source/SIL.AppBuilder.Portal/src/routes/(authenticated)/projects/import/[id=idNumber]/+page.svelte
+++ b/source/SIL.AppBuilder.Portal/src/routes/(authenticated)/projects/import/[id=idNumber]/+page.svelte
@@ -2,7 +2,7 @@
   import { page } from '$app/state';
   import LabeledFormInput from '$lib/components/settings/LabeledFormInput.svelte';
   import { m } from '$lib/paraglide/messages';
-  import { getLocale } from '$lib/paraglide/runtime';
+  import { getLocale, localizeHref } from '$lib/paraglide/runtime';
   import { importJSONSchema } from '$lib/projects';
   import { byName, byString } from '$lib/utils/sorting';
   import { onMount } from 'svelte';
@@ -154,7 +154,9 @@
       </ul>
     {/if}
     <div class="flex flex-wrap place-content-center gap-4 p-4">
-      <a href="/projects/own/{page.params.id}" class="btn w-full max-w-xs">{m.common_cancel()}</a>
+      <a href={localizeHref(`/projects/own/${page.params.id}`)} class="btn w-full max-w-xs">
+        {m.common_cancel()}
+      </a>
       <button class="btn btn-primary w-full max-w-xs" disabled={!canSubmit} type="submit">
         {m.common_save()}
       </button>

--- a/source/SIL.AppBuilder.Portal/src/routes/(authenticated)/projects/new/[id=idNumber]/+page.server.ts
+++ b/source/SIL.AppBuilder.Portal/src/routes/(authenticated)/projects/new/[id=idNumber]/+page.server.ts
@@ -1,3 +1,4 @@
+import { localizeHref } from '$lib/paraglide/runtime';
 import { projectCreateSchema } from '$lib/projects';
 import { verifyCanCreateProject } from '$lib/projects/server';
 import { error, redirect } from '@sveltejs/kit';
@@ -76,7 +77,7 @@ export const actions: Actions = {
         },
         BullMQ.Retry5e5
       );
-      return redirect(302, `/projects/${project}`);
+      return redirect(302, localizeHref(`/projects/${project}`));
     }
     return {
       form,

--- a/source/SIL.AppBuilder.Portal/src/routes/(authenticated)/projects/new/[id=idNumber]/+page.svelte
+++ b/source/SIL.AppBuilder.Portal/src/routes/(authenticated)/projects/new/[id=idNumber]/+page.svelte
@@ -4,7 +4,7 @@
   import InputWithMessage from '$lib/components/settings/InputWithMessage.svelte';
   import LabeledFormInput from '$lib/components/settings/LabeledFormInput.svelte';
   import { m } from '$lib/paraglide/messages';
-  import { getLocale } from '$lib/paraglide/runtime';
+  import { getLocale, localizeHref } from '$lib/paraglide/runtime';
   import { byName, byString } from '$lib/utils/sorting';
   import { superForm } from 'sveltekit-superforms';
   import type { PageData } from './$types';
@@ -34,7 +34,7 @@
         </LabeledFormInput>
         <LabeledFormInput name="project_projectGroup" className="md:max-w-xs">
           <select name="group" id="group" class="select select-bordered" bind:value={$form.group}>
-            {#each data.organization.Groups.toSorted( (a, b) => byName(a, b, getLocale()) ) as group}
+            {#each data.organization.Groups.toSorted((a, b) => byName(a, b, getLocale())) as group}
               <option value={group.Id}>{group.Name}</option>
             {/each}
           </select>
@@ -88,7 +88,9 @@
         </ul>
       {/if}
       <div class="flex flex-wrap place-content-center gap-4 p-4">
-        <a href="/projects/own/{page.params.id}" class="btn w-full max-w-xs">{m.common_cancel()}</a>
+        <a href={localizeHref(`/projects/own/${page.params.id}`)} class="btn w-full max-w-xs">
+          {m.common_cancel()}
+        </a>
         <button
           class="btn btn-primary w-full max-w-xs"
           class:btn-disabled={!($form.Name.length && $form.Language.length)}

--- a/source/SIL.AppBuilder.Portal/src/routes/(authenticated)/tasks/+page.svelte
+++ b/source/SIL.AppBuilder.Portal/src/routes/(authenticated)/tasks/+page.svelte
@@ -4,7 +4,7 @@
   import Tooltip from '$lib/components/Tooltip.svelte';
   import { getIcon } from '$lib/icons/productDefinitionIcon';
   import { m } from '$lib/paraglide/messages';
-  import { getLocale } from '$lib/paraglide/runtime';
+  import { getLocale, localizeHref } from '$lib/paraglide/runtime';
   import { getRelativeTime } from '$lib/utils/time';
   import type { PageData } from './$types';
 
@@ -30,7 +30,10 @@
         </thead>
         <tbody>
           {#each data.tasks as task}
-            <tr class="cursor-pointer" onclick={() => goto(`/tasks/${task.ProductId}`)}>
+            <tr
+              class="cursor-pointer"
+              onclick={() => goto(localizeHref(`/tasks/${task.ProductId}`))}
+            >
               <td>
                 <span class="flex items-center">
                   <IconContainer
@@ -48,7 +51,7 @@
                 </span>
               </td>
               <td>
-                <a class="link" href="/projects/{task.Product.ProjectId}">
+                <a class="link" href={localizeHref(`/projects/${task.Product.ProjectId}`)}>
                   {task.Product.Project.Name}
                 </a>
               </td>

--- a/source/SIL.AppBuilder.Portal/src/routes/(authenticated)/tasks/[product_id]/+page.server.ts
+++ b/source/SIL.AppBuilder.Portal/src/routes/(authenticated)/tasks/[product_id]/+page.server.ts
@@ -1,3 +1,4 @@
+import { localizeHref } from '$lib/paraglide/runtime';
 import { isSuperAdmin } from '$lib/utils/roles';
 import type { Session } from '@auth/sveltekit';
 import { error, redirect } from '@sveltejs/kit';
@@ -206,7 +207,7 @@ export const actions = {
       select: { ProjectId: true }
     }))!;
 
-    redirect(302, `/projects/${product.ProjectId}`);
+    redirect(302, localizeHref(`/projects/${product.ProjectId}`));
   }
 } satisfies Actions;
 

--- a/source/SIL.AppBuilder.Portal/src/routes/(authenticated)/tasks/[product_id]/+page.svelte
+++ b/source/SIL.AppBuilder.Portal/src/routes/(authenticated)/tasks/[product_id]/+page.svelte
@@ -3,7 +3,7 @@
   import LabeledFormInput from '$lib/components/settings/LabeledFormInput.svelte';
   import SortTable from '$lib/components/SortTable.svelte';
   import { m } from '$lib/paraglide/messages';
-  import { getLocale } from '$lib/paraglide/runtime';
+  import { getLocale, localizeHref } from '$lib/paraglide/runtime';
   import { bytesToHumanSize } from '$lib/utils';
   import { byName, byNumber, byString } from '$lib/utils/sorting';
   import { superForm } from 'sveltekit-superforms';
@@ -29,8 +29,8 @@
   <div class="flex flex-row gap-x-3 p-2 flex-wrap">
     <div class="breadcrumbs">
       <ul>
-        <li><a class="link" href="/tasks">{m.sidebar_myTasks({ count: 0 })}</a></li>
-        <li><a class="link" href="/projects/{data.projectId}">{data.fields.projectName}</a></li>
+        <li><a class="link" href={localizeHref("/tasks")}>{m.sidebar_myTasks({ count: 0 })}</a></li>
+        <li><a class="link" href={localizeHref(`/projects/${data.projectId}`)}>{data.fields.projectName}</a></li>
         <li>{data.productDescription}</li>
       </ul>
     </div>

--- a/source/SIL.AppBuilder.Portal/src/routes/(authenticated)/users/+page.server.ts
+++ b/source/SIL.AppBuilder.Portal/src/routes/(authenticated)/users/+page.server.ts
@@ -1,3 +1,4 @@
+import { localizeHref } from '$lib/paraglide/runtime';
 import { paginateSchema } from '$lib/table';
 import { isSuperAdmin } from '$lib/utils/roles';
 import { idSchema } from '$lib/valibot';
@@ -84,7 +85,7 @@ function adminOrDefaultWhere(isSuper: boolean, orgIds: number[]) {
 export const load = (async (event) => {
   const userInfo = (await event.locals.auth())?.user;
   const userId = userInfo?.userId;
-  if (!userId) return redirect(302, '/');
+  if (!userId) return redirect(302, localizeHref('/'));
 
   const isSuper = isSuperAdmin(userInfo.roles);
 

--- a/source/SIL.AppBuilder.Portal/src/routes/(authenticated)/users/+page.svelte
+++ b/source/SIL.AppBuilder.Portal/src/routes/(authenticated)/users/+page.svelte
@@ -5,7 +5,7 @@
   import Pagination from '$lib/components/Pagination.svelte';
   import SearchBar from '$lib/components/SearchBar.svelte';
   import { m } from '$lib/paraglide/messages';
-  import { getLocale } from '$lib/paraglide/runtime';
+  import { getLocale, localizeHref } from '$lib/paraglide/runtime';
   import { isAdmin } from '$lib/utils/roles';
   import { byName, byString } from '$lib/utils/sorting';
   import { superForm, type FormResult } from 'sveltekit-superforms';
@@ -52,7 +52,7 @@
     <div class="flex flex-row items-center">
       <h1>{m.users_title()}</h1>
       {#if isAdmin(data.session?.user.roles)}
-        <a href="/users/invite" class="btn btn-outline">
+        <a href={localizeHref('/users/invite')} class="btn btn-outline">
           <IconContainer icon="mdi:user-add" width="20" />
           <span>{m.organizationMembership_invite_create_inviteUserButtonTitle()}</span>
         </a>
@@ -97,7 +97,7 @@
           <tr class="align-top">
             <td class="p-2">
               <p>
-                <a href="/users/{user.I}/settings" class="link pb-2">
+                <a href={localizeHref(`/users/${user.I}/settings`)} class="link pb-2">
                   {user.N}
                 </a>
               </p>

--- a/source/SIL.AppBuilder.Portal/src/routes/(authenticated)/users/[id=idNumber]/settings/+page.server.ts
+++ b/source/SIL.AppBuilder.Portal/src/routes/(authenticated)/users/[id=idNumber]/settings/+page.server.ts
@@ -1,6 +1,7 @@
+import { localizeHref } from '$lib/paraglide/runtime';
 import { redirect } from '@sveltejs/kit';
 import type { PageServerLoad } from './$types';
 
 export const load = (async ({ params: { id } }) => {
-  return redirect(302, '/users/' + id + '/settings/profile');
+  return redirect(302, localizeHref(`/users/${id}/settings/profile`));
 }) satisfies PageServerLoad;

--- a/source/SIL.AppBuilder.Portal/src/routes/(authenticated)/users/invite/+page.svelte
+++ b/source/SIL.AppBuilder.Portal/src/routes/(authenticated)/users/invite/+page.svelte
@@ -2,6 +2,7 @@
   import OrganizationDropdown from '$lib/components/OrganizationDropdown.svelte';
   import LabeledFormInput from '$lib/components/settings/LabeledFormInput.svelte';
   import { m } from '$lib/paraglide/messages';
+  import { localizeHref } from '$lib/paraglide/runtime';
   import { onMount } from 'svelte';
   import { superForm } from 'sveltekit-superforms';
   import GroupsSelector from '../GroupsSelector.svelte';
@@ -22,7 +23,7 @@
         inputEle.value = 'Success!';
         inputEle.classList.remove('btn-primary');
         setTimeout(() => {
-          window.location.href = '/users';
+          window.location.href = localizeHref('/users');
         }, 2000);
       }
     }
@@ -97,7 +98,7 @@
         value={m.organizationMembership_invite_create_sendInviteButton()}
         bind:this={inputEle}
       />
-      <a class="btn" href="/users">{m.common_cancel()}</a>
+      <a class="btn" href={localizeHref('/users')}>{m.common_cancel()}</a>
     </div>
   </form>
 </div>

--- a/source/SIL.AppBuilder.Portal/src/routes/(authenticated)/workflow-instances/+page.svelte
+++ b/source/SIL.AppBuilder.Portal/src/routes/(authenticated)/workflow-instances/+page.svelte
@@ -6,7 +6,7 @@
   import SortTable from '$lib/components/SortTable.svelte';
   import Tooltip from '$lib/components/Tooltip.svelte';
   import { m } from '$lib/paraglide/messages';
-  import { getLocale } from '$lib/paraglide/runtime';
+  import { getLocale, localizeHref } from '$lib/paraglide/runtime';
   import { byName } from '$lib/utils/sorting';
   import { getRelativeTime } from '$lib/utils/time';
   import type { FormResult } from 'sveltekit-superforms';
@@ -129,15 +129,15 @@
           {@const prodDef = instance.Product.ProductDefinition}
           <tr class="cursor-pointer hover:bg-neutral">
             <td class="border">
-              <a class="link" href="/projects/organization/{org.Id}">
+              <a class="link" href={localizeHref(`/projects/organization/${org.Id}`)}>
                 {org.Name}
               </a>
             </td>
             <td class="border">
-              <a class="link" href="/projects/{project.Id}">{project.Name}</a>
+              <a class="link" href={localizeHref(`/projects/${project.Id}`)}>{project.Name}</a>
             </td>
             <td class="border">
-              <a class="link" href="/workflow-instances/{instance.Product.Id}">
+              <a class="link" href={localizeHref(`/workflow-instances/${instance.Product.Id}`)}>
                 {prodDef.Name}
               </a>
             </td>

--- a/source/SIL.AppBuilder.Portal/src/routes/(authenticated)/workflow-instances/[product_id]/+page.svelte
+++ b/source/SIL.AppBuilder.Portal/src/routes/(authenticated)/workflow-instances/[product_id]/+page.svelte
@@ -1,14 +1,15 @@
 <script lang="ts">
   import { browser } from '$app/environment';
+  import Dropdown from '$lib/components/Dropdown.svelte';
   import IconContainer from '$lib/components/IconContainer.svelte';
   import { m } from '$lib/paraglide/messages';
+  import { localizeHref } from '$lib/paraglide/runtime';
   import ProductDetails from '$lib/products/components/ProductDetails.svelte';
   import { Springy } from '$lib/springyGraph.js';
   import { onMount } from 'svelte';
   import { superForm } from 'sveltekit-superforms';
   import { Anchor, Node, Svelvet } from 'svelvet';
   import type { PageData } from './$types';
-  import Dropdown from '$lib/components/Dropdown.svelte';
 
   interface Props {
     data: PageData;
@@ -107,17 +108,20 @@
     <div class="breadcrumbs text-sm grow">
       <ul>
         <li>
-          <a class="link" href="/projects/organization/{data.product?.Project.Organization.Id}">
+          <a
+            class="link"
+            href={localizeHref(`/projects/organization/${data.product?.Project.Organization.Id}`)}
+          >
             {data.product?.Project.Organization.Name}
           </a>
         </li>
         <li>
-          <a class="link" href="/projects/{data.product?.Project.Id}">
+          <a class="link" href={localizeHref(`/projects/${data.product?.Project.Id}`)}>
             {data.product?.Project.Name}
           </a>
         </li>
         <li>
-          <a class="link" href="/workflow-instances">
+          <a class="link" href={localizeHref('/workflow-instances')}>
             {m.workflowInstances_title()}
           </a>
         </li>

--- a/source/SIL.AppBuilder.Portal/src/routes/(unauthenticated)/(auth)/login/+page.server.ts
+++ b/source/SIL.AppBuilder.Portal/src/routes/(unauthenticated)/(auth)/login/+page.server.ts
@@ -1,3 +1,4 @@
+import { localizeHref } from '$lib/paraglide/runtime';
 import { redirect } from '@sveltejs/kit';
 import { signIn } from '../../../../auth';
 import type { Actions, PageServerLoad } from './$types';
@@ -6,9 +7,9 @@ export const load: PageServerLoad = async (event) => {
   if ((await event.locals.auth())?.user) {
     if (event.cookies.get('inviteToken')) {
       const inviteToken = event.cookies.get('inviteToken')!;
-      return redirect(302, '/invitations/organization-membership?t=' + inviteToken);
+      return redirect(302, localizeHref('/invitations/organization-membership?t=' + inviteToken));
     }
-    return redirect(302, '/tasks');
+    return redirect(302, localizeHref('/tasks'));
   }
 };
 export const actions: Actions = { default: signIn };

--- a/source/SIL.AppBuilder.Portal/src/routes/(unauthenticated)/(auth)/logout/+page.server.ts
+++ b/source/SIL.AppBuilder.Portal/src/routes/(unauthenticated)/(auth)/logout/+page.server.ts
@@ -1,8 +1,9 @@
+import { localizeHref } from '$lib/paraglide/runtime';
 import { redirect } from '@sveltejs/kit';
 import { signOut } from '../../../../auth';
 import type { Actions, PageServerLoad } from './$types';
 
 export const load: PageServerLoad = async (event) => {
-  if (!(await event.locals.auth())?.user) return redirect(302, '/');
+  if (!(await event.locals.auth())?.user) return redirect(302, localizeHref('/'));
 };
 export const actions: Actions = { default: signOut };

--- a/source/SIL.AppBuilder.Portal/src/routes/(unauthenticated)/invitations/organization-membership/+page.server.ts
+++ b/source/SIL.AppBuilder.Portal/src/routes/(unauthenticated)/invitations/organization-membership/+page.server.ts
@@ -1,4 +1,5 @@
 import { acceptOrganizationInvite, checkInviteErrors } from '$lib/organizationInvites';
+import { localizeHref } from '$lib/paraglide/runtime';
 import { redirect } from '@sveltejs/kit';
 import type { PageServerLoad } from './$types';
 
@@ -18,6 +19,6 @@ export const load = (async (event) => {
     event.cookies.set('inviteToken', inviteToken, {
       path: '/'
     });
-    return redirect(302, '/login');
+    return redirect(302, localizeHref('/login'));
   }
 }) satisfies PageServerLoad;

--- a/source/SIL.AppBuilder.Portal/src/routes/(unauthenticated)/invitations/organization-membership/+page.svelte
+++ b/source/SIL.AppBuilder.Portal/src/routes/(unauthenticated)/invitations/organization-membership/+page.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
   import { m } from '$lib/paraglide/messages';
+  import { localizeHref } from '$lib/paraglide/runtime';
   import type { PageData } from './$types';
 
   interface Props {
@@ -36,7 +37,7 @@
           <h3>{data.joinedOrganization?.name}</h3>
         </div>
       </div>
-      <a href="/tasks" class="btn btn-primary">
+      <a href={localizeHref('/tasks')} class="btn btn-primary">
         {m.organizationMembership_invite_returnToDashboard()}
       </a>
     {/if}

--- a/source/SIL.AppBuilder.Portal/src/routes/+page.server.ts
+++ b/source/SIL.AppBuilder.Portal/src/routes/+page.server.ts
@@ -1,6 +1,7 @@
+import { localizeHref } from '$lib/paraglide/runtime';
 import { redirect } from '@sveltejs/kit';
 import type { PageServerLoad } from './$types';
 
 export const load: PageServerLoad = async (event) => {
-  if (await event.locals.auth()) return redirect(302, '/tasks');
+  if (await event.locals.auth()) return redirect(302, localizeHref('/tasks'));
 };


### PR DESCRIPTION
Paraglide provides the function `localizeHref` to use in constructing l10n aware URLs. Using this function consistently will correctly preserve a user's locale when following internal links.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - All navigation links now adapt dynamically to the current locale, ensuring consistent and localized routing across menus, settings, and various pages.
  
- **Refactor**
  - Streamlined URL construction throughout the application to replace static paths with dynamically localized links, enhancing overall navigation consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->