### PR TITLE
Fix tooltip to properly display m.directory_searchHelp()

### DIFF
--- a/source/SIL.AppBuilder.Portal/src/lib/components/SearchBar.svelte
+++ b/source/SIL.AppBuilder.Portal/src/lib/components/SearchBar.svelte
@@ -5,27 +5,17 @@
   interface Props {
     className?: string;
     value: string;
-    /** TODO: replace with component. will need to wait until Svelte 5/DaisyUI 5*/
-    tooltip?: string;
   }
 
-  let { className = '', value = $bindable(), tooltip = '' }: Props = $props();
+  let { className = '', value = $bindable() }: Props = $props();
 </script>
 
 <div
-  class="{tooltip ? 'tooltip tooltip-bottom' : ''} {className}"
+  class={className}
   data-html="true"
-  data-tip={tooltip}
 >
   <label class="input input-bordered flex items-center gap-2 w-full">
     <input type="text" placeholder={m.search()} class="grow" bind:value />
     <IconContainer icon="mdi:search" class="ml-auto" width={24} />
   </label>
 </div>
-
-<style>
-  .tooltip:before {
-    white-space: pre-wrap;
-    text-align: start;
-  }
-</style>

--- a/source/SIL.AppBuilder.Portal/src/lib/components/Tooltip.svelte
+++ b/source/SIL.AppBuilder.Portal/src/lib/components/Tooltip.svelte
@@ -2,21 +2,24 @@
   import type { Snippet } from 'svelte';
   
   interface Props {
-    tip: string | null | undefined;
-    className?: string; // TODO: Add snippet support once we have DaisyUI 5
+    tip?: string | null | undefined;
+    className?: string;
+    // tooltip-content can also be handled in the children snippet
     children?: Snippet;
   }
 
   let { tip, className = '', children }: Props = $props();
-  
 </script>
 
-<span class="tooltip [--tt-bg:#FFFFFF] dark:tooltip-secondary {className}" data-tip={tip}>
+<span
+  class="tooltip [--tt-bg:var(--color-white)] dark:tooltip-secondary {className}"
+  data-tip={tip}
+>
   {@render children?.()}
 </span>
 
 <style>
-  .tooltip::before {
+  .tooltip::before, .tooltip :global(.tooltip-content) {
     box-shadow: var(--shadow-md);
   }
 </style>

--- a/source/SIL.AppBuilder.Portal/src/lib/locales/en-us.json
+++ b/source/SIL.AppBuilder.Portal/src/lib/locales/en-us.json
@@ -92,7 +92,7 @@
       "numProjects=*": "Project Directory ({numProjects})"
     }
   }],
-  "directory_searchHelp": "This allows you to search over: \n• Project Name\n• Project Language \n• Owner Name\n• Organization Name\n• Group Name",
+  "directory_searchHelp": "This allows you to search over: <br />• Project Name<br />• Project Language<br />• Owner Name<br />• Organization Name<br />• Group Name",
   "directory_filters_dateRange": "Project Updated Date Between",
   "header_myProfile": "My Profile",
   "header_community": "Community",

--- a/source/SIL.AppBuilder.Portal/src/routes/(authenticated)/directory/+page.svelte
+++ b/source/SIL.AppBuilder.Portal/src/routes/(authenticated)/directory/+page.svelte
@@ -4,6 +4,7 @@
   import OrganizationDropdown from '$lib/components/OrganizationDropdown.svelte';
   import Pagination from '$lib/components/Pagination.svelte';
   import SearchBar from '$lib/components/SearchBar.svelte';
+  import Tooltip from '$lib/components/Tooltip.svelte';
   import { m } from '$lib/paraglide/messages';
   import { getLocale } from '$lib/paraglide/runtime';
   import type { PrunedProject } from '$lib/projects';
@@ -69,11 +70,12 @@
           bind:value={$form.organizationId}
           allowNull={true}
         />
-        <SearchBar
-          bind:value={$form.search}
-          className={mobileSizing}
-          tooltip={m.directory_searchHelp()}
-        />
+        <Tooltip className="tooltip-bottom {mobileSizing}">
+          <div class="tooltip-content text-left">
+            {@html m.directory_searchHelp()}
+          </div>
+          <SearchBar bind:value={$form.search} />
+        </Tooltip>
       </div>
     </div>
     <div class="flex flex-row flex-wrap gap-1 place-content-start px-4 pt-1 {mobileSizing}">

--- a/source/SIL.AppBuilder.Portal/src/routes/(authenticated)/projects/[filter=projectSelector]/[id]/+page.svelte
+++ b/source/SIL.AppBuilder.Portal/src/routes/(authenticated)/projects/[filter=projectSelector]/[id]/+page.svelte
@@ -5,6 +5,7 @@
   import OrganizationDropdown from '$lib/components/OrganizationDropdown.svelte';
   import Pagination from '$lib/components/Pagination.svelte';
   import SearchBar from '$lib/components/SearchBar.svelte';
+  import Tooltip from '$lib/components/Tooltip.svelte';
   import { getIcon } from '$lib/icons/productDefinitionIcon';
   import { m } from '$lib/paraglide/messages';
   import { getLocale } from '$lib/paraglide/runtime';
@@ -151,7 +152,12 @@
           bind:value={$pageForm.organizationId}
           onchange={() => goto($pageForm.organizationId + '')}
         />
-        <SearchBar bind:value={$pageForm.search} className={mobileSizing} />
+        <Tooltip className="tooltip-bottom {mobileSizing}">
+          <div class="tooltip-content text-left">
+            {@html m.directory_searchHelp()}
+          </div>
+          <SearchBar bind:value={$pageForm.search} />
+        </Tooltip>
       </div>
     </div>
   </form>


### PR DESCRIPTION
Changes:
- Add box-shadow to `tooltip` when using DaisyUI 5 `tooltip-content`
- Revert `directory_searchHelp()` to use `<br />` again instead of `\n`
- Use `tooltip-content` class in addition to svelte `@html` to properly render message with embedded HTML
- Remove `tooltip` prop from SearchBar.svelte in favor of wrapping in Tooltip component
- Add tooltip to SearchBar in `/projects/filter`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Integrated a dedicated tooltip component for search help, now wrapping the search bar on directory and project pages.
  
- **Refactor**
  - Removed the built-in tooltip functionality from the search bar to centralize help display.
  - Adjusted tooltip settings to allow optional content handling.
  
- **Style**
  - Improved help text formatting by replacing newline characters with HTML breaks.
  - Enhanced tooltip styling with dynamic theming for a cleaner presentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->