### PR TITLE
Replace inline import with regular import for Snippets

### DIFF
--- a/source/SIL.AppBuilder.Portal/src/lib/components/Tooltip.svelte
+++ b/source/SIL.AppBuilder.Portal/src/lib/components/Tooltip.svelte
@@ -1,8 +1,10 @@
 <script lang="ts">
+  import type { Snippet } from 'svelte';
+  
   interface Props {
     tip: string | null | undefined;
     className?: string; // TODO: Add snippet support once we have DaisyUI 5
-    children?: import('svelte').Snippet;
+    children?: Snippet;
   }
 
   let { tip, className = '', children }: Props = $props();

--- a/source/SIL.AppBuilder.Portal/src/lib/components/TypeaheadInput.svelte
+++ b/source/SIL.AppBuilder.Portal/src/lib/components/TypeaheadInput.svelte
@@ -1,4 +1,5 @@
 <script lang="ts" generics="T">
+  import type { Snippet } from 'svelte';
   import type { HTMLInputAttributes } from 'svelte/elements';
 
   let selectedIndex = $state(-1);
@@ -10,8 +11,8 @@
     getList: (searchTerm: string) => T[];
     search?: string;
     inputElement?: HTMLInputElement;
-    custom?: import('svelte').Snippet;
-    listElement?: import('svelte').Snippet<[any]>;
+    custom?: Snippet;
+    listElement?: Snippet<[any]>;
     onItemClicked?: (item: T) => void;
   }
 

--- a/source/SIL.AppBuilder.Portal/src/lib/components/settings/DataDisplayBox.svelte
+++ b/source/SIL.AppBuilder.Portal/src/lib/components/settings/DataDisplayBox.svelte
@@ -6,6 +6,7 @@
   import type { ValidI13nKey } from '$lib/i18n';
   import { m } from '$lib/paraglide/messages';
   import Icon from '@iconify/svelte';
+  import type { Snippet } from 'svelte';
 
   interface Props {
     title: string | null;
@@ -13,10 +14,10 @@
     fields: {
       key: ValidI13nKey;
       value?: string | null;
-      snippet?: import('svelte').Snippet<[T | undefined]>;
+      snippet?: Snippet<[T | undefined]>;
     }[];
     editable?: boolean;
-    children?: import('svelte').Snippet;
+    children?: Snippet;
     onEdit?: () => void;
   }
 

--- a/source/SIL.AppBuilder.Portal/src/lib/components/settings/InputWithMessage.svelte
+++ b/source/SIL.AppBuilder.Portal/src/lib/components/settings/InputWithMessage.svelte
@@ -6,10 +6,12 @@
 <script lang="ts">
   import type { ValidI13nKey } from '$lib/i18n';
   import * as m from '$lib/paraglide/messages';
+  import type { Snippet } from 'svelte';
+
   interface Props {
     name: ValidI13nKey;
     className?: string;
-    children?: import('svelte').Snippet;
+    children?: Snippet;
   }
 
   let { name, className = '', children }: Props = $props();

--- a/source/SIL.AppBuilder.Portal/src/lib/components/settings/LabeledFormInput.svelte
+++ b/source/SIL.AppBuilder.Portal/src/lib/components/settings/LabeledFormInput.svelte
@@ -6,10 +6,12 @@
 <script lang="ts">
   import type { ValidI13nKey } from '$lib/i18n';
   import { m } from '$lib/paraglide/messages';
+  import type { Snippet } from 'svelte';
+  
   interface Props {
     name: ValidI13nKey;
     className?: string;
-    children?: import('svelte').Snippet;
+    children?: Snippet;
   }
 
   let { name, className = '', children }: Props = $props();

--- a/source/SIL.AppBuilder.Portal/src/lib/components/settings/MultiselectBox.svelte
+++ b/source/SIL.AppBuilder.Portal/src/lib/components/settings/MultiselectBox.svelte
@@ -1,7 +1,9 @@
 <script lang="ts">
+  import type { Snippet } from 'svelte';
+  
   interface Props {
     header: string;
-    children?: import('svelte').Snippet;
+    children?: Snippet;
   }
 
   let { header, children }: Props = $props();

--- a/source/SIL.AppBuilder.Portal/src/lib/components/settings/TabbedMenu.svelte
+++ b/source/SIL.AppBuilder.Portal/src/lib/components/settings/TabbedMenu.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
   import { page } from '$app/state';
+  import type { Snippet } from 'svelte';
   import IconContainer from '../IconContainer.svelte';
 
   interface Props {
@@ -11,8 +12,8 @@
     routeId: string;
     titleString?: string;
     allowTitleWrap?: boolean;
-    children?: import('svelte').Snippet;
-    title?: import('svelte').Snippet;
+    children?: Snippet;
+    title?: Snippet;
   }
 
   let {

--- a/source/SIL.AppBuilder.Portal/src/lib/projects/components/ProjectCard.svelte
+++ b/source/SIL.AppBuilder.Portal/src/lib/projects/components/ProjectCard.svelte
@@ -6,12 +6,13 @@
   import type { PrunedProject } from '$lib/projects';
   import { byString } from '$lib/utils/sorting';
   import { getTimeDateString } from '$lib/utils/time';
+  import type { Snippet } from 'svelte';
 
   interface Props {
     project: PrunedProject;
     route?: string;
-    select?: import('svelte').Snippet;
-    actions?: import('svelte').Snippet;
+    select?: Snippet;
+    actions?: Snippet;
   }
 
   let { project, route = 'projects', select, actions }: Props = $props();

--- a/source/SIL.AppBuilder.Portal/src/routes/(authenticated)/+layout.svelte
+++ b/source/SIL.AppBuilder.Portal/src/routes/(authenticated)/+layout.svelte
@@ -2,17 +2,18 @@
   import { dev } from '$app/environment';
   import { base } from '$app/paths';
   import { page } from '$app/state';
+  import Dropdown from '$lib/components/Dropdown.svelte';
   import LanguageSelector from '$lib/components/LanguageSelector.svelte';
   import { HamburgerIcon } from '$lib/icons';
   import { m } from '$lib/paraglide/messages';
   import { isAdmin, isSuperAdmin } from '$lib/utils/roles';
   import { signOut } from '@auth/sveltekit/client';
+  import type { Snippet } from 'svelte';
   import type { LayoutData } from './$types';
-  import Dropdown from '$lib/components/Dropdown.svelte';
 
   interface Props {
     data: LayoutData;
-    children?: import('svelte').Snippet;
+    children?: Snippet;
   }
 
   let { data, children }: Props = $props();

--- a/source/SIL.AppBuilder.Portal/src/routes/(authenticated)/admin/settings/+layout.svelte
+++ b/source/SIL.AppBuilder.Portal/src/routes/(authenticated)/admin/settings/+layout.svelte
@@ -7,8 +7,10 @@
   import { base } from '$app/paths';
   import TabbedMenu from '$lib/components/settings/TabbedMenu.svelte';
   import { m } from '$lib/paraglide/messages';
+  import type { Snippet } from 'svelte';
+  
   interface Props {
-    children?: import('svelte').Snippet;
+    children?: Snippet;
   }
 
   let { children }: Props = $props();

--- a/source/SIL.AppBuilder.Portal/src/routes/(authenticated)/admin/settings/build-engines/+layout.svelte
+++ b/source/SIL.AppBuilder.Portal/src/routes/(authenticated)/admin/settings/build-engines/+layout.svelte
@@ -1,7 +1,12 @@
-<script>
+<script lang="ts">
   import { m } from '$lib/paraglide/messages';
-  /** @type {{children?: import('svelte').Snippet}} */
-  let { children } = $props();
+  import type { Snippet } from 'svelte';
+
+  interface Props {
+    children?: Snippet;
+  }
+
+  let { children }: Props = $props();
 </script>
 
 <h2>{m.admin_settings_buildEngines_title()}</h2>

--- a/source/SIL.AppBuilder.Portal/src/routes/(authenticated)/admin/settings/organizations/+layout.svelte
+++ b/source/SIL.AppBuilder.Portal/src/routes/(authenticated)/admin/settings/organizations/+layout.svelte
@@ -1,8 +1,11 @@
 <script lang="ts">
   import { m } from '$lib/paraglide/messages';
+  import type { Snippet } from 'svelte';
+
   interface Props {
-    children?: import('svelte').Snippet;
+    children?: Snippet;
   }
+  
   let { children }: Props = $props();
 </script>
 

--- a/source/SIL.AppBuilder.Portal/src/routes/(authenticated)/admin/settings/product-definitions/+layout.svelte
+++ b/source/SIL.AppBuilder.Portal/src/routes/(authenticated)/admin/settings/product-definitions/+layout.svelte
@@ -1,8 +1,11 @@
 <script lang="ts">
   import { m } from '$lib/paraglide/messages';
+  import type { Snippet } from 'svelte';
+
   interface Props {
-    children?: import('svelte').Snippet;
+    children?: Snippet;
   }
+
   let { children }: Props = $props();
 </script>
 

--- a/source/SIL.AppBuilder.Portal/src/routes/(authenticated)/admin/settings/store-types/+layout.svelte
+++ b/source/SIL.AppBuilder.Portal/src/routes/(authenticated)/admin/settings/store-types/+layout.svelte
@@ -1,7 +1,12 @@
-<script>
+<script lang="ts">
   import { m } from '$lib/paraglide/messages';
-  /** @type {{children?: import('svelte').Snippet}} */
-  let { children } = $props();
+  import type { Snippet } from 'svelte';
+  
+  interface Props {
+    children?: Snippet;
+  }
+
+  let { children }: Props = $props();
 </script>
 
 <h2>{m.admin_settings_storeTypes_title()}</h2>

--- a/source/SIL.AppBuilder.Portal/src/routes/(authenticated)/admin/settings/stores/+layout.svelte
+++ b/source/SIL.AppBuilder.Portal/src/routes/(authenticated)/admin/settings/stores/+layout.svelte
@@ -1,8 +1,11 @@
 <script lang="ts">
   import { m } from '$lib/paraglide/messages';
+  import type { Snippet } from 'svelte';
+
   interface Props {
-    children?: import('svelte').Snippet;
+    children?: Snippet;
   }
+  
   let { children }: Props = $props();
 </script>
 

--- a/source/SIL.AppBuilder.Portal/src/routes/(authenticated)/admin/settings/workflow-definitions/+layout.svelte
+++ b/source/SIL.AppBuilder.Portal/src/routes/(authenticated)/admin/settings/workflow-definitions/+layout.svelte
@@ -1,8 +1,11 @@
 <script lang="ts">
   import { m } from '$lib/paraglide/messages';
+  import type { Snippet } from 'svelte';
+
   interface Props {
-    children?: import('svelte').Snippet;
+    children?: Snippet;
   }
+  
   let { children }: Props = $props();
 </script>
 

--- a/source/SIL.AppBuilder.Portal/src/routes/(authenticated)/organizations/[id]/settings/+layout.svelte
+++ b/source/SIL.AppBuilder.Portal/src/routes/(authenticated)/organizations/[id]/settings/+layout.svelte
@@ -10,11 +10,12 @@
     org_settingsTitle,
     org_storesTitle
   } from '$lib/paraglide/messages';
+  import type { Snippet } from 'svelte';
   import type { LayoutData } from './$types';
 
   interface Props {
     data: LayoutData;
-    children?: import('svelte').Snippet;
+    children?: Snippet;
   }
 
   let { data, children }: Props = $props();

--- a/source/SIL.AppBuilder.Portal/src/routes/(authenticated)/users/[id=idNumber]/settings/+layout.svelte
+++ b/source/SIL.AppBuilder.Portal/src/routes/(authenticated)/users/[id=idNumber]/settings/+layout.svelte
@@ -3,6 +3,7 @@
   import { page } from '$app/state';
   import TabbedMenu from '$lib/components/settings/TabbedMenu.svelte';
   import { m } from '$lib/paraglide/messages';
+  import type { Snippet } from 'svelte';
   import type { LayoutData } from './$types';
 
   let userSettingsLinks = [
@@ -13,7 +14,7 @@
 
   interface Props {
     data: LayoutData;
-    children?: import('svelte').Snippet;
+    children?: Snippet;
   }
 
   let { data, children }: Props = $props();

--- a/source/SIL.AppBuilder.Portal/src/routes/(unauthenticated)/(auth)/+layout.svelte
+++ b/source/SIL.AppBuilder.Portal/src/routes/(unauthenticated)/(auth)/+layout.svelte
@@ -1,7 +1,10 @@
 <script lang="ts">
+  import type { Snippet } from 'svelte';
+
   interface Props {
-    children?: import('svelte').Snippet;
+    children?: Snippet;
   }
+  
   let { children }: Props = $props();
 </script>
 

--- a/source/SIL.AppBuilder.Portal/src/routes/+layout.svelte
+++ b/source/SIL.AppBuilder.Portal/src/routes/+layout.svelte
@@ -1,8 +1,11 @@
 <script lang="ts">
+  import type { Snippet } from 'svelte';
   import '../app.css';
+  
   interface Props {
-    children?: import('svelte').Snippet;
+    children?: Snippet;
   }
+  
   let { children }: Props = $props();
 </script>
 


### PR DESCRIPTION
This has been a common nitpick in multiple PRs. I have fixed the remaining instances of this import style (for Snippets) across the board.