### PR TITLE
Fix LanguageCodeTypeahead results to more closely match S1

### DIFF
--- a/source/SIL.AppBuilder.Portal/src/lib/components/LanguageCodeTypeahead.svelte
+++ b/source/SIL.AppBuilder.Portal/src/lib/components/LanguageCodeTypeahead.svelte
@@ -49,7 +49,7 @@
   });
 
   function search(searchValue: string) {
-    return fuzzySearch.search(searchValue);
+    return fuzzySearch.search(searchValue, { limit: 5 });
   }
   type FuseResult = ReturnType<typeof search>[number];
 
@@ -154,7 +154,7 @@
 
 <TypeaheadInput
   inputElProps={{ placeholder: m.project_languageCode(), ...inputElProps }}
-  getList={(searchValue) => search(searchValue).slice(0, 5)}
+  getList={(searchValue) => search(searchValue)}
   classes="pr-20 {inputClasses}"
   bind:search={langCode}
   onItemClicked={(res) => {
@@ -175,7 +175,7 @@
       {langtagList.find((l) => l.tag === langCode)?.nameInLocale ?? ''}
     </span>
     {#if validatorHint}
-      <br>
+      <br />
       {@render validatorHint()}
     {/if}
   {/snippet}

--- a/source/SIL.AppBuilder.Portal/src/lib/components/LanguageCodeTypeahead.svelte
+++ b/source/SIL.AppBuilder.Portal/src/lib/components/LanguageCodeTypeahead.svelte
@@ -42,7 +42,7 @@
     includeScore: true,
     includeMatches: true,
     isCaseSensitive: false,
-    threshold: 0.6,
+    threshold: 0.2,
     ignoreLocation: true,
     ignoreFieldNorm: true
     // minMatchCharLength: 2


### PR DESCRIPTION
Fixes #1099 

Granted, it still isn't identical to S1, but it is much closer.

S1:
![image](https://github.com/user-attachments/assets/3b2a16a2-3101-48f9-b233-f36b08f5f6f8)

S2:
![image](https://github.com/user-attachments/assets/bc046e13-2309-4db0-b998-286ec65c28d9)

S1:
![image](https://github.com/user-attachments/assets/d6a7ccd5-c8ad-468f-89c4-6de830773b6e)

S2:
![image](https://github.com/user-attachments/assets/5d271a59-6780-418d-9bef-863bf228f625)

S1:
![image](https://github.com/user-attachments/assets/c42bb493-3aff-468c-a60c-22726420fa4a)

S2:
![image](https://github.com/user-attachments/assets/7eb6b275-365b-43f5-8757-176f46d7d439)

S1:
![image](https://github.com/user-attachments/assets/e5d773d7-c8f7-48ac-b76f-0ad45665386d)

S2:
![image](https://github.com/user-attachments/assets/37b0dea2-8029-4750-ae2c-a4e0ff631bdb)
