### PR TITLE
Use specific ports instead of defaults

### DIFF
--- a/source/SIL.AppBuilder.Portal/Dockerfile
+++ b/source/SIL.AppBuilder.Portal/Dockerfile
@@ -45,5 +45,5 @@ COPY --from=builder /build/common /app/common
 # Copy prisma data (npm ci nukes node_modules, so this must be last)
 COPY --from=builder /build/node_modules/.prisma /app/node_modules/.prisma
 
-EXPOSE 3000
+EXPOSE 6000
 CMD ["node", "/app/index.js"]

--- a/source/SIL.AppBuilder.Portal/Dockerfile
+++ b/source/SIL.AppBuilder.Portal/Dockerfile
@@ -45,5 +45,5 @@ COPY --from=builder /build/common /app/common
 # Copy prisma data (npm ci nukes node_modules, so this must be last)
 COPY --from=builder /build/node_modules/.prisma /app/node_modules/.prisma
 
-EXPOSE 6000
+EXPOSE 6100
 CMD ["node", "/app/index.js"]

--- a/source/SIL.AppBuilder.Portal/node-server/dev.ts
+++ b/source/SIL.AppBuilder.Portal/node-server/dev.ts
@@ -16,7 +16,7 @@ createBullBoard({
   serverAdapter
 });
 app.use(serverAdapter.getRouter());
-app.listen(3000, () => console.log('Dev server started'));
+app.listen(6000, () => console.log('Dev server started'));
 
 new Workers.Builds();
 new Workers.DefaultRecurring();

--- a/source/SIL.AppBuilder.Portal/node-server/dev.ts
+++ b/source/SIL.AppBuilder.Portal/node-server/dev.ts
@@ -16,7 +16,7 @@ createBullBoard({
   serverAdapter
 });
 app.use(serverAdapter.getRouter());
-app.listen(6000, () => console.log('Dev server started'));
+app.listen(6100, () => console.log('Dev server started'));
 
 new Workers.Builds();
 new Workers.DefaultRecurring();

--- a/source/SIL.AppBuilder.Portal/node-server/index.ts
+++ b/source/SIL.AppBuilder.Portal/node-server/index.ts
@@ -99,4 +99,4 @@ const handler = await import('./build/handler.js');
 // Svelte application handles authentication already, including login and logout
 app.use(handler.handler);
 
-app.listen(6000, () => console.log('Server started!'));
+app.listen(6100, () => console.log('Server started!'));

--- a/source/SIL.AppBuilder.Portal/node-server/index.ts
+++ b/source/SIL.AppBuilder.Portal/node-server/index.ts
@@ -99,4 +99,4 @@ const handler = await import('./build/handler.js');
 // Svelte application handles authentication already, including login and logout
 app.use(handler.handler);
 
-app.listen(3000, () => console.log('Server started!'));
+app.listen(6000, () => console.log('Server started!'));

--- a/source/SIL.AppBuilder.Portal/node-server/job-executors/common.build-publish.ts
+++ b/source/SIL.AppBuilder.Portal/node-server/job-executors/common.build-publish.ts
@@ -30,7 +30,7 @@ export async function addProductPropertiesToEnvironment(productId: string) {
       Properties: true
     }
   });
-  const uiUrl = process.env.UI_URL || 'http://localhost:5173';
+  const uiUrl = process.env.UI_URL || 'http://localhost:6173';
   const projectUrl = uiUrl + '/projects/' + product.Project.Id;
 
   return {

--- a/source/SIL.AppBuilder.Portal/node-server/job-executors/project.ts
+++ b/source/SIL.AppBuilder.Portal/node-server/job-executors/project.ts
@@ -34,7 +34,7 @@ export async function create(job: Job<BullMQ.Project.Create>): Promise<unknown> 
   } else {
     await DatabaseWrites.projects.update(job.data.projectId, {
       WorkflowProjectId: response.id,
-      WorkflowAppProjectUrl: `${process.env.UI_URL ?? 'http://localhost:5173'}/projects/${
+      WorkflowAppProjectUrl: `${process.env.UI_URL || 'http://localhost:6173'}/projects/${
         job.data.projectId
       }`
     });

--- a/source/SIL.AppBuilder.Portal/src/routes/(authenticated)/+layout.svelte
+++ b/source/SIL.AppBuilder.Portal/src/routes/(authenticated)/+layout.svelte
@@ -189,7 +189,7 @@
             <li>
               <a
                 class="rounded-none"
-                href={dev ? 'http://localhost:6000' : '/admin/jobs'}
+                href={dev ? 'http://localhost:6100' : '/admin/jobs'}
                 onclick={closeDrawer}
                 target="_blank"
               >

--- a/source/SIL.AppBuilder.Portal/src/routes/(authenticated)/+layout.svelte
+++ b/source/SIL.AppBuilder.Portal/src/routes/(authenticated)/+layout.svelte
@@ -189,7 +189,7 @@
             <li>
               <a
                 class="rounded-none"
-                href={dev ? 'http://localhost:3000' : '/admin/jobs'}
+                href={dev ? 'http://localhost:6000' : '/admin/jobs'}
                 onclick={closeDrawer}
                 target="_blank"
               >

--- a/source/SIL.AppBuilder.Portal/vite.config.ts
+++ b/source/SIL.AppBuilder.Portal/vite.config.ts
@@ -17,7 +17,8 @@ export default defineConfig({
   server: {
     fs: {
       allow: [searchForWorkspaceRoot(process.cwd()), '/common']
-    }
+    },
+    port: 6173
   },
   plugins: [
     tailwindcss(),


### PR DESCRIPTION
Use localhost:6173 for UI
Use localhost:6100 for backend

Since 5173 is the default for SvelteKit projects, and we now have several of those, using different ports for each makes it simpler to have multiple running locally if needed.