### PR TITLE
Use Prisma to compose typing for components

### DIFF
--- a/portal/src/auth.ts
+++ b/portal/src/auth.ts
@@ -7,6 +7,7 @@ import { SvelteKitAuth, type DefaultSession, type SvelteKitAuthConfig } from '@a
 import Auth0Provider from '@auth/sveltekit/providers/auth0';
 import { error, redirect, type Handle } from '@sveltejs/kit';
 import { DatabaseWrites, prisma } from 'sil.appbuilder.portal.common';
+import type { RoleId } from 'sil.appbuilder.portal.common/prisma';
 
 // this works, even though TS/eslint are unhappy (no actual errors here, see the expect errors elsewhere)
 declare module '@auth/sveltekit' {
@@ -14,7 +15,7 @@ declare module '@auth/sveltekit' {
     user: {
       userId: number;
       /** [organizationId, RoleId][]*/
-      roles: [number, number][];
+      roles: [number, RoleId][];
     } & DefaultSession['user'];
   }
 }

--- a/portal/src/lib/products/components/BuildArtifacts.svelte
+++ b/portal/src/lib/products/components/BuildArtifacts.svelte
@@ -6,25 +6,32 @@
   import { bytesToHumanSize } from '$lib/utils';
   import { byString } from '$lib/utils/sorting';
   import { getRelativeTime } from '$lib/utils/time';
+  import type { Prisma } from '@prisma/client';
 
   interface Props {
-    build: {
-      Version: string | null;
-      Success: boolean | null;
-      BuildId: number;
-      ProductArtifacts: {
-        ArtifactType: string | null;
-        FileSize: bigint | null;
-        Url: string | null;
-        DateUpdated: Date | null;
-      }[];
-      ProductPublications: {
-        Channel: string | null;
-        Success: boolean | null;
-        LogUrl: string | null;
-        DateUpdated: Date | null;
-      }[];
-    };
+    build: Prisma.ProductBuildsGetPayload<{
+      select: {
+        Version: true;
+        Success: true;
+        BuildId: true;
+        ProductArtifacts: {
+          select: {
+            ArtifactType: true;
+            FileSize: true;
+            Url: true;
+            DateUpdated: true;
+          };
+        };
+        ProductPublications: {
+          select: {
+            Channel: true;
+            Success: true;
+            LogUrl: true;
+            DateUpdated: true;
+          };
+        };
+      };
+    }>;
     latestBuildId: number | undefined;
   }
 
@@ -53,7 +60,7 @@
       {versionString(build)}
     </span>
     <span>
-      {m.project_products_numArtifacts({ amount: build.ProductArtifacts.length})}
+      {m.project_products_numArtifacts({ amount: build.ProductArtifacts.length })}
     </span>
   </div>
   <div class="p-2 overflow-x-auto">

--- a/portal/src/lib/products/components/ProductDetails.svelte
+++ b/portal/src/lib/products/components/ProductDetails.svelte
@@ -2,26 +2,31 @@
   import IconContainer from '$lib/components/IconContainer.svelte';
   import { m } from '$lib/paraglide/messages';
   import { getTimeDateString } from '$lib/utils/time';
+  import type { Prisma } from '@prisma/client';
   import { ProductTransitionType } from 'sil.appbuilder.portal.common/prisma';
 
   interface Props {
-    product: {
-      Id: string;
-      Store: { Description: string | null } | null;
-      Transitions: {
-        TransitionType: number;
-        InitialState: string | null;
-        WorkflowType: number | null;
-        AllowedUserNames: string | null;
-        Command: string | null;
-        Comment: string | null;
-        DateTransition: Date | null;
-        User: { Name: string | null } | null;
-      }[];
-    };
+    product: Prisma.ProductsGetPayload<{
+      select: {
+        Id: true;
+        Store: { select: { Description: true } };
+      };
+    }>;
+    transitions: Prisma.ProductTransitionsGetPayload<{
+      select: {
+        TransitionType: true;
+        InitialState: true;
+        WorkflowType: true;
+        AllowedUserNames: true;
+        Command: true;
+        Comment: true;
+        DateTransition: true;
+        User: { select: { Name: true } };
+      };
+    }>[];
   }
 
-  let { product }: Props = $props();
+  let { product, transitions }: Props = $props();
 
   function stateString(workflowTypeNum: number, transitionType: number) {
     if ([2, 3, 4].includes(transitionType)) {
@@ -75,7 +80,7 @@
         </tr>
       </thead>
       <tbody>
-        {#each product.Transitions as transition}
+        {#each transitions as transition}
           <tr class:font-bold={[2, 3, 4].includes(transition.TransitionType)}>
             <td>
               {#if transition.TransitionType === ProductTransitionType.Activity}

--- a/portal/src/lib/products/index.ts
+++ b/portal/src/lib/products/index.ts
@@ -1,4 +1,5 @@
-import { WorkflowType } from "sil.appbuilder.portal.common/prisma";
+import type { Prisma } from '@prisma/client';
+import { WorkflowType } from 'sil.appbuilder.portal.common/prisma';
 
 export enum ProductActionType {
   Rebuild = 'rebuild',
@@ -7,15 +8,21 @@ export enum ProductActionType {
 }
 
 export function getProductActions(
-  product: {
-    WorkflowInstance: {
-      WorkflowDefinition: {
-        Type: WorkflowType;
+  product: Prisma.ProductsGetPayload<{
+    select: {
+      WorkflowInstance: {
+        select: {
+          WorkflowDefinition: {
+            select: {
+              Type: true;
+            };
+          };
+        };
       };
-    } | null;
-    DatePublished: unknown;
-    ProductDefinition: { RebuildWorkflowId: unknown; RepublishWorkflowId: unknown };
-  },
+      DatePublished: true;
+      ProductDefinition: { select: { RebuildWorkflowId: true; RepublishWorkflowId: true } };
+    };
+  }>,
   projectOwnerId: number,
   userId: number
 ) {
@@ -44,6 +51,7 @@ export async function getFileInfo(url: string) {
   return {
     contentType: res.headers.get('Content-Type'),
     lastModified: new Date(res.headers.get('Last-Modified') ?? 0).toISOString(),
-    fileSize: res.headers.get('Content-Type') !== 'text/html'? res.headers.get('Content-Length') : null
-  }
+    fileSize:
+      res.headers.get('Content-Type') !== 'text/html' ? res.headers.get('Content-Length') : null
+  };
 }

--- a/portal/src/lib/projects/index.ts
+++ b/portal/src/lib/projects/index.ts
@@ -153,13 +153,15 @@ export const bulkProjectActionSchema = v.object({
 
 export type ProjectActionSchema = typeof projectActionSchema;
 
-export type ProjectForAction = {
-  Id: number;
-  Name: string | null;
-  OwnerId: number;
-  GroupId: number;
-  DateArchived: Date | null;
-};
+export type ProjectForAction = Prisma.ProjectsGetPayload<{
+  select: {
+    Id: true;
+    Name: true;
+    OwnerId: true;
+    GroupId: true;
+    DateArchived: true;
+  };
+}>;
 
 export function canModifyProject(
   user: Session | null | undefined,

--- a/portal/src/lib/utils/roles.ts
+++ b/portal/src/lib/utils/roles.ts
@@ -1,9 +1,12 @@
-import { RoleId } from "sil.appbuilder.portal.common/prisma";
+import type { Session } from '@auth/sveltekit';
+import { RoleId } from 'sil.appbuilder.portal.common/prisma';
+
+type RolesMap = Session['user']['roles'];
 
 /** returns true if user is a SuperAdmin, or is an OrgAdmin for the specified organization
  * @param roles [OrganizationId, RoleId][]
  */
-export function isAdminForOrg(orgId: number, roles?: [number, number][]): boolean {
+export function isAdminForOrg(orgId: number, roles?: RolesMap): boolean {
   return !!roles?.find(
     ([org, role]) => role === RoleId.SuperAdmin || (role === RoleId.OrgAdmin && org === orgId)
   );
@@ -11,7 +14,7 @@ export function isAdminForOrg(orgId: number, roles?: [number, number][]): boolea
 /** returns true if user is a SuperAdmin, or is an OrgAdmin for any of the provided orgs
  * @param roles [OrganizationId, RoleId][]
  */
-export function isAdminForOrgs(orgs: number[], roles?: [number, number][]): boolean {
+export function isAdminForOrgs(orgs: number[], roles?: RolesMap): boolean {
   return !!roles?.find(
     ([org, role]) => role === RoleId.SuperAdmin || (role === RoleId.OrgAdmin && orgs.includes(org))
   );
@@ -19,28 +22,28 @@ export function isAdminForOrgs(orgs: number[], roles?: [number, number][]): bool
 /** returns true if user is a SuperAdmin, or is an OrgAdmin for any organization
  * @param roles [OrganizationId, RoleId][]
  */
-export function isAdmin(roles?: [number, number][]): boolean {
-  return !!roles?.find((r) => r[1] === RoleId.SuperAdmin || r[1] === RoleId.OrgAdmin);
+export function isAdmin(roles?: RolesMap): boolean {
+  return !!roles?.find(([_, role]) => role === RoleId.SuperAdmin || role === RoleId.OrgAdmin);
 }
 /** returns true if user is a SuperAdmin
  * @param roles [OrganizationId, RoleId][]
  */
-export function isSuperAdmin(roles?: [number, number][]): boolean {
-  return !!roles?.find((r) => r[1] === RoleId.SuperAdmin);
+export function isSuperAdmin(roles?: RolesMap): boolean {
+  return !!roles?.find(([_, role]) => role === RoleId.SuperAdmin);
 }
 /** returns true if user has specified role in specified org
- * 
+ *
  * IS NOT SHORT-CIRCUITED by SuperAdmin
  * @param roles [OrganizationId, RoleId][]
  */
-export function hasRoleForOrg(role: RoleId, orgId: number, roles?: [number, number][]): boolean {
-  return !!roles?.find((r) => r[1] === role && r[0] === orgId);
+export function hasRoleForOrg(role: RoleId, orgId: number, roles?: RolesMap): boolean {
+  return !!roles?.find(([org, roleId]) => roleId === role && org === orgId);
 }
-/** returns a list of organizations where the user has the specified role 
- * 
+/** returns a list of organizations where the user has the specified role
+ *
  * IS NOT SHORT-CIRCUITED by SuperAdmin
  * @param roles [OrganizationId, RoleId][]
-*/
-export function orgsForRole(role: RoleId, roles?: [number, number][]): number[] {
-  return roles?.filter((r) => r[1] === role).map((r) => r[0]) ?? [];
+ */
+export function orgsForRole(role: RoleId, roles?: RolesMap): number[] {
+  return roles?.filter(([_, roleId]) => roleId === role).map(([org, _]) => org) ?? [];
 }

--- a/portal/src/routes/(authenticated)/projects/[id=idNumber]/+page.svelte
+++ b/portal/src/routes/(authenticated)/projects/[id=idNumber]/+page.svelte
@@ -89,9 +89,7 @@
   let selectingStore: boolean = $state(false);
   let selectedProduct = $state(data.productsToAdd[0]);
   let availableStores = $derived(
-    data.stores.filter(
-      (s) => s.StoreTypeId === selectedProduct.Workflow.StoreTypeId
-    )
+    data.stores.filter((s) => s.StoreTypeId === selectedProduct.Workflow.StoreTypeId)
   );
 
   let deleteProductModal: HTMLDialogElement | undefined = $state(undefined);
@@ -456,7 +454,7 @@
                   {/if}
                 </div>
               {/if}
-              <ProductDetails {product} />
+              <ProductDetails {product} transitions={product.Transitions} />
             </div>
           {/each}
         {/if}

--- a/portal/src/routes/(authenticated)/projects/[id=idNumber]/DeleteProductModal.svelte
+++ b/portal/src/routes/(authenticated)/projects/[id=idNumber]/DeleteProductModal.svelte
@@ -2,16 +2,21 @@
   import { enhance } from '$app/forms';
   import { m } from '$lib/paraglide/messages';
   import { getLocale } from '$lib/paraglide/runtime';
+  import type { Prisma } from '@prisma/client';
 
   interface Props {
     modal?: HTMLDialogElement;
-    product: {
-      Id: string;
-      DatePublished: Date | null;
-      ProductDefinition: {
-        Name: string | null;
+    product: Prisma.ProductsGetPayload<{
+      select: {
+        Id: true;
+        DatePublished: true;
+        ProductDefinition: {
+          select: {
+            Name: true;
+          };
+        };
       };
-    };
+    }>;
     endpoint: string;
     project: string;
   }

--- a/portal/src/routes/(authenticated)/projects/[id=idNumber]/PropertiesModal.svelte
+++ b/portal/src/routes/(authenticated)/projects/[id=idNumber]/PropertiesModal.svelte
@@ -3,13 +3,16 @@
   import LabeledFormInput from '$lib/components/settings/LabeledFormInput.svelte';
   import PropertiesEditor from '$lib/components/settings/PropertiesEditor.svelte';
   import { m } from '$lib/paraglide/messages';
+  import type { Prisma } from '@prisma/client';
 
   interface Props {
     modal?: HTMLDialogElement;
-    product: {
-      Id: string;
-      Properties: string | null;
-    };
+    product: Prisma.ProductsGetPayload<{
+      select: {
+        Id: true;
+        Properties: true;
+      };
+    }>;
     endpoint: string;
   }
 

--- a/portal/src/routes/(authenticated)/users/GroupsSelector.svelte
+++ b/portal/src/routes/(authenticated)/users/GroupsSelector.svelte
@@ -1,9 +1,10 @@
 <script
   lang="ts"
-  generics="Group extends { Id: number; Name: string | null } & Record<string, unknown>"
+  generics="Group extends Prisma.GroupsGetPayload<{ select: { Id: true; Name: true }}>"
 >
   import { getLocale } from '$lib/paraglide/runtime';
   import { byName } from '$lib/utils/sorting';
+  import type { Prisma } from '@prisma/client';
   import type { Snippet } from 'svelte';
 
   interface Props {

--- a/portal/src/routes/(authenticated)/users/common.ts
+++ b/portal/src/routes/(authenticated)/users/common.ts
@@ -1,14 +1,20 @@
-type UserInfo = {
-  Id: number;
-  Name: string | null;
-  Email: string | null;
-  UserRoles: { OrganizationId: number; RoleId: number }[];
-  GroupMemberships: { Group: { Id: number; OwnerId: number } }[];
-  OrganizationMemberships: {
-    OrganizationId: number;
-  }[];
-  IsLocked: boolean;
-};
+import type { Prisma } from '@prisma/client';
+
+type UserInfo = Prisma.UsersGetPayload<{
+  select: {
+    Id: true;
+    Name: true;
+    Email: true;
+    UserRoles: { select: { OrganizationId: true; RoleId: true } };
+    GroupMemberships: { select: { Group: { select: { Id: true; OwnerId: true } } } };
+    OrganizationMemberships: {
+      select: {
+        OrganizationId: true;
+      };
+    };
+    IsLocked: true;
+  };
+}>;
 
 // or by using smaller (or even minified) keys (eg N instead of Name, O instead of Organizations)
 // Done - Aidan
@@ -33,7 +39,7 @@ export function minifyUser(user: UserInfo) {
         (groupMem) => groupMem.Group.OwnerId === orgMem.OrganizationId
       ).map((group) => group.Group.Id)
     })),
-    /** User IsLocked */
+    /** User is Active (i.e. !IsLocked) */
     A: !user.IsLocked
   };
 }

--- a/portal/src/routes/(authenticated)/workflow-instances/[product_id]/+page.server.ts
+++ b/portal/src/routes/(authenticated)/workflow-instances/[product_id]/+page.server.ts
@@ -40,28 +40,6 @@ export const load: PageServerLoad = async ({ params }) => {
         select: {
           Name: true
         }
-      },
-      ProductTransitions: {
-        select: {
-          DateTransition: true,
-          DestinationState: true,
-          InitialState: true,
-          Command: true,
-          TransitionType: true,
-          WorkflowType: true,
-          AllowedUserNames: true,
-          Comment: true,
-          User: {
-            select: {
-              Name: true
-            }
-          }
-        },
-        orderBy: [
-          {
-            DateTransition: 'asc'
-          }
-        ]
       }
     }
   });
@@ -83,11 +61,7 @@ export const load: PageServerLoad = async ({ params }) => {
   });
 
   return {
-    product: {
-      ...product,
-      Transitions: product?.ProductTransitions,
-      ProductTransitions: undefined
-    },
+    product,
     snapshot: snap,
     machine: snap ? flow.serializeForVisualization() : [],
     definition: workflowDefinition,
@@ -96,7 +70,30 @@ export const load: PageServerLoad = async ({ params }) => {
         state: snap?.state
       },
       valibot(jumpStateSchema)
-    )
+    ),
+    transitions: await prisma.productTransitions.findMany({
+      where: { ProductId: params.product_id },
+      select: {
+        DateTransition: true,
+        DestinationState: true,
+        InitialState: true,
+        Command: true,
+        TransitionType: true,
+        WorkflowType: true,
+        AllowedUserNames: true,
+        Comment: true,
+        User: {
+          select: {
+            Name: true
+          }
+        }
+      },
+      orderBy: [
+        {
+          DateTransition: 'asc'
+        }
+      ]
+    })
   };
 };
 

--- a/portal/src/routes/(authenticated)/workflow-instances/[product_id]/+page.svelte
+++ b/portal/src/routes/(authenticated)/workflow-instances/[product_id]/+page.svelte
@@ -157,7 +157,7 @@
       </Dropdown>
     </span>
   </div>
-  <ProductDetails product={data.product} />
+  <ProductDetails product={data.product} transitions={data.transitions} />
   <div id="svelvet-wrapper">
     {#if ready}
       <Svelvet


### PR DESCRIPTION
I got tired of having to specify the exact type of specific fields from the database. Prisma.<model>GetPayload creates an easy way to "select" database fields to be included in a type. This was already used in a few other places already.

Also updated the roles utility functions to key off of the Session type from `src/auth.ts` (no substantive change).

If at all possible, I would like this to be merged *before* #1120 so I can make some changes there to reflect this PR.