### PR TITLE
Create a custom polyfill for Arra.toSorted

### DIFF
--- a/portal/src/app.html
+++ b/portal/src/app.html
@@ -13,7 +13,7 @@
 
     %sveltekit.head%
   </head>
-  <script src="./custom-polyfills.js"></script>
+  <script src="/custom-polyfills.js"></script>
   <body data-sveltekit-preload-data="hover">
     <div style="display: contents">%sveltekit.body%</div>
   </body>

--- a/portal/src/app.html
+++ b/portal/src/app.html
@@ -13,6 +13,7 @@
 
     %sveltekit.head%
   </head>
+  <script src="./custom-polyfills.js"></script>
   <body data-sveltekit-preload-data="hover">
     <div style="display: contents">%sveltekit.body%</div>
   </body>

--- a/portal/static/custom-polyfills.js
+++ b/portal/static/custom-polyfills.js
@@ -1,0 +1,9 @@
+if (!Array.prototype.toSorted)
+  Array.prototype.toSorted = function (
+    /** @type {((a: any, b: any) => number) | undefined} */ compareFn
+  ) {
+    if (typeof compareFn !== 'function') {
+      throw new Error(`Array.prototype.toSorted: ${compareFn} is not a function!`);
+    }
+    return this.slice(0).sort(compareFn);
+  };

--- a/portal/static/custom-polyfills.js
+++ b/portal/static/custom-polyfills.js
@@ -1,4 +1,4 @@
-if (!Array.prototype.toSorted)
+if (!Array.prototype.toSorted) {
   Array.prototype.toSorted = function (
     /** @type {((a: any, b: any) => number) | undefined} */ compareFn
   ) {
@@ -7,3 +7,4 @@ if (!Array.prototype.toSorted)
     }
     return this.slice(0).sort(compareFn);
   };
+}


### PR DESCRIPTION
Instead of going throughout the entire code base and replacing all instances of `arr.toSorted` with `[...arr].sort`, which looks ugly, I opted to instead create a simple script that would polyfill `Array.prototype.toSorted` with a reasonable implementation if it doesn't exist. I wasn't able to test this in a browser that doesn't have `toSorted` implemented, but I was able to test it by manually setting `Array.prototype.toSorted` to undefined (which does in fact break the site), and then let the polyfill assign a working implementation.

`slice` and `sort` both have 95-96% availability according to caniuse.com, an improvement over the 91% availability for `toSorted`.

I created this in a `custom-polyfills.js` so we can add our own implementations in the future for whenever we would like to use any other functions with *only* 91% coverage.