### PR TITLE
Share Redis connection with Queues and Workers

### DIFF
--- a/portal/common/bullmq/queues.ts
+++ b/portal/common/bullmq/queues.ts
@@ -3,13 +3,14 @@ import { Redis } from 'ioredis';
 import type { Job } from './types.js';
 import { QueueName } from './types.js';
 
-export const REDIS_URL = process.env.NODE_ENV === 'development' ? 'localhost' : 'redis';
-
 class Connection {
   private conn: Redis;
   private connected: boolean;
   constructor() {
-    this.conn = new Redis({ host: REDIS_URL, maxRetriesPerRequest: null });
+    this.conn = new Redis({
+      host: process.env.NODE_ENV === 'development' ? 'localhost' : 'redis',
+      maxRetriesPerRequest: null
+    });
     this.connected = false;
     this.conn.on('close', () => (this.connected = false));
     this.conn.on('connect', () => (this.connected = true));

--- a/portal/common/bullmq/queues.ts
+++ b/portal/common/bullmq/queues.ts
@@ -3,15 +3,13 @@ import { Redis } from 'ioredis';
 import type { Job } from './types.js';
 import { QueueName } from './types.js';
 
-export const connection = {
-  host: process.env.NODE_ENV === 'development' ? 'localhost' : 'redis'
-} as const;
+export const REDIS_URL = process.env.NODE_ENV === 'development' ? 'localhost' : 'redis';
 
 class Connection {
   private conn: Redis;
   private connected: boolean;
   constructor() {
-    this.conn = new Redis(connection);
+    this.conn = new Redis({ host: REDIS_URL, maxRetriesPerRequest: null });
     this.connected = false;
     this.conn.on('close', () => (this.connected = false));
     this.conn.on('connect', () => (this.connected = true));
@@ -33,24 +31,29 @@ class Connection {
   public IsConnected() {
     return this.connected;
   }
+
+  public connection() {
+    return this.conn;
+  }
 }
 
-const conn = new Connection();
+const connection = new Connection();
 
-/** Redis is up */
-export const connected = () => conn.IsConnected();
+export const connected = () => connection.IsConnected();
+
+export const config = { connection: connection.connection() } as const;
 
 /** Queue for Product Builds */
-export const Builds = new Queue<Job>(QueueName.Builds, { connection });
+export const Builds = new Queue<Job>(QueueName.Builds, config);
 /** Queue for default recurring jobs such as the BuildEngine status check */
-export const DefaultRecurring = new Queue<Job>(QueueName.DefaultRecurring, { connection });
+export const DefaultRecurring = new Queue<Job>(QueueName.DefaultRecurring, config);
 /** Queue for miscellaneous jobs such as Product and Project Creation */
-export const Miscellaneous = new Queue<Job>(QueueName.Miscellaneous, { connection });
+export const Miscellaneous = new Queue<Job>(QueueName.Miscellaneous, config);
 /** Queue for Product Publishing  */
-export const Publishing = new Queue<Job>(QueueName.Publishing, { connection });
+export const Publishing = new Queue<Job>(QueueName.Publishing, config);
 /** Queue for jobs that poll BuildEngine, such as checking the status of a build */
-export const RemotePolling = new Queue<Job>(QueueName.RemotePolling, { connection });
+export const RemotePolling = new Queue<Job>(QueueName.RemotePolling, config);
 /** Queue for operations on UserTasks */
-export const UserTasks = new Queue<Job>(QueueName.UserTasks, { connection });
+export const UserTasks = new Queue<Job>(QueueName.UserTasks, config);
 /** Queue for Email tasks */
-export const Emails = new Queue<Job>(QueueName.Emails, { connection });
+export const Emails = new Queue<Job>(QueueName.Emails, config);

--- a/portal/node-server/BullWorker.ts
+++ b/portal/node-server/BullWorker.ts
@@ -5,9 +5,7 @@ import * as Executor from './job-executors/index.js';
 export abstract class BullWorker<T> {
   public worker: Worker;
   constructor(public queue: BullMQ.QueueName) {
-    this.worker = new Worker<T>(queue, this.run, {
-      connection: Queues.connection
-    });
+    this.worker = new Worker<T>(queue, this.run, Queues.config);
   }
   abstract run(job: Job<T>): Promise<unknown>;
 }


### PR DESCRIPTION
Modified creation of Queues and Workers to share a single redis connection in accordance with the documentation: https://docs.bullmq.io/guide/connections

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Improved Redis connection management for background queues, enhancing reliability and connection status tracking.
	- Updated internal configuration for queue and worker initialization to use a more robust connection setup.

- **Chores**
	- Streamlined connection handling for background job processing, reducing potential connection issues.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->