### PR TITLE
Switch to valkey

### DIFF
--- a/deployment/development/docker-compose.yml
+++ b/deployment/development/docker-compose.yml
@@ -13,7 +13,7 @@ volumes:
   ui-node_modules:
   ui-yarn-cache:
   postgres-data:
-  redis-data:
+  valkey-data:
   outdir:
 
 
@@ -104,13 +104,13 @@ services:
       VITE_DATABASE_URL: "postgresql://db-user:1234@db:5432/development?schema=public"
       # MUST be included (the path the application will be accessed on) and MUST NOT have a trailing slash
       ORIGIN: "http://localhost:6173"
-  redis:
-    image: redis:latest
+  valkey:
+    image: valkey/valkey:latest
     ports:
       - "6379:6379"
-    command: redis-server --appendonly yes --appendfilename appendonly.aof --maxmemory-policy noeviction
+    command: valkey-server --appendonly yes --appendfilename appendonly.aof --maxmemory-policy noeviction
     volumes:
-      - redis-data:/data
+      - valkey-data:/data
   stg-tunnel:
     build:
       context: ./deployment/development

--- a/portal/common/bullmq/queues.ts
+++ b/portal/common/bullmq/queues.ts
@@ -8,7 +8,7 @@ class Connection {
   private connected: boolean;
   constructor() {
     this.conn = new Redis({
-      host: process.env.NODE_ENV === 'development' ? 'localhost' : 'redis',
+      host: process.env.NODE_ENV === 'development' ? 'localhost' : 'valkey',
       maxRetriesPerRequest: null
     });
     this.connected = false;
@@ -23,7 +23,7 @@ class Connection {
           })
           .catch((err) => {
             console.error(err);
-            console.log('Redis disconnected');
+            console.log('Valkey disconnected');
             this.connected = false;
           });
       }


### PR DESCRIPTION
It is cheaper to use Valkey than Redis on AWS. As best as I can tell based on some limited testing, all I had to change was the docker image, and it all works without any further changes.