### PR TITLE
Fix store usage

### DIFF
--- a/src/lib/stores.ts
+++ b/src/lib/stores.ts
@@ -7,7 +7,7 @@ import { browser } from '$app/environment';
  * @param key The localStorage key
  * @param initial Initial value to use if nothing is stored
  */
-export function persisted<T>(key: string, initial: T): Writable<T> {
+export function persistedLocal<T>(key: string, initial: T): Writable<T> {
   // Start with initial value (safe for SSR)
   const start = writable(initial);
 
@@ -32,4 +32,35 @@ export function persisted<T>(key: string, initial: T): Writable<T> {
   return start;
 }
 
-export const orgActive = persisted('orgActive', 0);
+/**
+ * A Svelte store that persists its value in sessionStorage (unique to each tab)
+ *
+ * @param key The sessionStorage key
+ * @param initial Initial value to use if nothing is stored
+ */
+export function persistedSession<T>(key: string, initial: T): Writable<T> {
+  // Start with initial value (safe for SSR)
+  const start = writable(initial);
+
+  if (browser) {
+    // If there’s already something stored, load it
+    const stored = sessionStorage.getItem(key);
+    if (stored !== null) {
+      try {
+        start.set(JSON.parse(stored));
+      } catch {
+        // if parsing fails, fall back to initial
+        start.set(initial);
+      }
+    }
+
+    // Keep sessionStorage in sync
+    start.subscribe((value) => {
+      sessionStorage.setItem(key, JSON.stringify(value));
+    });
+  }
+
+  return start;
+}
+
+export const orgActive = persistedSession('orgActive', 0);

--- a/src/lib/stores.ts
+++ b/src/lib/stores.ts
@@ -16,10 +16,8 @@ export function persistedLocal<T>(key: string, initial: T): Writable<T> {
     const stored = localStorage.getItem(key);
     if (stored !== null) {
       try {
-        console.log('Loaded from localStorage:', JSON.parse(stored));
         start.set(JSON.parse(stored));
       } catch {
-        console.error('Failed to parse stored value for key ', key, ' using ', initial);
         // if parsing fails, fall back to initial
         start.set(initial);
       }

--- a/src/routes/(authenticated)/+layout.svelte
+++ b/src/routes/(authenticated)/+layout.svelte
@@ -174,7 +174,7 @@
               <a
                 class="rounded-none"
                 class:active-menu-item={isUrlActive('/organizations')}
-                href={localizeHref('/organizations')}
+                href={activeOrgUrl('/organizations')}
                 onclick={closeDrawer}
               >
                 {m.sidebar_orgSettings()}

--- a/src/routes/(authenticated)/projects/[filter=projectSelector]/+page.server.ts
+++ b/src/routes/(authenticated)/projects/[filter=projectSelector]/+page.server.ts
@@ -4,10 +4,23 @@ import { localizeHref } from '$lib/paraglide/runtime';
 
 export const load = (async (event) => {
   const data = await event.parent();
-  if (data.organizations.length >= 1)
-    return redirect(
-      302,
-      localizeHref(`/projects/${event.params.filter}/${data.organizations[0].Id}`)
-    );
+  let orgDefault = data.organizations[0]?.Id;
+
+  // Try to get orgLastSelected from cookie
+  const cookieHeader = event.request.headers.get('cookie');
+  if (cookieHeader) {
+    const match = cookieHeader.match(/orgLastSelected=([^;]+)/);
+    if (match) {
+      const orgLastSelected = decodeURIComponent(match[1]);
+      // Only use if it matches an org in the list
+      if (data.organizations.some((org) => String(org.Id) === orgLastSelected)) {
+        orgDefault = Number(orgLastSelected);
+      }
+    }
+  }
+
+  if (data.organizations.length >= 1) {
+    return redirect(302, localizeHref(`/projects/${event.params.filter}/${orgDefault}`));
+  }
   return {};
 }) satisfies PageServerLoad;

--- a/src/routes/(authenticated)/projects/[filter=projectSelector]/[id]/+page.svelte
+++ b/src/routes/(authenticated)/projects/[filter=projectSelector]/[id]/+page.svelte
@@ -141,15 +141,7 @@
   });
 
   $effect(() => {
-    console.log(
-      'pageForm.organizationId',
-      $pageForm.organizationId,
-      'orgLastSelected',
-      $orgLastSelected,
-      'orgActive',
-      $orgActive
-    );
-    $orgActive = $pageForm.organizationId || $orgActive || $orgLastSelected;
+    $orgActive = $pageForm.organizationId || $orgLastSelected;
   });
   const mobileSizing = 'w-full max-w-xs md:w-auto md:max-w-none';
 </script>

--- a/src/routes/(authenticated)/projects/[filter=projectSelector]/[id]/+page.svelte
+++ b/src/routes/(authenticated)/projects/[filter=projectSelector]/[id]/+page.svelte
@@ -18,7 +18,7 @@
   import ProjectActionMenu from '$lib/projects/components/ProjectActionMenu.svelte';
   import ProjectCard from '$lib/projects/components/ProjectCard.svelte';
   import ProjectFilterSelector from '$lib/projects/components/ProjectFilterSelector.svelte';
-  import { orgActive } from '$lib/stores';
+  import { orgActive, orgLastSelected } from '$lib/stores';
   import { toast } from '$lib/utils';
   import { byName, byString } from '$lib/utils/sorting';
 
@@ -141,7 +141,15 @@
   });
 
   $effect(() => {
-    $orgActive = $pageForm.organizationId || 0;
+    console.log(
+      'pageForm.organizationId',
+      $pageForm.organizationId,
+      'orgLastSelected',
+      $orgLastSelected,
+      'orgActive',
+      $orgActive
+    );
+    $orgActive = $pageForm.organizationId || $orgActive || $orgLastSelected;
   });
   const mobileSizing = 'w-full max-w-xs md:w-auto md:max-w-none';
 </script>


### PR DESCRIPTION
* add separate persistLocal and persistSession
* use persistSession for orgActive
* use orgActive for Organizational Settings
* update orgLastSelected whenever orgActive is changed and save in session storage for new tab
* save orgLastSelected in a cookie for /projects/own route, which redirects to org page in server code

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Active organization now persists per-tab (clears on browser close) and a separate "last selected" value is persisted for cross-tab/default selection.
  * Organizations menu deep-links to the currently active organization when present; otherwise links to the general organizations page (localized).
  * Project list routing uses the stored last-selected organization as a cookie-driven default when available.

* **Bug Fixes**
  * More robust handling of corrupted persisted data — falls back to defaults.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->