### PR TITLE
Link BullMQ jobs to the actions that initiated them

### DIFF
--- a/src/lib/products/server.ts
+++ b/src/lib/products/server.ts
@@ -1,3 +1,5 @@
+import { trace } from '@opentelemetry/api';
+import { api } from '@opentelemetry/sdk-node';
 import { ProductTransitionType, WorkflowType } from '$lib/prisma';
 import { BullMQ, getQueues } from '$lib/server/bullmq';
 import { DatabaseReads, DatabaseWrites } from '$lib/server/database';
@@ -63,6 +65,7 @@ export async function doProductAction(productId: string, action: ProductActionTy
             `Delete UserTasks for canceled workflow (product #${productId})`,
             {
               type: BullMQ.JobType.UserTasks_Modify,
+              OTContext: trace.getSpanContext(api.context.active()) ?? null,
               scope: 'Product',
               productId,
               operation: {

--- a/src/lib/projects/server.ts
+++ b/src/lib/projects/server.ts
@@ -1,4 +1,6 @@
 import type { Session } from '@auth/sveltekit';
+import { trace } from '@opentelemetry/api';
+import { api } from '@opentelemetry/sdk-node';
 import type { Prisma } from '@prisma/client';
 import { RoleId } from '$lib/prisma';
 import { type ProjectForAction, canClaimProject, canModifyProject } from '$lib/projects';
@@ -161,6 +163,7 @@ export async function doProjectAction(
     await getQueues().UserTasks.add(`Delete UserTasks for Archived Project #${project.Id}`, {
       type: BullMQ.JobType.UserTasks_Modify,
       scope: 'Project',
+      OTContext: trace.getSpanContext(api.context.active()) ?? null,
       projectId: project.Id,
       operation: {
         type: BullMQ.UserTasks.OpType.Delete
@@ -172,6 +175,7 @@ export async function doProjectAction(
     });
     await getQueues().UserTasks.add(`Create UserTasks for Reactivated Project #${project.Id}`, {
       type: BullMQ.JobType.UserTasks_Modify,
+      OTContext: trace.getSpanContext(api.context.active()) ?? null,
       scope: 'Project',
       projectId: project.Id,
       operation: {

--- a/src/lib/server/bullmq/BullWorker.ts
+++ b/src/lib/server/bullmq/BullWorker.ts
@@ -19,7 +19,7 @@ export abstract class BullWorker<T extends BullMQ.Job> {
   private async runInternal(job: Job<T>) {
     return await tracer.startActiveSpan(
       `${job.queueName} - ${job.data.type}`,
-      { links: job.data.OTLinks },
+      { links: job.data.OTContext ? [{ context: job.data.OTContext }] : undefined },
       async (span) => {
         span.setAttributes({
           'job.id': job.id,

--- a/src/lib/server/bullmq/BullWorker.ts
+++ b/src/lib/server/bullmq/BullWorker.ts
@@ -73,7 +73,8 @@ export class SystemRecurring<J extends BullMQ.RecurringJob> extends BullWorker<J
       {
         name: 'Check System Statuses',
         data: {
-          type: BullMQ.JobType.System_CheckEngineStatuses
+          type: BullMQ.JobType.System_CheckEngineStatuses,
+          OTContext: null
         }
       }
     );
@@ -86,7 +87,8 @@ export class SystemRecurring<J extends BullMQ.RecurringJob> extends BullWorker<J
       {
         name: 'Refresh LangTags',
         data: {
-          type: BullMQ.JobType.System_RefreshLangTags
+          type: BullMQ.JobType.System_RefreshLangTags,
+          OTContext: null
         }
       }
     );
@@ -109,19 +111,22 @@ export class SystemStartup<J extends BullMQ.StartupJob> extends BullWorker<J> {
       [
         'Check System Statuses (Startup)',
         {
-          type: BullMQ.JobType.System_CheckEngineStatuses
+          type: BullMQ.JobType.System_CheckEngineStatuses,
+          OTContext: null
         }
       ],
       [
         'Refresh LangTags (Startup)',
         {
-          type: BullMQ.JobType.System_RefreshLangTags
+          type: BullMQ.JobType.System_RefreshLangTags,
+          OTContext: null
         }
       ],
       [
         'Migrate Features from S1 to S2 (Startup)',
         {
-          type: BullMQ.JobType.System_Migrate
+          type: BullMQ.JobType.System_Migrate,
+          OTContext: null
         }
       ]
     ] as const;

--- a/src/lib/server/bullmq/types.ts
+++ b/src/lib/server/bullmq/types.ts
@@ -1,4 +1,5 @@
 /* eslint-disable @typescript-eslint/no-namespace */
+import type { Link } from '@opentelemetry/api';
 import type { RepeatOptions } from 'bullmq';
 import type { RoleId } from '../../prisma';
 import type { BuildResponse, Channels, ReleaseResponse } from '../build-engine-api/types';
@@ -70,8 +71,13 @@ export enum JobType {
   SvelteSSE_UpdateUserTasks = 'Update UserTasks'
 }
 
+export interface JobBase {
+  type: JobType;
+  OTLinks?: Link[];
+}
+
 export namespace Build {
-  export interface Product {
+  export interface Product extends JobBase {
     type: JobType.Build_Product;
     productId: string;
     defaultTargets: string;
@@ -87,7 +93,7 @@ export namespace Build {
 }
 
 export namespace Polling {
-  export interface Build {
+  export interface Build extends JobBase {
     type: JobType.Poll_Build;
     organizationId: number;
     productId: string;
@@ -96,14 +102,14 @@ export namespace Polling {
     productBuildId: number;
   }
 
-  export interface Project {
+  export interface Project extends JobBase {
     type: JobType.Poll_Project;
     workflowProjectId: number;
     organizationId: number;
     projectId: number;
   }
 
-  export interface Publish {
+  export interface Publish extends JobBase {
     type: JobType.Poll_Publish;
     organizationId: number;
     productId: string;
@@ -115,20 +121,20 @@ export namespace Polling {
 }
 
 export namespace Product {
-  export interface Create {
+  export interface Create extends JobBase {
     type: JobType.Product_Create;
     productId: string;
   }
-  export interface Delete {
+  export interface Delete extends JobBase {
     type: JobType.Product_Delete;
     organizationId: number;
     workflowJobId: number;
   }
-  export interface GetVersionCode {
+  export interface GetVersionCode extends JobBase {
     type: JobType.Product_GetVersionCode;
     productId: string;
   }
-  export interface CreateLocal {
+  export interface CreateLocal extends JobBase {
     type: JobType.Product_CreateLocal;
     projectId: number;
     productDefinitionId: number;
@@ -137,12 +143,12 @@ export namespace Product {
 }
 
 export namespace Project {
-  export interface Create {
+  export interface Create extends JobBase {
     type: JobType.Project_Create;
     projectId: number;
   }
 
-  export interface ImportProducts {
+  export interface ImportProducts extends JobBase {
     type: JobType.Project_ImportProducts;
     organizationId: number;
     importId: number;
@@ -151,7 +157,7 @@ export namespace Project {
 }
 
 export namespace Publish {
-  export interface Product {
+  export interface Product extends JobBase {
     type: JobType.Publish_Product;
     productId: string;
     defaultChannel: Channels;
@@ -159,7 +165,7 @@ export namespace Publish {
     environment: Record<string, string>;
   }
 
-  export interface PostProcess {
+  export interface PostProcess extends JobBase {
     type: JobType.Publish_PostProcess;
     productId: string;
     publicationId: number;
@@ -168,13 +174,13 @@ export namespace Publish {
 }
 
 export namespace System {
-  export interface CheckEngineStatuses {
+  export interface CheckEngineStatuses extends JobBase {
     type: JobType.System_CheckEngineStatuses;
   }
-  export interface RefreshLangTags {
+  export interface RefreshLangTags extends JobBase {
     type: JobType.System_RefreshLangTags;
   }
-  export interface Migrate {
+  export interface Migrate extends JobBase {
     type: JobType.System_Migrate;
   }
 }
@@ -200,48 +206,49 @@ export namespace UserTasks {
       };
 
   // Using type here instead of interface for easier composition
-  export type Modify = (
-    | {
-        scope: 'Project';
-        projectId: number;
-      }
-    | {
-        scope: 'Product';
-        productId: string;
-      }
-  ) & {
-    type: JobType.UserTasks_Modify;
-    comment?: string; // just ignore comment for Delete and Reassign
-    operation: Config;
-  };
+  export type Modify = JobBase &
+    (
+      | {
+          scope: 'Project';
+          projectId: number;
+        }
+      | {
+          scope: 'Product';
+          productId: string;
+        }
+    ) & {
+      type: JobType.UserTasks_Modify;
+      comment?: string; // just ignore comment for Delete and Reassign
+      operation: Config;
+    };
 }
 
 export namespace Email {
-  export interface InviteUser {
+  export interface InviteUser extends JobBase {
     type: JobType.Email_InviteUser;
     email: string;
     inviteToken: string;
     inviteLink: string;
   }
-  export interface SendNotificationToUser {
+  export interface SendNotificationToUser extends JobBase {
     type: JobType.Email_SendNotificationToUser;
     userId: number;
     messageKey: string;
     messageProperties: Record<string, string>;
     link?: string;
   }
-  export interface SendNotificationToReviewers {
+  export interface SendNotificationToReviewers extends JobBase {
     type: JobType.Email_SendNotificationToReviewers;
     productId: string;
   }
-  export interface SendNotificationToOrgAdminsAndOwner {
+  export interface SendNotificationToOrgAdminsAndOwner extends JobBase {
     type: JobType.Email_SendNotificationToOrgAdminsAndOwner;
     projectId: number;
     messageKey: string;
     messageProperties: Record<string, string>;
     link?: string;
   }
-  export interface SendBatchUserTaskNotifications {
+  export interface SendBatchUserTaskNotifications extends JobBase {
     type: JobType.Email_SendBatchUserTaskNotifications;
     notifications: {
       userId: number;
@@ -253,36 +260,36 @@ export namespace Email {
       comment: string;
     }[];
   }
-  export interface NotifySuperAdminsOfNewOrganizationRequest {
+  export interface NotifySuperAdminsOfNewOrganizationRequest extends JobBase {
     type: JobType.Email_NotifySuperAdminsOfNewOrganizationRequest;
     organizationName: string;
     email: string;
     url: string;
   }
 
-  export interface NotifySuperAdminsOfOfflineSystems {
+  export interface NotifySuperAdminsOfOfflineSystems extends JobBase {
     type: JobType.Email_NotifySuperAdminsOfOfflineSystems;
   }
 
-  export interface NotifySuperAdminsLowPriority {
+  export interface NotifySuperAdminsLowPriority extends JobBase {
     type: JobType.Email_NotifySuperAdminsLowPriority;
     messageKey: string;
     messageProperties: Record<string, string>;
     link?: string;
   }
-  export interface ProjectImportReport {
+  export interface ProjectImportReport extends JobBase {
     type: JobType.Email_ProjectImportReport;
     importId: number;
   }
 }
 
 export namespace SvelteProjectSSE {
-  export interface UpdateProject {
+  export interface UpdateProject extends JobBase {
     type: JobType.SvelteSSE_UpdateProject;
     projectIds: number[];
   }
 
-  export interface UpdateUserTasks {
+  export interface UpdateUserTasks extends JobBase {
     type: JobType.SvelteSSE_UpdateUserTasks;
     userIds: number[];
   }

--- a/src/lib/server/bullmq/types.ts
+++ b/src/lib/server/bullmq/types.ts
@@ -73,7 +73,7 @@ export enum JobType {
 
 export interface JobBase {
   type: JobType;
-  OTContext?: SpanContext;
+  OTContext: SpanContext | null;
 }
 
 export namespace Build {
@@ -84,7 +84,7 @@ export namespace Build {
     environment: Record<string, string>;
   }
 
-  export interface PostProcess {
+  export interface PostProcess extends JobBase {
     type: JobType.Build_PostProcess;
     productId: string;
     productBuildId: number;

--- a/src/lib/server/bullmq/types.ts
+++ b/src/lib/server/bullmq/types.ts
@@ -1,5 +1,5 @@
 /* eslint-disable @typescript-eslint/no-namespace */
-import type { Link } from '@opentelemetry/api';
+import type { SpanContext } from '@opentelemetry/api';
 import type { RepeatOptions } from 'bullmq';
 import type { RoleId } from '../../prisma';
 import type { BuildResponse, Channels, ReleaseResponse } from '../build-engine-api/types';
@@ -73,7 +73,7 @@ export enum JobType {
 
 export interface JobBase {
   type: JobType;
-  OTLinks?: Link[];
+  OTContext?: SpanContext;
 }
 
 export namespace Build {

--- a/src/lib/server/database/Authors.ts
+++ b/src/lib/server/database/Authors.ts
@@ -17,6 +17,7 @@ async function deleteAuthor(id: number) {
 
   getQueues().SvelteSSE.add(`Update Project #${author.ProjectId} (author removed)`, {
     type: BullMQ.JobType.SvelteSSE_UpdateProject,
+    OTContext: null,
     projectIds: [author.ProjectId]
   });
   return ret;
@@ -28,6 +29,7 @@ export async function create(authorData: Prisma.AuthorsUncheckedCreateInput) {
   });
   getQueues().SvelteSSE.add(`Update Project #${authorData.ProjectId} (author added)`, {
     type: BullMQ.JobType.SvelteSSE_UpdateProject,
+    OTContext: null,
     projectIds: [authorData.ProjectId]
   });
   return ret;

--- a/src/lib/server/database/ProductTransitions.ts
+++ b/src/lib/server/database/ProductTransitions.ts
@@ -10,6 +10,7 @@ export async function create(createData: Prisma.ProductTransitionsCreateArgs) {
     });
     getQueues().SvelteSSE.add(`Update Project #${res.Product.ProjectId} (transition created)`, {
       type: BullMQ.JobType.SvelteSSE_UpdateProject,
+      OTContext: null,
       projectIds: [res.Product.ProjectId]
     });
     return res;
@@ -28,6 +29,7 @@ export async function createMany(
     });
     getQueues().SvelteSSE.add(`Update Project #${projectId} (transitions created)`, {
       type: BullMQ.JobType.SvelteSSE_UpdateProject,
+      OTContext: null,
       projectIds: [projectId]
     });
     return res;
@@ -44,6 +46,7 @@ export async function update(updateData: Prisma.ProductTransitionsUpdateArgs) {
     });
     getQueues().SvelteSSE.add(`Update Project #${res.Product.ProjectId} (transition updated)`, {
       type: BullMQ.JobType.SvelteSSE_UpdateProject,
+      OTContext: null,
       projectIds: [res.Product.ProjectId]
     });
     return res;
@@ -61,6 +64,7 @@ export async function updateMany(
     if (projectId !== false)
       getQueues().SvelteSSE.add(`Update Project #${projectId} (transitions updated)`, {
         type: BullMQ.JobType.SvelteSSE_UpdateProject,
+        OTContext: null,
         projectIds: [projectId]
       });
     return res;
@@ -77,6 +81,7 @@ export async function deleteMany(
     const res = await prisma.productTransitions.deleteMany(deleteWhere);
     getQueues().SvelteSSE.add(`Update Project #${projectId} (transitions deleted)`, {
       type: BullMQ.JobType.SvelteSSE_UpdateProject,
+      OTContext: null,
       projectIds: [projectId]
     });
     return res;

--- a/src/lib/server/database/Reviewers.ts
+++ b/src/lib/server/database/Reviewers.ts
@@ -16,6 +16,7 @@ async function deleteReviewer(id: number) {
 
   getQueues().SvelteSSE.add(`Update Project #${reviewer.ProjectId} (reviewer removed)`, {
     type: BullMQ.JobType.SvelteSSE_UpdateProject,
+    OTContext: null,
     projectIds: [reviewer.ProjectId]
   });
   return ret;
@@ -29,6 +30,7 @@ export async function create(reviewerData: Prisma.ReviewersUncheckedCreateInput)
   });
   getQueues().SvelteSSE.add(`Update Project #${reviewerData.ProjectId} (reviewer added)`, {
     type: BullMQ.JobType.SvelteSSE_UpdateProject,
+    OTContext: null,
     projectIds: [reviewerData.ProjectId]
   });
   return ret;

--- a/src/lib/server/database/UserRoles.ts
+++ b/src/lib/server/database/UserRoles.ts
@@ -1,3 +1,5 @@
+import { trace } from '@opentelemetry/api';
+import { api } from '@opentelemetry/sdk-node';
 import { BullMQ, getQueues } from '../bullmq/index';
 import prisma from './prisma';
 import { RoleId } from '$lib/prisma';
@@ -45,6 +47,7 @@ export async function toggleForOrg(
         name: `${enabled ? 'Add' : 'Remove'} OrgAdmin tasks for User #${UserId} on Project #${p.Id}`,
         data: {
           type: BullMQ.JobType.UserTasks_Modify,
+          OTContext: trace.getSpanContext(api.context.active()) ?? null,
           scope: 'Project',
           projectId: p.Id,
           operation: {

--- a/src/lib/server/database/UserTasks.ts
+++ b/src/lib/server/database/UserTasks.ts
@@ -8,6 +8,7 @@ export async function createMany(createManyData: Prisma.UserTasksCreateManyArgs)
   });
   getQueues().SvelteSSE.add(`Update UserTasks`, {
     type: BullMQ.JobType.SvelteSSE_UpdateUserTasks,
+    OTContext: null,
     userIds: [createManyData.data].flat().map((r) => r.UserId)
   });
   return res;
@@ -23,6 +24,7 @@ export async function deleteMany(deleteManyData: Prisma.UserTasksDeleteManyArgs)
 
   getQueues().SvelteSSE.add(`Update UserTasks`, {
     type: BullMQ.JobType.SvelteSSE_UpdateUserTasks,
+    OTContext: null,
     userIds: [...new Set(rows.map((r) => r.UserId))]
   });
   return res;
@@ -40,6 +42,7 @@ export async function updateMany(updateManyData: Prisma.UserTasksUpdateManyArgs)
   });
   getQueues().SvelteSSE.add(`Update UserTasks`, {
     type: BullMQ.JobType.SvelteSSE_UpdateUserTasks,
+    OTContext: null,
     userIds: [...new Set([...beforeUsers.map((r) => r.UserId), ...afterUsers.map((r) => r.UserId)])]
   });
   return res;

--- a/src/lib/server/job-executors/build.ts
+++ b/src/lib/server/job-executors/build.ts
@@ -1,3 +1,5 @@
+import { trace } from '@opentelemetry/api';
+import { api } from '@opentelemetry/sdk-node';
 import type { Prisma } from '@prisma/client';
 import type { Job } from 'bullmq';
 import { BuildEngine } from '../build-engine-api';
@@ -105,6 +107,7 @@ export async function product(job: Job<BullMQ.Build.Product>): Promise<unknown> 
         name,
         data: {
           type: BullMQ.JobType.Poll_Build,
+          OTContext: trace.getSpanContext(api.context.active()) ?? null,
           productId: job.data.productId,
           organizationId: productData.Project.OrganizationId,
           jobId: productData.WorkflowJobId,
@@ -276,6 +279,7 @@ async function notifyConnectionFailed(
     `Notify Owner/Admins of Failure to Create Build for Product #${productId}`,
     {
       type: BullMQ.JobType.Email_SendNotificationToOrgAdminsAndOwner,
+      OTContext: trace.getSpanContext(api.context.active()) ?? null,
       projectId,
       messageKey: 'buildFailedUnableToConnect',
       messageProperties: {
@@ -295,6 +299,7 @@ async function notifyUnableToCreate(
     `Notify Owner/Admins of Failure to Create Build for Product #${productId}`,
     {
       type: BullMQ.JobType.Email_SendNotificationToOrgAdminsAndOwner,
+      OTContext: trace.getSpanContext(api.context.active()) ?? null,
       projectId,
       messageKey: 'buildFailedUnableToCreate',
       messageProperties: {
@@ -315,6 +320,7 @@ async function notifyCompleted(
     `Notify Owner of Successful Completion of Build #${productBuildId} for Product #${productId}`,
     {
       type: BullMQ.JobType.Email_SendNotificationToUser,
+      OTContext: trace.getSpanContext(api.context.active()) ?? null,
       userId,
       messageKey: 'buildCompletedSuccessfully',
       messageProperties: {
@@ -351,6 +357,7 @@ async function notifyFailed(
     `Notify Owner/Admins of Failure to Create Build #${productBuildId} for Product #${productId}`,
     {
       type: BullMQ.JobType.Email_SendNotificationToOrgAdminsAndOwner,
+      OTContext: trace.getSpanContext(api.context.active()) ?? null,
       projectId: product.Project.Id,
       messageKey: 'buildFailed',
       messageProperties: {
@@ -372,6 +379,7 @@ async function notifyFailed(
 export async function notifyProductNotFound(productId: string) {
   await getQueues().Emails.add(`Notify SuperAdmins of Failure to Find Product #${productId}`, {
     type: BullMQ.JobType.Email_NotifySuperAdminsLowPriority,
+    OTContext: trace.getSpanContext(api.context.active()) ?? null,
     messageKey: 'buildProductRecordNotFound',
     messageProperties: {
       productId

--- a/src/lib/server/job-executors/product.ts
+++ b/src/lib/server/job-executors/product.ts
@@ -1,3 +1,5 @@
+import { trace } from '@opentelemetry/api';
+import { api } from '@opentelemetry/sdk-node';
 import type { Job } from 'bullmq';
 import { BuildEngine } from '../build-engine-api';
 import { BullMQ, getQueues } from '../bullmq';
@@ -258,6 +260,7 @@ async function notifyConnectionFailed(
 ) {
   return getQueues().Emails.add(`Notify Owner/Admins of Product #${productId} Creation Failure`, {
     type: BullMQ.JobType.Email_SendNotificationToOrgAdminsAndOwner,
+    OTContext: trace.getSpanContext(api.context.active()) ?? null,
     projectId,
     messageKey: 'productFailedUnableToConnect',
     messageProperties: {
@@ -274,6 +277,7 @@ async function notifyProjectUrlNotSet(
 ) {
   return getQueues().Emails.add(`Notify Owner/Admins of Product #${productId} Creation Failure`, {
     type: BullMQ.JobType.Email_SendNotificationToOrgAdminsAndOwner,
+    OTContext: trace.getSpanContext(api.context.active()) ?? null,
     projectId,
     messageKey: 'productProjectUrlNotSet',
     messageProperties: {
@@ -290,6 +294,7 @@ async function notifyCreated(
 ) {
   return getQueues().Emails.add(`Notify Owner of Product #${productId} Creation Success`, {
     type: BullMQ.JobType.Email_SendNotificationToUser,
+    OTContext: trace.getSpanContext(api.context.active()) ?? null,
     userId,
     messageKey: 'productCreatedSuccessfully',
     messageProperties: {
@@ -309,6 +314,7 @@ async function notifyFailed(
   const buildEngineUrl = endpoint + '/job-admin';
   return getQueues().Emails.add(`Notify Owner/Admins of Product #${productId} Creation Failure`, {
     type: BullMQ.JobType.Email_SendNotificationToOrgAdminsAndOwner,
+    OTContext: trace.getSpanContext(api.context.active()) ?? null,
     projectId,
     messageKey: 'productCreationFailed',
     messageProperties: {
@@ -322,6 +328,7 @@ async function notifyFailed(
 async function notifyNotFound(productId: string) {
   await getQueues().Emails.add(`Notify SuperAdmins of Failure to Find Product #${productId}`, {
     type: BullMQ.JobType.Email_NotifySuperAdminsLowPriority,
+    OTContext: trace.getSpanContext(api.context.active()) ?? null,
     messageKey: 'productRecordNotFound',
     messageProperties: {
       productId

--- a/src/lib/server/job-executors/publish.ts
+++ b/src/lib/server/job-executors/publish.ts
@@ -1,3 +1,5 @@
+import { trace } from '@opentelemetry/api';
+import { api } from '@opentelemetry/sdk-node';
 import type { Prisma } from '@prisma/client';
 import type { Job } from 'bullmq';
 import { BuildEngine } from '../build-engine-api';
@@ -132,6 +134,7 @@ export async function product(job: Job<BullMQ.Publish.Product>): Promise<unknown
         name,
         data: {
           type: BullMQ.JobType.Poll_Publish,
+          OTContext: trace.getSpanContext(api.context.active()) ?? null,
           productId: job.data.productId,
           organizationId: productData.Project.OrganizationId,
           jobId: productData.WorkflowJobId,
@@ -265,6 +268,7 @@ async function notifyConnectionFailed(
     `Notify Owner/Admins of Failure to Create Release for Product #${productId}`,
     {
       type: BullMQ.JobType.Email_SendNotificationToOrgAdminsAndOwner,
+      OTContext: trace.getSpanContext(api.context.active()) ?? null,
       projectId,
       messageKey: 'releaseFailedUnableToConnect',
       messageProperties: {
@@ -284,6 +288,7 @@ async function notifyUnableToCreate(
     `Notify Owner/Admins of Failure to Create Release for Product #${productId}`,
     {
       type: BullMQ.JobType.Email_SendNotificationToOrgAdminsAndOwner,
+      OTContext: trace.getSpanContext(api.context.active()) ?? null,
       projectId,
       messageKey: 'releaseFailedUnableToCreate',
       messageProperties: {
@@ -304,6 +309,7 @@ async function notifyCompleted(
     `Notify Owner of Successful Completion of Release #${publicationId} for Product #${productId}`,
     {
       type: BullMQ.JobType.Email_SendNotificationToUser,
+      OTContext: trace.getSpanContext(api.context.active()) ?? null,
       userId,
       messageKey: 'releaseCompletedSuccessfully',
       messageProperties: {
@@ -341,6 +347,7 @@ async function notifyFailed(
     `Notify Owner/Admins of Failure to Create Release #${publicationId} for Product #${productId}`,
     {
       type: BullMQ.JobType.Email_SendNotificationToOrgAdminsAndOwner,
+      OTContext: trace.getSpanContext(api.context.active()) ?? null,
       projectId: product.Project.Id,
       messageKey: 'releaseFailed',
       messageProperties: {
@@ -363,6 +370,7 @@ async function notifyFailed(
 export async function notifyProductNotFound(productId: string) {
   await getQueues().Emails.add(`Notify SuperAdmins of Failure to Find Product #${productId}`, {
     type: BullMQ.JobType.Email_NotifySuperAdminsLowPriority,
+    OTContext: trace.getSpanContext(api.context.active()) ?? null,
     messageKey: 'releaseProductRecordNotFound',
     messageProperties: {
       productId

--- a/src/lib/server/job-executors/system.ts
+++ b/src/lib/server/job-executors/system.ts
@@ -145,7 +145,8 @@ export async function checkSystemStatuses(
         {
           name: 'Email SuperAdmins about offline systems',
           data: {
-            type: BullMQ.JobType.Email_NotifySuperAdminsOfOfflineSystems
+            type: BullMQ.JobType.Email_NotifySuperAdminsOfOfflineSystems,
+            OTContext: null
           }
         }
       );

--- a/src/lib/server/job-executors/userTasks.ts
+++ b/src/lib/server/job-executors/userTasks.ts
@@ -1,3 +1,5 @@
+import { trace } from '@opentelemetry/api';
+import { api } from '@opentelemetry/sdk-node';
 import type { Prisma } from '@prisma/client';
 import type { Job } from 'bullmq';
 import { BullMQ, getQueues } from '../bullmq';
@@ -213,6 +215,7 @@ export async function modify(job: Job<BullMQ.UserTasks.Modify>): Promise<unknown
   // might be good to use one job type for all notification types
   await getQueues().Emails.add('Email Notifications', {
     type: BullMQ.JobType.Email_SendBatchUserTaskNotifications,
+    OTContext: trace.getSpanContext(api.context.active()) ?? null,
     notifications
   });
   job.updateProgress(100);

--- a/src/lib/server/workflow/index.ts
+++ b/src/lib/server/workflow/index.ts
@@ -1,3 +1,5 @@
+import { trace } from '@opentelemetry/api';
+import { api } from '@opentelemetry/sdk-node';
 import type { Prisma } from '@prisma/client';
 import type {
   Actor,
@@ -76,6 +78,7 @@ export class Workflow {
     });
     await getQueues().UserTasks.add(`Create UserTasks for Product #${productId}`, {
       type: BullMQ.JobType.UserTasks_Modify,
+      OTContext: trace.getSpanContext(api.context.active()) ?? null,
       scope: 'Product',
       productId: productId,
       operation: {
@@ -320,6 +323,7 @@ export class Workflow {
         // This will also create the dummy entries in the ProductTransitions table
         await getQueues().UserTasks.add(`Update UserTasks for Product #${this.productId}`, {
           type: BullMQ.JobType.UserTasks_Modify,
+          OTContext: trace.getSpanContext(api.context.active()) ?? null,
           scope: 'Product',
           productId: this.productId,
           comment: jump ? undefined : migration ? '' : event.comment,

--- a/src/lib/server/workflow/state-machine.ts
+++ b/src/lib/server/workflow/state-machine.ts
@@ -1,3 +1,5 @@
+import { trace } from '@opentelemetry/api';
+import { api } from '@opentelemetry/sdk-node';
 import { assign, setup } from 'xstate';
 import { RoleId, WorkflowType } from '../../prisma';
 import type {
@@ -302,6 +304,7 @@ export const WorkflowStateMachine = setup({
             `Create Product #${context.productId}`,
             {
               type: BullMQ.JobType.Product_Create,
+              OTContext: trace.getSpanContext(api.context.active()) ?? null,
               productId: context.productId
             },
             BullMQ.Retry0f600
@@ -496,6 +499,7 @@ export const WorkflowStateMachine = setup({
             `Build Product #${context.productId}`,
             {
               type: BullMQ.JobType.Build_Product,
+              OTContext: trace.getSpanContext(api.context.active()) ?? null,
               productId: context.productId,
               defaultTargets:
                 context.workflowType === WorkflowType.Republish
@@ -651,6 +655,7 @@ export const WorkflowStateMachine = setup({
               // Given that the Set Google Play Uploaded action in S1 require DB and BuildEngine queries, this is probably the best way to do this
               getQueues().Products.add(`Get VersionCode for Product #${context.productId}`, {
                 type: BullMQ.JobType.Product_GetVersionCode,
+                OTContext: trace.getSpanContext(api.context.active()) ?? null,
                 productId: context.productId
               });
             },
@@ -667,6 +672,7 @@ export const WorkflowStateMachine = setup({
             actions: ({ context }) => {
               getQueues().Products.add(`Get VersionCode for Product #${context.productId}`, {
                 type: BullMQ.JobType.Product_GetVersionCode,
+                OTContext: trace.getSpanContext(api.context.active()) ?? null,
                 productId: context.productId
               });
             },
@@ -759,6 +765,7 @@ export const WorkflowStateMachine = setup({
           actions: ({ context }) => {
             getQueues().Emails.add(`Email reviewers for Product #${context.productId}`, {
               type: BullMQ.JobType.Email_SendNotificationToReviewers,
+              OTContext: trace.getSpanContext(api.context.active()) ?? null,
               productId: context.productId
             });
           }
@@ -773,6 +780,7 @@ export const WorkflowStateMachine = setup({
             `Publish Product #${context.productId}`,
             {
               type: BullMQ.JobType.Publish_Product,
+              OTContext: trace.getSpanContext(api.context.active()) ?? null,
               productId: context.productId,
               defaultChannel: 'production', //default unless overriden by WorkflowDefinition.Properties or ProductDefinition.Properties
               defaultTargets:
@@ -930,6 +938,7 @@ export const WorkflowStateMachine = setup({
           if (isDeprecated(event.target) && event.target === 'Set Google Play Uploaded') {
             getQueues().Products.add(`Get VersionCode for Migrated Product #${context.productId}`, {
               type: BullMQ.JobType.Product_GetVersionCode,
+              OTContext: trace.getSpanContext(api.context.active()) ?? null,
               productId: context.productId
             });
           }

--- a/src/routes/(authenticated)/projects/[id=idNumber]/+page.server.ts
+++ b/src/routes/(authenticated)/projects/[id=idNumber]/+page.server.ts
@@ -1,3 +1,5 @@
+import { trace } from '@opentelemetry/api';
+import { api } from '@opentelemetry/sdk-node';
 import { error } from '@sveltejs/kit';
 import { fail, superValidate } from 'sveltekit-superforms';
 import { valibot } from 'sveltekit-superforms/adapters';
@@ -80,6 +82,7 @@ export const actions = {
     if (!author) return fail(404, { form, ok: false });
     await getQueues().UserTasks.add(`Remove UserTasks for Author #${form.data.id}`, {
       type: BullMQ.JobType.UserTasks_Modify,
+      OTContext: trace.getSpanContext(api.context.active()),
       scope: 'Project',
       projectId: parseInt(event.params.id),
       operation: {
@@ -123,6 +126,7 @@ export const actions = {
     }
     getQueues().Products.add(`Create Product for Project #${event.params.id}`, {
       type: BullMQ.JobType.Product_CreateLocal,
+      OTContext: trace.getSpanContext(api.context.active()),
       projectId: parseInt(event.params.id),
       productDefinitionId: form.data.productDefinitionId,
       storeId: form.data.storeId
@@ -185,6 +189,7 @@ export const actions = {
     });
     await getQueues().UserTasks.add(`Add UserTasks for Author #${author.Id}`, {
       type: BullMQ.JobType.UserTasks_Modify,
+      OTContext: trace.getSpanContext(api.context.active()),
       scope: 'Project',
       projectId,
       operation: {

--- a/src/routes/(authenticated)/projects/[id=idNumber]/+page.server.ts
+++ b/src/routes/(authenticated)/projects/[id=idNumber]/+page.server.ts
@@ -82,7 +82,7 @@ export const actions = {
     if (!author) return fail(404, { form, ok: false });
     await getQueues().UserTasks.add(`Remove UserTasks for Author #${form.data.id}`, {
       type: BullMQ.JobType.UserTasks_Modify,
-      OTContext: trace.getSpanContext(api.context.active()),
+      OTContext: trace.getSpanContext(api.context.active()) ?? null,
       scope: 'Project',
       projectId: parseInt(event.params.id),
       operation: {
@@ -126,7 +126,7 @@ export const actions = {
     }
     getQueues().Products.add(`Create Product for Project #${event.params.id}`, {
       type: BullMQ.JobType.Product_CreateLocal,
-      OTContext: trace.getSpanContext(api.context.active()),
+      OTContext: trace.getSpanContext(api.context.active()) ?? null,
       projectId: parseInt(event.params.id),
       productDefinitionId: form.data.productDefinitionId,
       storeId: form.data.storeId
@@ -189,7 +189,7 @@ export const actions = {
     });
     await getQueues().UserTasks.add(`Add UserTasks for Author #${author.Id}`, {
       type: BullMQ.JobType.UserTasks_Modify,
-      OTContext: trace.getSpanContext(api.context.active()),
+      OTContext: trace.getSpanContext(api.context.active()) ?? null,
       scope: 'Project',
       projectId,
       operation: {

--- a/src/routes/(authenticated)/projects/import/[id=idNumber]/+page.server.ts
+++ b/src/routes/(authenticated)/projects/import/[id=idNumber]/+page.server.ts
@@ -1,3 +1,5 @@
+import { trace } from '@opentelemetry/api';
+import { api } from '@opentelemetry/sdk-node';
 import { error, redirect } from '@sveltejs/kit';
 import { fail, superValidate } from 'sveltekit-superforms';
 import { valibot } from 'sveltekit-superforms/adapters';
@@ -230,6 +232,7 @@ export const actions: Actions = {
             name: `Create Project #${p}`,
             data: {
               type: BullMQ.JobType.Project_Create,
+              OTContext: trace.getSpanContext(api.context.active()),
               projectId: p
             }
           }))

--- a/src/routes/(authenticated)/projects/import/[id=idNumber]/+page.server.ts
+++ b/src/routes/(authenticated)/projects/import/[id=idNumber]/+page.server.ts
@@ -232,7 +232,7 @@ export const actions: Actions = {
             name: `Create Project #${p}`,
             data: {
               type: BullMQ.JobType.Project_Create,
-              OTContext: trace.getSpanContext(api.context.active()),
+              OTContext: trace.getSpanContext(api.context.active()) ?? null,
               projectId: p
             }
           }))

--- a/src/routes/(authenticated)/projects/new/[id=idNumber]/+page.server.ts
+++ b/src/routes/(authenticated)/projects/new/[id=idNumber]/+page.server.ts
@@ -77,7 +77,7 @@ export const actions: Actions = {
         `Create Project #${project}`,
         {
           type: BullMQ.JobType.Project_Create,
-          OTContext: trace.getSpanContext(api.context.active()),
+          OTContext: trace.getSpanContext(api.context.active()) ?? null,
           projectId: project as number
         },
         BullMQ.Retry0f600

--- a/src/routes/(authenticated)/projects/new/[id=idNumber]/+page.server.ts
+++ b/src/routes/(authenticated)/projects/new/[id=idNumber]/+page.server.ts
@@ -1,3 +1,5 @@
+import { trace } from '@opentelemetry/api';
+import { api } from '@opentelemetry/sdk-node';
 import { error, redirect } from '@sveltejs/kit';
 import { fail, superValidate } from 'sveltekit-superforms';
 import { valibot } from 'sveltekit-superforms/adapters';
@@ -75,6 +77,7 @@ export const actions: Actions = {
         `Create Project #${project}`,
         {
           type: BullMQ.JobType.Project_Create,
+          OTContext: trace.getSpanContext(api.context.active()),
           projectId: project as number
         },
         BullMQ.Retry0f600

--- a/src/routes/(authenticated)/users/invite/+page.server.ts
+++ b/src/routes/(authenticated)/users/invite/+page.server.ts
@@ -1,3 +1,5 @@
+import { trace } from '@opentelemetry/api';
+import { api } from '@opentelemetry/sdk-node';
 import { error, fail } from '@sveltejs/kit';
 import { superValidate } from 'sveltekit-superforms';
 import { valibot } from 'sveltekit-superforms/adapters';
@@ -65,6 +67,7 @@ export const actions = {
     const inviteLink = `${url.origin}/invitations/organization-membership?t=${inviteToken}`;
     await getQueues().Emails.add('Invite User ' + email, {
       type: BullMQ.JobType.Email_InviteUser,
+      OTContext: trace.getSpanContext(api.context.active()),
       email,
       inviteToken,
       inviteLink

--- a/src/routes/(authenticated)/users/invite/+page.server.ts
+++ b/src/routes/(authenticated)/users/invite/+page.server.ts
@@ -67,7 +67,7 @@ export const actions = {
     const inviteLink = `${url.origin}/invitations/organization-membership?t=${inviteToken}`;
     await getQueues().Emails.add('Invite User ' + email, {
       type: BullMQ.JobType.Email_InviteUser,
-      OTContext: trace.getSpanContext(api.context.active()),
+      OTContext: trace.getSpanContext(api.context.active()) ?? null,
       email,
       inviteToken,
       inviteLink

--- a/src/routes/(unauthenticated)/request-access-for-organization/+page.server.ts
+++ b/src/routes/(unauthenticated)/request-access-for-organization/+page.server.ts
@@ -22,7 +22,7 @@ export const actions = {
     if (!form.valid) return fail(400, { form, ok: false });
     await getQueues().Emails.add('Email SuperAdmins about new org ' + form.data.organizationName, {
       type: BullMQ.JobType.Email_NotifySuperAdminsOfNewOrganizationRequest,
-      OTContext: trace.getSpanContext(api.context.active()),
+      OTContext: trace.getSpanContext(api.context.active()) ?? null,
       email: form.data.email,
       organizationName: form.data.organizationName,
       url: form.data.url

--- a/src/routes/(unauthenticated)/request-access-for-organization/+page.server.ts
+++ b/src/routes/(unauthenticated)/request-access-for-organization/+page.server.ts
@@ -1,3 +1,5 @@
+import { trace } from '@opentelemetry/api';
+import { api } from '@opentelemetry/sdk-node';
 import { fail, superValidate } from 'sveltekit-superforms';
 import { valibot } from 'sveltekit-superforms/adapters';
 import * as v from 'valibot';
@@ -20,6 +22,7 @@ export const actions = {
     if (!form.valid) return fail(400, { form, ok: false });
     await getQueues().Emails.add('Email SuperAdmins about new org ' + form.data.organizationName, {
       type: BullMQ.JobType.Email_NotifySuperAdminsOfNewOrganizationRequest,
+      OTContext: trace.getSpanContext(api.context.active()),
       email: form.data.email,
       organizationName: form.data.organizationName,
       url: form.data.url


### PR DESCRIPTION
Closes #1221 

I have added the proper mechanism to the backend, I just need to actually populate the links.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Chores
  - Enhanced observability by propagating tracing context across background jobs, notifications, and workflow actions for products, projects, publishing, and user tasks.
  - Added tracing to system health checks and SSE update events for more consistent monitoring.
- Refactor
  - Standardized job payloads with a common base to enable trace context and consistent shapes across queues.
  - Improved error reporting within job execution spans.

No user-facing behavior or UI changes; these updates improve diagnostics and reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->