### PR TITLE
Fix number of attempts for RetryOf600

### DIFF
--- a/src/lib/server/bullmq/types.ts
+++ b/src/lib/server/bullmq/types.ts
@@ -3,9 +3,9 @@ import type { RepeatOptions } from 'bullmq';
 import type { RoleId } from '../../prisma';
 import type { BuildResponse, Channels, ReleaseResponse } from '../build-engine-api/types';
 
-/** Retry a job forever with fixed backoff of 10 minutes. Useful for build engine tasks */
+/** Retry a job for 72 hours every 10 minutes. Useful for build engine tasks */
 export const Retry0f600 = {
-  attempts: Infinity,
+  attempts: 432,
   backoff: {
     type: 'fixed',
     delay: 600000 // 10 minute

--- a/src/lib/server/bullmq/types.ts
+++ b/src/lib/server/bullmq/types.ts
@@ -5,7 +5,7 @@ import type { BuildResponse, Channels, ReleaseResponse } from '../build-engine-a
 
 /** Retry a job for 72 hours every 10 minutes. Useful for build engine tasks */
 export const Retry0f600 = {
-  attempts: 432,
+  attempts: 72 * 60 / 10,
   backoff: {
     type: 'fixed',
     delay: 600000 // 10 minute


### PR DESCRIPTION
JSON does not serialize Infinity (or NaN)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Bug Fixes
  - Background job retries are now limited to 72 hours with a 10-minute interval (previously unlimited), preventing indefinite retry loops and improving system stability.
  - Users will see tasks surface as failed after 3 days of unsuccessful retries, enabling faster visibility and remediation.

- Documentation
  - Updated description of the retry behavior to reflect the 72-hour limit and 10-minute backoff.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->