### PR TITLE
Fix text color and weight of InputWithMessage

### DIFF
--- a/src/lib/components/settings/InputWithMessage.svelte
+++ b/src/lib/components/settings/InputWithMessage.svelte
@@ -20,7 +20,7 @@
 </script>
 
 <div class="flex flex-row items-center gap-2 {className}">
-  <div class="fieldset-label flex-col items-start grow">
+  <div class="fieldset-label flex-col items-start grow text-base-content">
     {#if title}
       <span class={title.classes ?? ''}>
         {m[title.key](title.params as any)}
@@ -34,3 +34,9 @@
   </div>
   {@render children?.()}
 </div>
+
+<style>
+  .fieldset-label > :not(.text-sm) {
+    font-weight: bold;
+  }
+</style>

--- a/src/lib/components/settings/InputWithMessage.svelte
+++ b/src/lib/components/settings/InputWithMessage.svelte
@@ -22,7 +22,7 @@
 <div class="flex flex-row items-center gap-2 {className}">
   <div class="fieldset-label flex-col items-start grow text-base-content">
     {#if title}
-      <span class={title.classes ?? ''}>
+      <span class="title {title.classes ?? ''}">
         {m[title.key](title.params as any)}
       </span>
     {/if}
@@ -36,7 +36,7 @@
 </div>
 
 <style>
-  .fieldset-label > :not(.text-sm) {
+  .title {
     font-weight: bold;
   }
 </style>


### PR DESCRIPTION
Fixes #1247 

Updated styling:

<img width="737" height="244" alt="image" src="https://github.com/user-attachments/assets/bda623ed-3e95-470a-892e-f69d2b4453c1" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Label text now uses the theme’s base content color for improved contrast and consistency.
  * Field titles are rendered bold by default to enhance visual hierarchy.
  * Helper/secondary message text retains its previous size and weight.
  * Purely presentational changes — no layout, behavior, or configuration changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->