### PR TITLE
Add org select dropdown to org settings

### DIFF
--- a/src/routes/(authenticated)/organizations/[id]/settings/+layout.svelte
+++ b/src/routes/(authenticated)/organizations/[id]/settings/+layout.svelte
@@ -49,21 +49,25 @@
       <h1 class="p-4 pl-3 pb-0 [text-wrap:nowrap]">
         {m.org_settingsTitle()}
       </h1>
-      <h2>
-        <OrganizationDropdown
-          bind:value={$orgActive}
-          organizations={data.organizations}
-          onchange={() =>
-            goto(
-              localizeUrl(
-                page.url.pathname.replace(
-                  `/organizations/${page.params.id}`,
-                  `/organizations/${$orgActive}`
+      {#if data.organizations.length > 1}
+        <h2>
+          <OrganizationDropdown
+            bind:value={$orgActive}
+            organizations={data.organizations}
+            onchange={() =>
+              goto(
+                localizeUrl(
+                  page.url.pathname.replace(
+                    `/organizations/${page.params.id}`,
+                    `/organizations/${$orgActive}`
+                  )
                 )
-              )
-            )}
-        />
-      </h2>
+              )}
+          />
+        </h2>
+      {:else}
+        <h2>{data.organization.Name}</h2>
+      {/if}
     </div>
   {/snippet}
   {@render children?.()}


### PR DESCRIPTION
Fixes #1243 

Changing the org will still stay on the same subpage (i.e. org 1 info -> org 2 info, org 1 groups -> org 2 groups)

Updated UI:

<img width="326" height="385" alt="image" src="https://github.com/user-attachments/assets/04d23936-77b3-42c5-a4ee-e0f942d0009d" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Replaced the static organization name in Settings with an organization switcher dropdown.
  * Switch organizations from the Settings header; the app navigates to the selected organization automatically.
  * Keeps you in the corresponding Settings section when switching to minimize context loss.
  * Dropdown is populated with all organizations you have access to.
  * Navigation respects your current language/locale settings.
  * If only one organization exists, the header shows the organization name as before.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->