### PR TITLE
Allow members of project group to view but not edit

### DIFF
--- a/src/auth.ts
+++ b/src/auth.ts
@@ -281,7 +281,7 @@ async function validateRouteForAuthenticatedUser(
       if (path[2] === '[filter=projectSelector]') return ServerStatus.Ok;
       else if (path[2] === '[id=idNumber]') {
         // prevent edits and actions without breaking SSE
-        if (path[3] === 'edit' || (method === 'POST' && path[3] !== 'sse')) {
+        if (path[3] === 'edit' || (method !== 'GET' && path[3] !== 'sse')) {
           return await verifyCanEdit(session, parseInt(params.id!));
         }
         // A project can be viewed if the user is an admin or in the project's group

--- a/src/lib/components/settings/PublicPrivateToggle.svelte
+++ b/src/lib/components/settings/PublicPrivateToggle.svelte
@@ -10,7 +10,7 @@
     className?: string;
     formName?: string;
     checked: boolean;
-    onchange?: HTMLInputAttributes['onchange'];
+    inputAttr?: HTMLInputAttributes;
   }
   let {
     title,
@@ -18,14 +18,14 @@
     className = '',
     formName,
     checked = $bindable(),
-    onchange
+    inputAttr
   }: Props = $props();
 </script>
 
 <InputWithMessage {title} {message} {className}>
   <label class="group">
     <div class="relative">
-      <input name={formName} type="checkbox" class="sr-only group" bind:checked {onchange} />
+      <input name={formName} type="checkbox" class="sr-only group" bind:checked {...inputAttr} />
       <div
         class="block h-8 rounded-full bg-gray-3 dark:bg-dark-2 w-14 toggle group-has-checked:border-accent"
       ></div>

--- a/src/lib/projects/components/ProjectActionMenu.svelte
+++ b/src/lib/projects/components/ProjectActionMenu.svelte
@@ -46,13 +46,6 @@
       }
     }
   });
-
-  function canClaimOwnership(project: Omit<ProjectForAction, 'Id' | 'Name'>): boolean {
-    return (
-      project.OwnerId !== page.data.session?.user.userId &&
-      canClaimProject(page.data.session, project.OwnerId, orgId, project.GroupId, userGroups)
-    );
-  }
 </script>
 
 <Dropdown
@@ -101,7 +94,7 @@
             </BlockIfJobsUnavailable>
           </li>
         {/if}
-        {#if canClaimOwnership(project)}
+        {#if canClaimProject(page.data.session, project.OwnerId, orgId, project.GroupId, userGroups)}
           <li class="w-full rounded-none">
             <BlockIfJobsUnavailable className="text-nowrap">
               {#snippet altContent()}

--- a/src/lib/projects/index.ts
+++ b/src/lib/projects/index.ts
@@ -162,8 +162,10 @@ export type ProjectForAction = Prisma.ProjectsGetPayload<{
   };
 }>;
 
+export type MaybeSession = Pick<Session, 'user'> | null | undefined;
+
 export function canModifyProject(
-  user: Session | null | undefined,
+  user: MaybeSession,
   projectOwnerId: number,
   organizationId: number
 ): boolean {
@@ -174,7 +176,7 @@ export function canModifyProject(
 }
 
 export function canClaimProject(
-  session: Session | null | undefined,
+  session: MaybeSession,
   projectOwnerId: number,
   organizationId: number,
   projectGroupId: number,
@@ -190,7 +192,7 @@ export function canClaimProject(
 
 export function canArchive(
   project: Pick<ProjectForAction, 'OwnerId' | 'DateArchived'>,
-  session: Session | null | undefined,
+  session: MaybeSession,
   orgId: number
 ): boolean {
   return !project.DateArchived && canModifyProject(session, project.OwnerId, orgId);
@@ -198,7 +200,7 @@ export function canArchive(
 
 export function canReactivate(
   project: Pick<ProjectForAction, 'OwnerId' | 'DateArchived'>,
-  session: Session | null | undefined,
+  session: MaybeSession,
   orgId: number
 ): boolean {
   return !!project.DateArchived && canModifyProject(session, project.OwnerId, orgId);

--- a/src/lib/server/database/UserRoles.ts
+++ b/src/lib/server/database/UserRoles.ts
@@ -121,25 +121,3 @@ export async function allUsersByRole(
   }
   return ret;
 }
-
-// returns -1 if no RoleId
-export async function getAdminRole(UserId: number, OrganizationId?: number): Promise<RoleId> {
-  return (
-    (
-      await prisma.userRoles.findFirst({
-        where: {
-          UserId,
-          OR: [
-            {
-              RoleId: RoleId.SuperAdmin
-            },
-            {
-              OrganizationId,
-              RoleId: RoleId.OrgAdmin
-            }
-          ]
-        }
-      })
-    )?.RoleId ?? -1
-  );
-}

--- a/src/lib/server/database/UserRoles.ts
+++ b/src/lib/server/database/UserRoles.ts
@@ -121,3 +121,25 @@ export async function allUsersByRole(
   }
   return ret;
 }
+
+// returns -1 if no RoleId
+export async function getAdminRole(UserId: number, OrganizationId?: number): Promise<RoleId> {
+  return (
+    (
+      await prisma.userRoles.findFirst({
+        where: {
+          UserId,
+          OR: [
+            {
+              RoleId: RoleId.SuperAdmin
+            },
+            {
+              OrganizationId,
+              RoleId: RoleId.OrgAdmin
+            }
+          ]
+        }
+      })
+    )?.RoleId ?? -1
+  );
+}

--- a/src/routes/(authenticated)/organizations/[id]/settings/products/+page.svelte
+++ b/src/routes/(authenticated)/organizations/[id]/settings/products/+page.svelte
@@ -39,7 +39,9 @@
       className="pb-2"
       formName="publicByDefault"
       checked={!!data.organization.PublicByDefault}
-      onchange={(e) => e.currentTarget.form?.requestSubmit()}
+      inputAttr={{
+        onchange: (e) => e.currentTarget.form?.requestSubmit()
+      }}
     />
   </form>
   <MultiselectBox header={m.org_productSelectTitle()}>

--- a/src/routes/(authenticated)/projects/[filter=projectSelector]/[id]/+page.svelte
+++ b/src/routes/(authenticated)/projects/[filter=projectSelector]/[id]/+page.svelte
@@ -149,11 +149,9 @@
   });
   const mobileSizing = 'w-full max-w-xs md:w-auto md:max-w-none';
 
-  const canCreateProject = $derived(
-    !(
-      isAdminForOrg(parsedParamId, data.session?.user.roles) ||
+  const canModifyProjects = $derived(
+    isAdminForOrg(parsedParamId, data.session?.user.roles) ||
       hasRoleForOrg(RoleId.AppBuilder, parsedParamId, data.session?.user.roles)
-    )
   );
 </script>
 
@@ -190,7 +188,7 @@
       </div>
     </div>
   </form>
-  {#if canCreateProject}
+  {#if canModifyProjects}
     <div class="w-full flex flex-row flex-wrap place-content-between gap-1 mt-4">
       <form
         class="flex flex-row flex-wrap {mobileSizing} gap-1 mx-4"
@@ -405,7 +403,7 @@
       {#each projects.toSorted((a, b) => byName(a, b, locale)) as project}
         <ProjectCard {project}>
           {#snippet select()}
-            {#if canCreateProject}
+            {#if canModifyProjects}
               <input
                 type="checkbox"
                 class="mr-2 checkbox checkbox-accent"
@@ -415,7 +413,7 @@
             {/if}
           {/snippet}
           {#snippet actions()}
-            {#if canCreateProject}
+            {#if canModifyProjects}
               <ProjectActionMenu
                 data={data.actionForm}
                 {project}

--- a/src/routes/(authenticated)/projects/[filter=projectSelector]/[id]/+page.svelte
+++ b/src/routes/(authenticated)/projects/[filter=projectSelector]/[id]/+page.svelte
@@ -15,7 +15,7 @@
   import { getLocale, localizeHref } from '$lib/paraglide/runtime';
   import { RoleId } from '$lib/prisma';
   import type { ProjectForAction, PrunedProject } from '$lib/projects';
-  import { canArchive, canReactivate } from '$lib/projects';
+  import { canArchive, canClaimProject, canReactivate } from '$lib/projects';
   import ProjectActionMenu from '$lib/projects/components/ProjectActionMenu.svelte';
   import ProjectCard from '$lib/projects/components/ProjectCard.svelte';
   import ProjectFilterSelector from '$lib/projects/components/ProjectFilterSelector.svelte';
@@ -111,13 +111,13 @@
     $pageForm.organizationId = parseInt(navigation.to!.params!.id);
   });
 
-  const parsedParamId = $derived(parseInt(page.params.id));
+  const organizationId = $derived(parseInt(page.params.id));
 
   let canArchiveSelected = $derived(
-    selectedProjects.every((p) => canArchive(p, page.data.session, parsedParamId))
+    selectedProjects.every((p) => canArchive(p, page.data.session, organizationId))
   );
   let canReactivateSelected = $derived(
-    selectedProjects.every((p) => canReactivate(p, page.data.session, parsedParamId))
+    selectedProjects.every((p) => canReactivate(p, page.data.session, organizationId))
   );
 
   const {
@@ -150,8 +150,8 @@
   const mobileSizing = 'w-full max-w-xs md:w-auto md:max-w-none';
 
   const canModifyProjects = $derived(
-    isAdminForOrg(parsedParamId, data.session?.user.roles) ||
-      hasRoleForOrg(RoleId.AppBuilder, parsedParamId, data.session?.user.roles)
+    isAdminForOrg(organizationId, data.session?.user.roles) ||
+      hasRoleForOrg(RoleId.AppBuilder, organizationId, data.session?.user.roles)
   );
 </script>
 
@@ -413,14 +413,14 @@
             {/if}
           {/snippet}
           {#snippet actions()}
-            {#if canModifyProjects}
+            {#if canModifyProjects || canClaimProject(data.session, project.OwnerId, organizationId, project.GroupId, data.userGroups)}
               <ProjectActionMenu
                 data={data.actionForm}
                 {project}
                 allowActions={data.allowActions}
                 allowReactivate={data.allowReactivate}
                 userGroups={data.userGroups}
-                orgId={parseInt(page.params.id)}
+                orgId={organizationId}
               />
             {/if}
           {/snippet}

--- a/src/routes/(authenticated)/projects/[filter=projectSelector]/[id]/+page.svelte
+++ b/src/routes/(authenticated)/projects/[filter=projectSelector]/[id]/+page.svelte
@@ -13,6 +13,7 @@
   import { getIcon } from '$lib/icons/productDefinitionIcon';
   import { m } from '$lib/paraglide/messages';
   import { getLocale, localizeHref } from '$lib/paraglide/runtime';
+  import { RoleId } from '$lib/prisma';
   import type { ProjectForAction, PrunedProject } from '$lib/projects';
   import { canArchive, canReactivate } from '$lib/projects';
   import ProjectActionMenu from '$lib/projects/components/ProjectActionMenu.svelte';
@@ -20,6 +21,7 @@
   import ProjectFilterSelector from '$lib/projects/components/ProjectFilterSelector.svelte';
   import { orgActive, orgLastSelected } from '$lib/stores';
   import { toast } from '$lib/utils';
+  import { hasRoleForOrg, isAdminForOrg } from '$lib/utils/roles';
   import { byName, byString } from '$lib/utils/sorting';
 
   interface Props {
@@ -98,7 +100,7 @@
     projects.filter((p) => $actionForm.projects.includes(p.Id))
   );
   /** For selecting products for bulk rebuild/republish */
-  let productSelectModal: HTMLDialogElement | undefined;
+  let productSelectModal: HTMLDialogElement | undefined = $state(undefined);
   let selectedProducts: ProductForAction[] = $state([]);
 
   afterNavigate((navigation) => {
@@ -109,11 +111,13 @@
     $pageForm.organizationId = parseInt(navigation.to!.params!.id);
   });
 
+  const parsedParamId = $derived(parseInt(page.params.id));
+
   let canArchiveSelected = $derived(
-    selectedProjects.every((p) => canArchive(p, page.data.session, parseInt(page.params.id)))
+    selectedProjects.every((p) => canArchive(p, page.data.session, parsedParamId))
   );
   let canReactivateSelected = $derived(
-    selectedProjects.every((p) => canReactivate(p, page.data.session, parseInt(page.params.id)))
+    selectedProjects.every((p) => canReactivate(p, page.data.session, parsedParamId))
   );
 
   const {
@@ -144,6 +148,13 @@
     $orgActive = $pageForm.organizationId || $orgLastSelected;
   });
   const mobileSizing = 'w-full max-w-xs md:w-auto md:max-w-none';
+
+  const canCreateProject = $derived(
+    !(
+      isAdminForOrg(parsedParamId, data.session?.user.roles) ||
+      hasRoleForOrg(RoleId.AppBuilder, parsedParamId, data.session?.user.roles)
+    )
+  );
 </script>
 
 <div class="w-full max-w-6xl mx-auto relative px-2">
@@ -179,232 +190,241 @@
       </div>
     </div>
   </form>
-  <div class="w-full flex flex-row flex-wrap place-content-between gap-1 mt-4">
-    <form
-      class="flex flex-row flex-wrap {mobileSizing} gap-1 mx-4"
-      method="POST"
-      action="?/projectAction"
-      use:actionEnhance
-    >
-      <input type="hidden" name="projectId" value={null} />
-      {#if data.allowActions && (canArchiveSelected || !selectedProjects.length)}
-        <BlockIfJobsUnavailable className="btn btn-outline {mobileSizing}">
-          {#snippet altContent()}
-            {m.common_archive()}
-          {/snippet}
-          <label
-            class="btn btn-outline {mobileSizing}"
-            class:btn-disabled={!(canArchiveSelected && selectedProjects.length)}
-          >
-            {@render altContent()}
-            <input
-              class="hidden"
-              type="radio"
-              bind:group={$actionForm.operation}
-              value="archive"
-              disabled={!(canArchiveSelected && selectedProjects.length)}
-            />
-          </label>
-        </BlockIfJobsUnavailable>
-      {/if}
-      {#if data.allowReactivate && (canReactivateSelected || !selectedProjects.length)}
-        <BlockIfJobsUnavailable className="btn btn-outline {mobileSizing}">
-          {#snippet altContent()}
-            {m.common_reactivate()}
-          {/snippet}
-          <label
-            class="btn btn-outline {mobileSizing}"
-            class:btn-disabled={!(canReactivateSelected && selectedProjects.length)}
-          >
-            {@render altContent()}
-            <input
-              class="hidden"
-              type="radio"
-              bind:group={$actionForm.operation}
-              value="reactivate"
-              disabled={!(canReactivateSelected && selectedProjects.length)}
-            />
-          </label>
-        </BlockIfJobsUnavailable>
-      {/if}
-      {#if data.allowActions && (canArchiveSelected || !selectedProjects.length)}
-        <BlockIfJobsUnavailable className="btn btn-outline {mobileSizing}">
-          {#snippet altContent()}
-            {m.common_rebuild()}
-          {/snippet}
-          <button
-            type="button"
-            class="btn btn-outline {mobileSizing}"
-            disabled={!(canArchiveSelected && selectedProjects.length)}
-            onclick={() => productSelectModal?.showModal()}
-          >
-            {@render altContent()}
-          </button>
-        </BlockIfJobsUnavailable>
-      {/if}
-    </form>
-    <dialog bind:this={productSelectModal} class="modal">
-      <form class="modal-box" action="?/productAction" method="POST" use:productEnhance>
-        <div class="items-center text-center">
-          <div class="flex flex-row">
-            <h2 class="text-lg font-bold grow">{m.projects_bulk_buildModal_title()}</h2>
-            <button
-              class="btn btn-ghost"
-              type="button"
-              onclick={() => {
-                productSelectModal?.close();
-              }}
-            >
-              <IconContainer icon="mdi:close" width={36} class="opacity-80" />
-            </button>
-          </div>
-          <hr />
-          <div class="flex flex-col pt-1 space-y-1">
-            {#each selectedProjects.toSorted((a, b) => byName(a, b, getLocale())) as project}
-              {@const products = project.Products?.filter((p) => p.CanRebuild || p.CanRepublish)}
-              <div class="p-2">
-                <h3>{project.Name}</h3>
-                {#if products?.length}
-                  {#each products.toSorted( (a, b) => byString(a.ProductDefinitionName, b.ProductDefinitionName, getLocale()) ) as product}
-                    <label
-                      class="flex flex-col border border-secondary rounded text-left cursor-pointer"
-                    >
-                      <div class="flex flex-row flex-wrap bg-neutral-300 p-2 w-full text-black">
-                        <input
-                          type="checkbox"
-                          class="checkbox checkbox-info"
-                          bind:group={selectedProducts}
-                          value={product}
-                        />
-                        <IconContainer
-                          icon={getIcon(product.ProductDefinitionName ?? '')}
-                          width="24"
-                        />
-                        {product.ProductDefinitionName}
-                        <div class="basis-full h-0"></div>
-                        {#if product.CanRebuild}
-                          <div class="badge badge-info">{m.products_acts_rebuild()}</div>
-                        {/if}
-                        {#if product.CanRepublish}
-                          <div class="badge badge-info">{m.products_acts_republish()}</div>
-                        {/if}
-                      </div>
-                      <p class="p-2 text-sm text-neutral-400">
-                        {data.productDefinitions.find((pd) => pd.Id === product.ProductDefinitionId)
-                          ?.Description}
-                      </p>
-                    </label>
-                  {/each}
-                {:else}
-                  {m.errors_invalidProjectSelection()}
-                {/if}
-              </div>
-            {/each}
-          </div>
-        </div>
-        <div class="flex flex-row justify-end gap-2">
-          <button
-            class="btn btn-secondary"
-            type="reset"
-            onclick={() => productSelectModal?.close()}
-          >
-            {m.common_cancel()}
-          </button>
-          <BlockIfJobsUnavailable className="btn btn-primary">
+  {#if canCreateProject}
+    <div class="w-full flex flex-row flex-wrap place-content-between gap-1 mt-4">
+      <form
+        class="flex flex-row flex-wrap {mobileSizing} gap-1 mx-4"
+        method="POST"
+        action="?/projectAction"
+        use:actionEnhance
+      >
+        <input type="hidden" name="projectId" value={null} />
+        {#if data.allowActions && (canArchiveSelected || !selectedProjects.length)}
+          <BlockIfJobsUnavailable className="btn btn-outline {mobileSizing}">
             {#snippet altContent()}
-              {m.products_acts_rebuild()}
+              {m.common_archive()}
             {/snippet}
             <label
-              class="btn btn-primary"
-              class:btn-disabled={!(
-                selectedProducts.length && selectedProducts.every((p) => p.CanRebuild)
-              )}
+              class="btn btn-outline {mobileSizing}"
+              class:btn-disabled={!(canArchiveSelected && selectedProjects.length)}
             >
               {@render altContent()}
               <input
-                type="radio"
                 class="hidden"
-                bind:group={$productForm.operation}
-                value="rebuild"
-                disabled={!(selectedProducts.length && selectedProducts.every((p) => p.CanRebuild))}
+                type="radio"
+                bind:group={$actionForm.operation}
+                value="archive"
+                disabled={!(canArchiveSelected && selectedProjects.length)}
               />
             </label>
           </BlockIfJobsUnavailable>
-          <BlockIfJobsUnavailable className="btn btn-primary">
+        {/if}
+        {#if data.allowReactivate && (canReactivateSelected || !selectedProjects.length)}
+          <BlockIfJobsUnavailable className="btn btn-outline {mobileSizing}">
             {#snippet altContent()}
-              {m.products_acts_republish()}
+              {m.common_reactivate()}
             {/snippet}
             <label
-              class="btn btn-primary"
-              class:btn-disabled={!(
-                selectedProducts.length && selectedProducts.every((p) => p.CanRepublish)
-              )}
+              class="btn btn-outline {mobileSizing}"
+              class:btn-disabled={!(canReactivateSelected && selectedProjects.length)}
             >
               {@render altContent()}
               <input
-                type="radio"
                 class="hidden"
-                bind:group={$productForm.operation}
-                value="republish"
-                disabled={!(
+                type="radio"
+                bind:group={$actionForm.operation}
+                value="reactivate"
+                disabled={!(canReactivateSelected && selectedProjects.length)}
+              />
+            </label>
+          </BlockIfJobsUnavailable>
+        {/if}
+        {#if data.allowActions && (canArchiveSelected || !selectedProjects.length)}
+          <BlockIfJobsUnavailable className="btn btn-outline {mobileSizing}">
+            {#snippet altContent()}
+              {m.common_rebuild()}
+            {/snippet}
+            <button
+              type="button"
+              class="btn btn-outline {mobileSizing}"
+              disabled={!(canArchiveSelected && selectedProjects.length)}
+              onclick={() => productSelectModal?.showModal()}
+            >
+              {@render altContent()}
+            </button>
+          </BlockIfJobsUnavailable>
+        {/if}
+      </form>
+      <dialog bind:this={productSelectModal} class="modal">
+        <form class="modal-box" action="?/productAction" method="POST" use:productEnhance>
+          <div class="items-center text-center">
+            <div class="flex flex-row">
+              <h2 class="text-lg font-bold grow">{m.projects_bulk_buildModal_title()}</h2>
+              <button
+                class="btn btn-ghost"
+                type="button"
+                onclick={() => {
+                  productSelectModal?.close();
+                }}
+              >
+                <IconContainer icon="mdi:close" width={36} class="opacity-80" />
+              </button>
+            </div>
+            <hr />
+            <div class="flex flex-col pt-1 space-y-1">
+              {#each selectedProjects.toSorted((a, b) => byName(a, b, getLocale())) as project}
+                {@const products = project.Products?.filter((p) => p.CanRebuild || p.CanRepublish)}
+                <div class="p-2">
+                  <h3>{project.Name}</h3>
+                  {#if products?.length}
+                    {#each products.toSorted( (a, b) => byString(a.ProductDefinitionName, b.ProductDefinitionName, getLocale()) ) as product}
+                      <label
+                        class="flex flex-col border border-secondary rounded text-left cursor-pointer"
+                      >
+                        <div class="flex flex-row flex-wrap bg-neutral-300 p-2 w-full text-black">
+                          <input
+                            type="checkbox"
+                            class="checkbox checkbox-info"
+                            bind:group={selectedProducts}
+                            value={product}
+                          />
+                          <IconContainer
+                            icon={getIcon(product.ProductDefinitionName ?? '')}
+                            width="24"
+                          />
+                          {product.ProductDefinitionName}
+                          <div class="basis-full h-0"></div>
+                          {#if product.CanRebuild}
+                            <div class="badge badge-info">{m.products_acts_rebuild()}</div>
+                          {/if}
+                          {#if product.CanRepublish}
+                            <div class="badge badge-info">{m.products_acts_republish()}</div>
+                          {/if}
+                        </div>
+                        <p class="p-2 text-sm text-neutral-400">
+                          {data.productDefinitions.find(
+                            (pd) => pd.Id === product.ProductDefinitionId
+                          )?.Description}
+                        </p>
+                      </label>
+                    {/each}
+                  {:else}
+                    {m.errors_invalidProjectSelection()}
+                  {/if}
+                </div>
+              {/each}
+            </div>
+          </div>
+          <div class="flex flex-row justify-end gap-2">
+            <button
+              class="btn btn-secondary"
+              type="reset"
+              onclick={() => productSelectModal?.close()}
+            >
+              {m.common_cancel()}
+            </button>
+            <BlockIfJobsUnavailable className="btn btn-primary">
+              {#snippet altContent()}
+                {m.products_acts_rebuild()}
+              {/snippet}
+              <label
+                class="btn btn-primary"
+                class:btn-disabled={!(
+                  selectedProducts.length && selectedProducts.every((p) => p.CanRebuild)
+                )}
+              >
+                {@render altContent()}
+                <input
+                  type="radio"
+                  class="hidden"
+                  bind:group={$productForm.operation}
+                  value="rebuild"
+                  disabled={!(
+                    selectedProducts.length && selectedProducts.every((p) => p.CanRebuild)
+                  )}
+                />
+              </label>
+            </BlockIfJobsUnavailable>
+            <BlockIfJobsUnavailable className="btn btn-primary">
+              {#snippet altContent()}
+                {m.products_acts_republish()}
+              {/snippet}
+              <label
+                class="btn btn-primary"
+                class:btn-disabled={!(
                   selectedProducts.length && selectedProducts.every((p) => p.CanRepublish)
                 )}
-              />
-            </label>
-          </BlockIfJobsUnavailable>
-        </div>
-      </form>
-      <form method="dialog" class="modal-backdrop">
-        <button>{m.common_close()}</button>
-      </form>
-    </dialog>
-    <div class="flex flex-row flex-wrap gap-1 mx-4 {mobileSizing}">
-      <BlockIfJobsUnavailable className="btn btn-outline {mobileSizing}">
-        {#snippet altContent()}
-          {m.projectImport_title()}
-        {/snippet}
-        <a
-          class="btn btn-outline {mobileSizing}"
-          href={localizeHref(`/projects/import/${$pageForm.organizationId}`)}
-        >
-          {@render altContent()}
-        </a>
-      </BlockIfJobsUnavailable>
-      <BlockIfJobsUnavailable className="btn btn-outline {mobileSizing}">
-        {#snippet altContent()}
-          {m.sidebar_addProject()}
-        {/snippet}
-        <a
-          class="btn btn-outline {mobileSizing}"
-          href={localizeHref(`/projects/new/${$pageForm.organizationId}`)}
-        >
-          {@render altContent()}
-        </a>
-      </BlockIfJobsUnavailable>
+              >
+                {@render altContent()}
+                <input
+                  type="radio"
+                  class="hidden"
+                  bind:group={$productForm.operation}
+                  value="republish"
+                  disabled={!(
+                    selectedProducts.length && selectedProducts.every((p) => p.CanRepublish)
+                  )}
+                />
+              </label>
+            </BlockIfJobsUnavailable>
+          </div>
+        </form>
+        <form method="dialog" class="modal-backdrop">
+          <button>{m.common_close()}</button>
+        </form>
+      </dialog>
+      <div class="flex flex-row flex-wrap gap-1 mx-4 {mobileSizing}">
+        <BlockIfJobsUnavailable className="btn btn-outline {mobileSizing}">
+          {#snippet altContent()}
+            {m.projectImport_title()}
+          {/snippet}
+          <a
+            class="btn btn-outline {mobileSizing}"
+            href={localizeHref(`/projects/import/${$pageForm.organizationId}`)}
+          >
+            {@render altContent()}
+          </a>
+        </BlockIfJobsUnavailable>
+        <BlockIfJobsUnavailable className="btn btn-outline {mobileSizing}">
+          {#snippet altContent()}
+            {m.sidebar_addProject()}
+          {/snippet}
+          <a
+            class="btn btn-outline {mobileSizing}"
+            href={localizeHref(`/projects/new/${$pageForm.organizationId}`)}
+          >
+            {@render altContent()}
+          </a>
+        </BlockIfJobsUnavailable>
+      </div>
     </div>
-  </div>
+  {/if}
   {#if projects.length > 0}
     {@const locale = getLocale()}
     <div class="w-full relative p-4">
       {#each projects.toSorted((a, b) => byName(a, b, locale)) as project}
         <ProjectCard {project}>
           {#snippet select()}
-            <input
-              type="checkbox"
-              class="mr-2 checkbox checkbox-accent"
-              bind:group={$actionForm.projects}
-              value={project.Id}
-            />
+            {#if canCreateProject}
+              <input
+                type="checkbox"
+                class="mr-2 checkbox checkbox-accent"
+                bind:group={$actionForm.projects}
+                value={project.Id}
+              />
+            {/if}
           {/snippet}
           {#snippet actions()}
-            <ProjectActionMenu
-              data={data.actionForm}
-              {project}
-              allowActions={data.allowActions}
-              allowReactivate={data.allowReactivate}
-              userGroups={data.userGroups}
-              orgId={parseInt(page.params.id)}
-            />
+            {#if canCreateProject}
+              <ProjectActionMenu
+                data={data.actionForm}
+                {project}
+                allowActions={data.allowActions}
+                allowReactivate={data.allowReactivate}
+                userGroups={data.userGroups}
+                orgId={parseInt(page.params.id)}
+              />
+            {/if}
           {/snippet}
         </ProjectCard>
       {/each}

--- a/src/routes/(authenticated)/projects/[id=idNumber]/+page.svelte
+++ b/src/routes/(authenticated)/projects/[id=idNumber]/+page.svelte
@@ -229,6 +229,7 @@
           project={projectData?.project}
           publicEndpoint="toggleVisibility"
           downloadEndpoint="toggleDownload"
+          {canEdit}
         />
       </div>
       <!-- Sidebar Settings -->

--- a/src/routes/(authenticated)/projects/[id=idNumber]/+page.svelte
+++ b/src/routes/(authenticated)/projects/[id=idNumber]/+page.svelte
@@ -15,6 +15,7 @@
   import ProjectActionMenu from '$lib/projects/components/ProjectActionMenu.svelte';
   import { byName } from '$lib/utils/sorting';
   import { getRelativeTime, getTimeDateString } from '$lib/utils/time';
+  import { canModifyProject } from '$lib/projects';
 
   const { data } = $props();
 
@@ -42,6 +43,14 @@
   const projectData = $derived($projectDataSSE ?? data.projectData);
   const dateCreated = $derived(getRelativeTime(projectData?.project?.DateCreated ?? null));
   const dateArchived = $derived(getRelativeTime(projectData?.project?.DateArchived ?? null));
+
+  const canEdit = $derived(
+    canModifyProject(
+      data.session,
+      projectData?.project.OwnerId ?? -1,
+      projectData?.project.Organization.Id ?? -1
+    )
+  );
 </script>
 
 <div class="w-full max-w-6xl mx-auto relative">
@@ -77,24 +86,26 @@
           </span>
         {/if}
       </div>
-      <div class="grow">
-        <Tooltip className="tooltip-bottom" tip={m.project_editProject()}>
-          <a
-            href={localizeHref(`/projects/${projectData?.project?.Id}/edit`)}
-            title={m.project_editProject()}
-          >
-            <IconContainer width="24" icon="mdi:pencil" />
-          </a>
-        </Tooltip>
-      </div>
-      <div class="shrink">
-        <ProjectActionMenu
-          data={data.actionForm}
-          project={projectData?.project}
-          userGroups={projectData?.userGroups}
-          orgId={projectData?.project.Organization.Id}
-        />
-      </div>
+      {#if canEdit}
+        <div class="grow">
+          <Tooltip className="tooltip-bottom" tip={m.project_editProject()}>
+            <a
+              href={localizeHref(`/projects/${projectData?.project?.Id}/edit`)}
+              title={m.project_editProject()}
+            >
+              <IconContainer width="24" icon="mdi:pencil" />
+            </a>
+          </Tooltip>
+        </div>
+        <div class="shrink">
+          <ProjectActionMenu
+            data={data.actionForm}
+            project={projectData?.project}
+            userGroups={projectData?.userGroups}
+            orgId={projectData?.project.Organization.Id}
+          />
+        </div>
+      {/if}
     </div>
     <div class="grid maingrid w-full p-4 pb-0">
       <div class="mainarea min-w-0">

--- a/src/routes/(authenticated)/projects/[id=idNumber]/+page.svelte
+++ b/src/routes/(authenticated)/projects/[id=idNumber]/+page.svelte
@@ -189,18 +189,20 @@
               class="btn btn-outline"
               onclick={() => addProductModal?.showModal()}
               disabled={!(
-                projectData.productsToAdd.length && projectData.project.WorkflowProjectUrl
+                canEdit && projectData.productsToAdd.length && projectData.project.WorkflowProjectUrl
               )}
             >
               {m.products_add()}
             </button>
           </BlockIfJobsUnavailable>
-          <AddProduct
-            bind:modal={addProductModal}
-            prodDefs={projectData?.productsToAdd}
-            stores={projectData?.stores}
-            endpoint="addProduct"
-          />
+          {#if canEdit}
+            <AddProduct
+              bind:modal={addProductModal}
+              prodDefs={projectData?.productsToAdd}
+              stores={projectData?.stores}
+              endpoint="addProduct"
+            />
+          {/if}
         </div>
         <!-- Products List -->
         <div>
@@ -214,6 +216,7 @@
                 actionEndpoint="productAction"
                 deleteEndpoint="deleteProduct"
                 updateEndpoint="updateProduct"
+                {canEdit}
               />
             {/each}
           {/if}

--- a/src/routes/(authenticated)/projects/[id=idNumber]/+page.svelte
+++ b/src/routes/(authenticated)/projects/[id=idNumber]/+page.svelte
@@ -12,10 +12,10 @@
   import { l10nMap, tryLocalizeName } from '$lib/locales.svelte';
   import { m } from '$lib/paraglide/messages';
   import { getLocale, localizeHref } from '$lib/paraglide/runtime';
+  import { canModifyProject } from '$lib/projects';
   import ProjectActionMenu from '$lib/projects/components/ProjectActionMenu.svelte';
   import { byName } from '$lib/utils/sorting';
   import { getRelativeTime, getTimeDateString } from '$lib/utils/time';
-  import { canModifyProject } from '$lib/projects';
 
   const { data } = $props();
 
@@ -189,7 +189,9 @@
               class="btn btn-outline"
               onclick={() => addProductModal?.showModal()}
               disabled={!(
-                canEdit && projectData.productsToAdd.length && projectData.project.WorkflowProjectUrl
+                canEdit &&
+                projectData.productsToAdd.length &&
+                projectData.project.WorkflowProjectUrl
               )}
             >
               {m.products_add()}

--- a/src/routes/(authenticated)/projects/[id=idNumber]/+page.svelte
+++ b/src/routes/(authenticated)/projects/[id=idNumber]/+page.svelte
@@ -12,7 +12,7 @@
   import { l10nMap, tryLocalizeName } from '$lib/locales.svelte';
   import { m } from '$lib/paraglide/messages';
   import { getLocale, localizeHref } from '$lib/paraglide/runtime';
-  import { canModifyProject } from '$lib/projects';
+  import { canClaimProject, canModifyProject } from '$lib/projects';
   import ProjectActionMenu from '$lib/projects/components/ProjectActionMenu.svelte';
   import { byName } from '$lib/utils/sorting';
   import { getRelativeTime, getTimeDateString } from '$lib/utils/time';
@@ -51,6 +51,15 @@
       projectData?.project.Organization.Id ?? -1
     )
   );
+  const canClaim = $derived(
+    canClaimProject(
+      data.session,
+      projectData?.project.OwnerId ?? -1,
+      projectData?.project.Organization.Id ?? -1,
+      projectData?.project.GroupId ?? -1,
+      projectData?.userGroups ?? []
+    )
+  );
 </script>
 
 <div class="w-full max-w-6xl mx-auto relative">
@@ -86,8 +95,9 @@
           </span>
         {/if}
       </div>
-      {#if canEdit}
-        <div class="grow">
+
+      <div class="grow">
+        {#if canEdit}
           <Tooltip className="tooltip-bottom" tip={m.project_editProject()}>
             <a
               href={localizeHref(`/projects/${projectData.project.Id}/edit`)}
@@ -96,7 +106,9 @@
               <IconContainer width="24" icon="mdi:pencil" />
             </a>
           </Tooltip>
-        </div>
+        {/if}
+      </div>
+      {#if canEdit || canClaim}
         <div class="shrink">
           <ProjectActionMenu
             data={data.actionForm}
@@ -244,6 +256,7 @@
             ?.Name}
           endpoint="editOwnerGroup"
           {canEdit}
+          {canClaim}
         />
         <Authors
           group={projectData.project.Group}

--- a/src/routes/(authenticated)/projects/[id=idNumber]/+page.svelte
+++ b/src/routes/(authenticated)/projects/[id=idNumber]/+page.svelte
@@ -63,16 +63,16 @@
     <div class="flex p-6">
       <div class="shrink">
         <h1 class="p-0">
-          {projectData?.project?.Name}
+          {projectData.project?.Name}
         </h1>
         <div>
           <span class="font-bold">
-            {projectData?.project?.IsPublic ? m.project_public() : m.project_private()}
+            {projectData.project.IsPublic ? m.project_public() : m.project_private()}
           </span>
           <span>-</span>
           <span>
             {m.project_createdOn()}
-            <Tooltip tip={getTimeDateString(projectData?.project?.DateCreated)}>
+            <Tooltip tip={getTimeDateString(projectData.project.DateCreated)}>
               {$dateCreated}
             </Tooltip>
           </span>
@@ -80,7 +80,7 @@
         {#if projectData?.project?.DateArchived}
           <span>
             {m.project_archivedOn()}
-            <Tooltip tip={getTimeDateString(projectData?.project?.DateArchived)}>
+            <Tooltip tip={getTimeDateString(projectData.project.DateArchived)}>
               {$dateArchived}
             </Tooltip>
           </span>
@@ -90,7 +90,7 @@
         <div class="grow">
           <Tooltip className="tooltip-bottom" tip={m.project_editProject()}>
             <a
-              href={localizeHref(`/projects/${projectData?.project?.Id}/edit`)}
+              href={localizeHref(`/projects/${projectData.project.Id}/edit`)}
               title={m.project_editProject()}
             >
               <IconContainer width="24" icon="mdi:pencil" />
@@ -100,9 +100,9 @@
         <div class="shrink">
           <ProjectActionMenu
             data={data.actionForm}
-            project={projectData?.project}
-            userGroups={projectData?.userGroups}
-            orgId={projectData?.project.Organization.Id}
+            project={projectData.project}
+            userGroups={projectData.userGroups}
+            orgId={projectData.project.Organization.Id}
           />
         </div>
       {/if}
@@ -119,36 +119,36 @@
                 {m.project_details_language()}:
               </span>
               <span>
-                {projectData?.project?.Language} ({tryLocalizeName(
+                {projectData.project.Language} ({tryLocalizeName(
                   data.langtags,
                   l10nMap.value,
                   getLocale(),
-                  projectData?.project.Language ?? ''
+                  projectData.project.Language ?? ''
                 )})
               </span>
             </div>
             <div class="flex place-content-between">
               <span>{m.project_details_type()}:</span>
-              <span>{projectData?.project?.ApplicationType.Description}</span>
+              <span>{projectData.project.ApplicationType.Description}</span>
             </div>
           </div>
           <div class="my-4">
             <span>{m.project_description()}:</span>
             <br />
-            <p>{projectData?.project?.Description}</p>
+            <p>{projectData.project.Description}</p>
           </div>
           <div>
             <span>{m.project_location()}:</span>
             <br />
             <div class="flex rounded-md text-nowrap bg-base-200 p-3 pt-2 mt-2">
               <p>
-                {projectData?.project?.WorkflowProjectUrl?.substring(0, 5) ?? ''}
+                {projectData.project.WorkflowProjectUrl?.substring(0, 5) ?? ''}
               </p>
-              {#if !projectData?.project?.WorkflowProjectUrl}
+              {#if !projectData.project.WorkflowProjectUrl}
                 <p class="italic">{m.project_location_placeholder()}</p>
               {:else}
                 <p class="shrink overflow-hidden text-ellipsis">
-                  {projectData?.project?.WorkflowProjectUrl?.split('/').slice(2, -1).join('/')}
+                  {projectData.project.WorkflowProjectUrl.split('/').slice(2, -1).join('/')}
                 </p>
                 <p class="grow pr-2">
                   /{projectData.project.WorkflowProjectUrl.split('/').pop()}
@@ -200,8 +200,8 @@
           {#if canEdit}
             <AddProduct
               bind:modal={addProductModal}
-              prodDefs={projectData?.productsToAdd}
-              stores={projectData?.stores}
+              prodDefs={projectData.productsToAdd}
+              stores={projectData.stores}
               endpoint="addProduct"
             />
           {/if}
@@ -211,10 +211,10 @@
           {#if !projectData?.project?.Products.length}
             {m.projectTable_noProducts()}
           {:else}
-            {#each projectData?.project.Products.toSorted( (a, b) => byName(a.ProductDefinition, b.ProductDefinition, getLocale()) ) as product}
+            {#each projectData.project.Products.toSorted( (a, b) => byName(a.ProductDefinition, b.ProductDefinition, getLocale()) ) as product}
               <ProductCard
                 {product}
-                project={projectData?.project}
+                project={projectData.project}
                 actionEndpoint="productAction"
                 deleteEndpoint="deleteProduct"
                 updateEndpoint="updateProduct"
@@ -228,7 +228,7 @@
       <!-- Settings -->
       <div class="settingsarea my-4">
         <Settings
-          project={projectData?.project}
+          project={projectData.project}
           publicEndpoint="toggleVisibility"
           downloadEndpoint="toggleDownload"
           {canEdit}
@@ -237,25 +237,25 @@
       <!-- Sidebar Settings -->
       <div class="space-y-2 min-w-0 flex-auto sidebararea">
         <OwnerGroup
-          project={projectData?.project}
-          users={projectData?.possibleProjectOwners}
-          groups={projectData?.possibleGroups}
-          orgName={data.organizations.find((o) => o.Id === projectData?.project.Organization.Id)
+          project={projectData.project}
+          users={projectData.possibleProjectOwners}
+          groups={projectData.possibleGroups}
+          orgName={data.organizations.find((o) => o.Id === projectData.project.Organization.Id)
             ?.Name}
           endpoint="editOwnerGroup"
           {canEdit}
         />
         <Authors
-          group={projectData?.project.Group}
-          projectAuthors={projectData?.project.Authors}
-          availableAuthors={projectData?.authorsToAdd}
+          group={projectData.project.Group}
+          projectAuthors={projectData.project.Authors}
+          availableAuthors={projectData.authorsToAdd}
           formData={data.authorForm}
           createEndpoint="addAuthor"
           deleteEndpoint="deleteAuthor"
           {canEdit}
         />
         <Reviewers
-          reviewers={projectData?.project.Reviewers}
+          reviewers={projectData.project.Reviewers}
           formData={data.reviewerForm}
           createEndpoint="addReviewer"
           deleteEndpoint="deleteReviewer"

--- a/src/routes/(authenticated)/projects/[id=idNumber]/+page.svelte
+++ b/src/routes/(authenticated)/projects/[id=idNumber]/+page.svelte
@@ -241,6 +241,7 @@
           orgName={data.organizations.find((o) => o.Id === projectData?.project.Organization.Id)
             ?.Name}
           endpoint="editOwnerGroup"
+          {canEdit}
         />
         <Authors
           group={projectData?.project.Group}
@@ -249,12 +250,14 @@
           formData={data.authorForm}
           createEndpoint="addAuthor"
           deleteEndpoint="deleteAuthor"
+          {canEdit}
         />
         <Reviewers
           reviewers={projectData?.project.Reviewers}
           formData={data.reviewerForm}
           createEndpoint="addReviewer"
           deleteEndpoint="deleteReviewer"
+          {canEdit}
         />
       </div>
     </div>

--- a/src/routes/(authenticated)/projects/[id=idNumber]/ProductCard.svelte
+++ b/src/routes/(authenticated)/projects/[id=idNumber]/ProductCard.svelte
@@ -89,9 +89,11 @@
     actionEndpoint: string;
     deleteEndpoint: string;
     updateEndpoint: string;
+    canEdit: boolean;
   }
 
-  let { product, project, actionEndpoint, deleteEndpoint, updateEndpoint }: Props = $props();
+  let { product, project, actionEndpoint, deleteEndpoint, updateEndpoint, canEdit }: Props =
+    $props();
 
   let deleteProductModal: HTMLDialogElement | undefined = $state(undefined);
   let updateProductModal: HTMLDialogElement | undefined = $state(undefined);
@@ -220,29 +222,33 @@
               </a>
             </li>
           {/if}
-          <li class="w-full rounded-none">
-            <BlockIfJobsUnavailable className="text-nowrap text-error">
-              {#snippet altContent()}
-                {m.models_delete({ name: m.tasks_product() })}
-              {/snippet}
-              <button
-                class="text-nowrap text-error"
-                onclick={() => deleteProductModal?.showModal()}
-              >
-                {m.models_delete({ name: m.tasks_product() })}
-              </button>
-            </BlockIfJobsUnavailable>
-          </li>
+          {#if canEdit}
+            <li class="w-full rounded-none">
+              <BlockIfJobsUnavailable className="text-nowrap text-error">
+                {#snippet altContent()}
+                  {m.models_delete({ name: m.tasks_product() })}
+                {/snippet}
+                <button
+                  class="text-nowrap text-error"
+                  onclick={() => deleteProductModal?.showModal()}
+                >
+                  {m.models_delete({ name: m.tasks_product() })}
+                </button>
+              </BlockIfJobsUnavailable>
+            </li>
+          {/if}
         </ul>
       {/snippet}
     </Dropdown>
-    <DeleteProduct
-      bind:modal={deleteProductModal}
-      {product}
-      endpoint={deleteEndpoint}
-      project={project.Name ?? m.tasks_project()}
-    />
-    <Properties bind:modal={updateProductModal} {product} endpoint={updateEndpoint} />
+    {#if canEdit}
+      <DeleteProduct
+        bind:modal={deleteProductModal}
+        {product}
+        endpoint={deleteEndpoint}
+        project={project.Name ?? m.tasks_project()}
+      />
+      <Properties bind:modal={updateProductModal} {product} endpoint={updateEndpoint} />
+    {/if}
   </div>
   {#if showTaskWaiting}
     <div class="p-2 flex gap-1">

--- a/src/routes/(authenticated)/projects/[id=idNumber]/forms/Authors.svelte
+++ b/src/routes/(authenticated)/projects/[id=idNumber]/forms/Authors.svelte
@@ -32,10 +32,17 @@
     formData: SuperValidated<Infer<AuthorSchema>>;
     createEndpoint: string;
     deleteEndpoint: string;
+    canEdit: boolean;
   }
 
-  let { projectAuthors, availableAuthors, formData, createEndpoint, deleteEndpoint }: Props =
-    $props();
+  let {
+    projectAuthors,
+    availableAuthors,
+    formData,
+    createEndpoint,
+    deleteEndpoint,
+    canEdit
+  }: Props = $props();
 
   const { form, enhance } = superForm(formData, {
     onError: ({ result }) => {
@@ -56,65 +63,70 @@
       {#each projectAuthors.toSorted((a, b) => byName(a.Users, b.Users, locale)) as author}
         <div class="flex flex-row w-full place-content-between p-2">
           <span>{author.Users.Name}</span>
-          <BlockIfJobsUnavailable>
-            {#snippet altContent()}
-              <IconContainer icon="mdi:close" width="24" />
-            {/snippet}
-            <form
-              action="?/{deleteEndpoint}"
-              method="post"
-              use:svk_enhance={() =>
-                ({ update, result }) => {
-                  if (result.type === 'error') {
-                    if (result.status === 503) {
-                      toast('error', m.system_unavailable());
-                    }
-                  }
-                  update({ reset: false });
-                }}
-            >
-              <input type="hidden" name="id" value={author.Id} />
-              <button type="submit" class="cursor-pointer">
+          {#if canEdit}
+            <BlockIfJobsUnavailable>
+              {#snippet altContent()}
                 <IconContainer icon="mdi:close" width="24" />
-              </button>
-            </form>
-          </BlockIfJobsUnavailable>
+              {/snippet}
+              <form
+                action="?/{deleteEndpoint}"
+                method="post"
+                use:svk_enhance={() =>
+                  ({ update, result }) => {
+                    if (result.type === 'error') {
+                      if (result.status === 503) {
+                        toast('error', m.system_unavailable());
+                      }
+                    }
+                    update({ reset: false });
+                  }}
+              >
+                <input type="hidden" name="id" value={author.Id} />
+                <button type="submit" class="cursor-pointer">
+                  <IconContainer icon="mdi:close" width="24" />
+                </button>
+              </form>
+            </BlockIfJobsUnavailable>
+          {/if}
         </div>
       {/each}
     {:else}
       <p class="p-2">{m.authors_empty()}</p>
     {/if}
   </div>
+
   <div class="bg-neutral p-2">
-    <form action="?/{createEndpoint}" method="post" use:enhance>
-      <div class="flex place-content-between space-x-2">
-        <select
-          class="grow select select-bordered"
-          name="author"
-          bind:value={$form.author}
-          required
-        >
-          {#if availableAuthors.length}
-            {#each availableAuthors.sort((a, b) => byName(a, b, getLocale())) as author}
-              <option value={author.Id}>
-                {author.Name}
+    {#if canEdit}
+      <form action="?/{createEndpoint}" method="post" use:enhance>
+        <div class="flex place-content-between space-x-2">
+          <select
+            class="grow select select-bordered"
+            name="author"
+            bind:value={$form.author}
+            required
+          >
+            {#if availableAuthors.length}
+              {#each availableAuthors.sort((a, b) => byName(a, b, getLocale())) as author}
+                <option value={author.Id}>
+                  {author.Name}
+                </option>
+              {/each}
+            {:else}
+              <option disabled selected value="">
+                {m.authors_emptyGroup()}
               </option>
-            {/each}
-          {:else}
-            <option disabled selected value="">
-              {m.authors_emptyGroup()}
-            </option>
-          {/if}
-        </select>
-        <BlockIfJobsUnavailable className="btn btn-primary">
-          {#snippet altContent()}
-            {m.authors_submit()}
-          {/snippet}
-          <button type="submit" class="btn btn-primary">
-            {m.authors_submit()}
-          </button>
-        </BlockIfJobsUnavailable>
-      </div>
-    </form>
+            {/if}
+          </select>
+          <BlockIfJobsUnavailable className="btn btn-primary">
+            {#snippet altContent()}
+              {m.authors_submit()}
+            {/snippet}
+            <button type="submit" class="btn btn-primary">
+              {m.authors_submit()}
+            </button>
+          </BlockIfJobsUnavailable>
+        </div>
+      </form>
+    {/if}
   </div>
 </div>

--- a/src/routes/(authenticated)/projects/[id=idNumber]/forms/OwnerGroup.svelte
+++ b/src/routes/(authenticated)/projects/[id=idNumber]/forms/OwnerGroup.svelte
@@ -126,6 +126,7 @@
                       user.Id !== page.data.session?.user.userId && canClaim && !canEdit}
                     <li class="w-full rounded-none">
                       <button
+                        type="button"
                         class="text-nowrap"
                         class:font-bold={user.Id === project.Owner.Id}
                         class:pointer-events-none={disabled || user.Id === project.Owner.Id}
@@ -172,6 +173,7 @@
                   {#each groups.toSorted((a, b) => byName(a, b, getLocale())) as group}
                     <li class="w-full rounded-none">
                       <button
+                        type="button"
                         class="text-nowrap"
                         class:font-bold={group.Id === project.Group.Id}
                         onclick={() => {

--- a/src/routes/(authenticated)/projects/[id=idNumber]/forms/OwnerGroup.svelte
+++ b/src/routes/(authenticated)/projects/[id=idNumber]/forms/OwnerGroup.svelte
@@ -48,19 +48,11 @@
 
   let { project, users, groups, orgName, endpoint, canEdit, canClaim }: Props = $props();
 
-  // eslint-disable-next-line no-undef
-  let timeout: NodeJS.Timeout;
   let form: HTMLFormElement;
   let ownerField: HTMLInputElement;
+  let ownerOpen = $state(false);
   let groupField: HTMLInputElement;
-  function submit() {
-    if (timeout) {
-      clearTimeout(timeout);
-    }
-    timeout = setTimeout(() => {
-      form.requestSubmit();
-    }, 2000);
-  }
+  let groupOpen = $state(false);
 </script>
 
 <div class="bg-neutral card card-bordered border-slate-400 rounded-md max-w-full">
@@ -107,6 +99,7 @@
             <Dropdown
               labelClasses="p-0.5 h-auto min-h-0 no-animation flex-nowrap items-center font-normal"
               contentClasses="drop-arrow arrow-top menu z-20 min-w-[10rem] top-8 right-0"
+              bind:open={ownerOpen}
             >
               {#snippet label()}
                 <BlockIfJobsUnavailable>
@@ -133,7 +126,8 @@
                         class:opacity-70={disabled && user.Id !== project.Owner.Id}
                         onclick={() => {
                           ownerField.value = user.Id + '';
-                          submit();
+                          form.requestSubmit();
+                          ownerOpen = false;
                         }}
                         {disabled}
                       >
@@ -161,6 +155,7 @@
             <Dropdown
               labelClasses="p-0.5 h-auto min-h-0 no-animation flex-nowrap items-center font-normal"
               contentClasses="drop-arrow arrow-top menu z-20 min-w-[10rem] top-8 right-0"
+              bind:open={groupOpen}
             >
               {#snippet label()}
                 <span class="flex items-center pl-1">
@@ -178,7 +173,8 @@
                         class:font-bold={group.Id === project.Group.Id}
                         onclick={() => {
                           groupField.value = group.Id + '';
-                          submit();
+                          form.requestSubmit();
+                          groupOpen = false;
                         }}
                       >
                         {group.Name}

--- a/src/routes/(authenticated)/projects/[id=idNumber]/forms/OwnerGroup.svelte
+++ b/src/routes/(authenticated)/projects/[id=idNumber]/forms/OwnerGroup.svelte
@@ -41,9 +41,10 @@
     }>[];
     orgName: string | null | undefined;
     endpoint: string;
+    canEdit: boolean;
   }
 
-  let { project, users, groups, orgName, endpoint }: Props = $props();
+  let { project, users, groups, orgName, endpoint, canEdit }: Props = $props();
 
   // eslint-disable-next-line no-undef
   let timeout: NodeJS.Timeout;
@@ -99,41 +100,45 @@
           {m.project_owner()}
         </span>
         <span class="text-right flex place-content-end dropdown-wrapper">
-          <Dropdown
-            labelClasses="p-0.5 h-auto min-h-0 no-animation flex-nowrap items-center font-normal"
-            contentClasses="drop-arrow arrow-top menu z-20 min-w-[10rem] top-8 right-0"
-          >
-            {#snippet label()}
-              <BlockIfJobsUnavailable>
-                {#snippet altContent()}
-                  <span class="flex items-center pl-1">
-                    {project?.Owner.Name}
-                    <IconContainer icon="gridicons:dropdown" width="20" />
-                  </span>
-                {/snippet}
-                {@render altContent()}
-              </BlockIfJobsUnavailable>
-            {/snippet}
-            {#snippet content()}
-              <input type="hidden" name="owner" value={project.Owner.Id} bind:this={ownerField} />
-              <ul class="menu menu-compact overflow-hidden rounded-md">
-                {#each users.toSorted((a, b) => byName(a, b, getLocale())) as user}
-                  <li class="w-full rounded-none">
-                    <button
-                      class="text-nowrap"
-                      class:font-bold={user.Id === project.Owner.Id}
-                      onclick={() => {
-                        ownerField.value = user.Id + '';
-                        submit();
-                      }}
-                    >
-                      {user.Name}
-                    </button>
-                  </li>
-                {/each}
-              </ul>
-            {/snippet}
-          </Dropdown>
+          <input type="hidden" name="owner" value={project.Owner.Id} bind:this={ownerField} />
+          {#if canEdit}
+            <Dropdown
+              labelClasses="p-0.5 h-auto min-h-0 no-animation flex-nowrap items-center font-normal"
+              contentClasses="drop-arrow arrow-top menu z-20 min-w-[10rem] top-8 right-0"
+            >
+              {#snippet label()}
+                <BlockIfJobsUnavailable>
+                  {#snippet altContent()}
+                    <span class="flex items-center pl-1">
+                      {project?.Owner.Name}
+                      <IconContainer icon="gridicons:dropdown" width="20" />
+                    </span>
+                  {/snippet}
+                  {@render altContent()}
+                </BlockIfJobsUnavailable>
+              {/snippet}
+              {#snippet content()}
+                <ul class="menu menu-compact overflow-hidden rounded-md">
+                  {#each users.toSorted((a, b) => byName(a, b, getLocale())) as user}
+                    <li class="w-full rounded-none">
+                      <button
+                        class="text-nowrap"
+                        class:font-bold={user.Id === project.Owner.Id}
+                        onclick={() => {
+                          ownerField.value = user.Id + '';
+                          submit();
+                        }}
+                      >
+                        {user.Name}
+                      </button>
+                    </li>
+                  {/each}
+                </ul>
+              {/snippet}
+            </Dropdown>
+          {:else}
+            {project.Owner.Name}
+          {/if}
         </span>
       </div>
       <div class="divider my-2"></div>
@@ -143,36 +148,40 @@
           {m.project_group()}
         </span>
         <span class="shrink text-right flex place-content-end items-center dropdown-wrapper">
-          <Dropdown
-            labelClasses="p-0.5 h-auto min-h-0 no-animation flex-nowrap items-center font-normal"
-            contentClasses="drop-arrow arrow-top menu z-20 min-w-[10rem] top-8 right-0"
-          >
-            {#snippet label()}
-              <span class="flex items-center pl-1">
-                {project?.Group.Name}
-                <IconContainer icon="gridicons:dropdown" width="20" />
-              </span>
-            {/snippet}
-            {#snippet content()}
-              <input type="hidden" name="group" value={project.Group.Id} bind:this={groupField} />
-              <ul class="menu menu-compact overflow-hidden rounded-md">
-                {#each groups.toSorted((a, b) => byName(a, b, getLocale())) as group}
-                  <li class="w-full rounded-none">
-                    <button
-                      class="text-nowrap"
-                      class:font-bold={group.Id === project.Group.Id}
-                      onclick={() => {
-                        groupField.value = group.Id + '';
-                        submit();
-                      }}
-                    >
-                      {group.Name}
-                    </button>
-                  </li>
-                {/each}
-              </ul>
-            {/snippet}
-          </Dropdown>
+          <input type="hidden" name="group" value={project.Group.Id} bind:this={groupField} />
+          {#if canEdit}
+            <Dropdown
+              labelClasses="p-0.5 h-auto min-h-0 no-animation flex-nowrap items-center font-normal"
+              contentClasses="drop-arrow arrow-top menu z-20 min-w-[10rem] top-8 right-0"
+            >
+              {#snippet label()}
+                <span class="flex items-center pl-1">
+                  {project?.Group.Name}
+                  <IconContainer icon="gridicons:dropdown" width="20" />
+                </span>
+              {/snippet}
+              {#snippet content()}
+                <ul class="menu menu-compact overflow-hidden rounded-md">
+                  {#each groups.toSorted((a, b) => byName(a, b, getLocale())) as group}
+                    <li class="w-full rounded-none">
+                      <button
+                        class="text-nowrap"
+                        class:font-bold={group.Id === project.Group.Id}
+                        onclick={() => {
+                          groupField.value = group.Id + '';
+                          submit();
+                        }}
+                      >
+                        {group.Name}
+                      </button>
+                    </li>
+                  {/each}
+                </ul>
+              {/snippet}
+            </Dropdown>
+          {:else}
+            {project.Group.Name}
+          {/if}
         </span>
       </div>
     </div>

--- a/src/routes/(authenticated)/projects/[id=idNumber]/forms/Reviewers.svelte
+++ b/src/routes/(authenticated)/projects/[id=idNumber]/forms/Reviewers.svelte
@@ -39,12 +39,14 @@
       {#each reviewers.toSorted((a, b) => byName(a, b, locale)) as reviewer}
         <div class="flex flex-row w-full place-content-between p-2">
           <span>{reviewer.Name} ({reviewer.Email})</span>
-          <form action="?/{deleteEndpoint}" method="post" use:svk_enhance>
-            <input type="hidden" name="id" value={reviewer.Id} />
-            <button type="submit" class="cursor-pointer">
-              <IconContainer icon="mdi:close" width="24" />
-            </button>
-          </form>
+          {#if canEdit}
+            <form action="?/{deleteEndpoint}" method="post" use:svk_enhance>
+              <input type="hidden" name="id" value={reviewer.Id} />
+              <button type="submit" class="cursor-pointer">
+                <IconContainer icon="mdi:close" width="24" />
+              </button>
+            </form>
+          {/if}
         </div>
       {/each}
     {:else}

--- a/src/routes/(authenticated)/projects/[id=idNumber]/forms/Reviewers.svelte
+++ b/src/routes/(authenticated)/projects/[id=idNumber]/forms/Reviewers.svelte
@@ -19,9 +19,10 @@
     formData: SuperValidated<Infer<ReviewerSchema>>;
     createEndpoint: string;
     deleteEndpoint: string;
+    canEdit: boolean;
   }
 
-  let { reviewers, formData, createEndpoint, deleteEndpoint }: Props = $props();
+  let { reviewers, formData, createEndpoint, deleteEndpoint, canEdit }: Props = $props();
 
   const { form, enhance } = superForm(formData, {
     resetForm: true
@@ -51,38 +52,40 @@
     {/if}
   </div>
   <div class="p-2 bg-neutral">
-    <form action="?/{createEndpoint}" method="post" use:enhance>
-      <div class="flex flex-col place-content-between space-y-2">
-        <div class="flex flex-col gap-2 reviewerform">
-          <input
-            type="text"
-            name="name"
-            placeholder="Name"
-            class="input input-bordered grow validator"
-            bind:value={$form.name}
-            required
-          />
-          <input
-            type="email"
-            name="email"
-            placeholder="Email"
-            class="input input-bordered grow validator"
-            bind:value={$form.email}
-            required
-          />
+    {#if canEdit}
+      <form action="?/{createEndpoint}" method="post" use:enhance>
+        <div class="flex flex-col place-content-between space-y-2">
+          <div class="flex flex-col gap-2 reviewerform">
+            <input
+              type="text"
+              name="name"
+              placeholder="Name"
+              class="input input-bordered grow validator"
+              bind:value={$form.name}
+              required
+            />
+            <input
+              type="email"
+              name="email"
+              placeholder="Email"
+              class="input input-bordered grow validator"
+              bind:value={$form.email}
+              required
+            />
+          </div>
+          <div class="flex flex-row space-x-2">
+            <select name="locale" class="grow select select-bordered" bind:value={$form.language}>
+              {#each locales as locale}
+                <option value={locale}>{locale.split('-')[0]}</option>
+              {/each}
+            </select>
+            <button type="submit" class="btn btn-primary">
+              {m.reviewers_submit()}
+            </button>
+          </div>
         </div>
-        <div class="flex flex-row space-x-2">
-          <select name="locale" class="grow select select-bordered" bind:value={$form.language}>
-            {#each locales as locale}
-              <option value={locale}>{locale.split('-')[0]}</option>
-            {/each}
-          </select>
-          <button type="submit" class="btn btn-primary">
-            {m.reviewers_submit()}
-          </button>
-        </div>
-      </div>
-    </form>
+      </form>
+    {/if}
   </div>
 </div>
 

--- a/src/routes/(authenticated)/projects/[id=idNumber]/forms/Settings.svelte
+++ b/src/routes/(authenticated)/projects/[id=idNumber]/forms/Settings.svelte
@@ -16,9 +16,10 @@
     }>;
     publicEndpoint: string;
     downloadEndpoint: string;
+    canEdit: boolean;
   }
 
-  let { project, publicEndpoint, downloadEndpoint }: Props = $props();
+  let { project, publicEndpoint, downloadEndpoint, canEdit }: Props = $props();
 
   let isPublic = $state(!!project.IsPublic);
   let publicForm: HTMLFormElement;
@@ -54,9 +55,13 @@
       message={{ key: 'project_visibility_description' }}
       formName="isPublic"
       bind:checked={isPublic}
-      onchange={() => {
-        publicForm.requestSubmit();
+      inputAttr={{
+        onchange: () => {
+          publicForm.requestSubmit();
+        },
+        disabled: !canEdit
       }}
+      className={canEdit ? '' : 'cursor-not-allowed'}
     />
   </form>
   <form
@@ -83,6 +88,7 @@
     <InputWithMessage
       title={{ key: 'project_orgDownloads_title' }}
       message={{ key: 'project_orgDownloads_description' }}
+      className={canEdit ? '' : 'cursor-not-allowed'}
     >
       <input
         bind:this={downloadInput}
@@ -93,6 +99,7 @@
         onchange={() => {
           downloadInput.form?.requestSubmit();
         }}
+        disabled={!canEdit}
       />
     </InputWithMessage>
   </form>

--- a/src/routes/(authenticated)/projects/[id=idNumber]/project.ts
+++ b/src/routes/(authenticated)/projects/[id=idNumber]/project.ts
@@ -4,6 +4,7 @@ import { getProductActions } from '$lib/products';
 import { canModifyProject } from '$lib/projects';
 import { userGroupsForOrg } from '$lib/projects/server';
 import { DatabaseReads } from '$lib/server/database';
+import { getAdminRole } from '$lib/server/database/UserRoles';
 
 const tracer = trace.getTracer('ProjectSSE');
 export type ProjectDataSSE = Awaited<ReturnType<typeof getProjectDetails>>;
@@ -201,20 +202,7 @@ export async function getProjectDetails(id: number, userId: number) {
         {
           user: {
             userId,
-            roles: [
-              [
-                project.Organization.Id,
-                (
-                  await DatabaseReads.userRoles.findFirst({
-                    where: {
-                      UserId: userId,
-                      OrganizationId: project.Organization.Id,
-                      RoleId: { in: [RoleId.SuperAdmin, RoleId.OrgAdmin] }
-                    }
-                  })
-                )?.RoleId ?? -1
-              ]
-            ]
+            roles: [[project.Organization.Id, await getAdminRole(userId, project.Organization.Id)]]
           }
         },
         project.Owner.Id,

--- a/src/routes/(authenticated)/projects/[id=idNumber]/project.ts
+++ b/src/routes/(authenticated)/projects/[id=idNumber]/project.ts
@@ -256,9 +256,15 @@ export async function getProjectDetails(id: number, userId: number) {
             }
           }
         }),
+        // possibleGroups are ones owned by the same org as the project and contain the project's owner
         possibleGroups: await DatabaseReads.groups.findMany({
           where: {
-            OwnerId: project.Organization.Id
+            OwnerId: project.Organization.Id,
+            GroupMemberships: {
+              some: {
+                UserId: project.Owner.Id
+              }
+            }
           }
         }),
         // All users who are members of the group and have the author role in the project's organization


### PR DESCRIPTION
Partial response to #1270 (there are some other fixes to come in separate PR(s))

Changes:
- Disables all actions in /projects/[id] for non owner/admin
- Hides/Disables UI for ^^^
- Filters /projects/[filter] by org membership for non admin
- Prevents UI from assigning invalid group to project (this was already handled in db previously)

Owner/Admin view:

<img width="1100" height="809" alt="image" src="https://github.com/user-attachments/assets/c6cf3b6f-eb2c-43d8-bd9b-eeb362d92cee" />

Alternate group member view:

<img width="1037" height="772" alt="image" src="https://github.com/user-attachments/assets/0d82d5ac-cfb9-46eb-ab4f-3a4568a681f3" />

Note: it does not show up in the screenshot, but `cursor-not-allowed` is applied as a style for the setting toggles in Fig 2.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - UI now shows edit/claim controls and per-item actions only to authorized users; product entries include action lists when editable.
  - Project settings expose relevant groups for owner selection; richer input attributes preserve form-submit behavior for toggles.

- **Bug Fixes**
  - Access enforcement tightened to respect org roles, group membership, SSE and HTTP method contexts to prevent unauthorized edits.

- **Refactor**
  - Permission/session handling and role-aware filtering unified for consistent UI gating and bulk-action visibility.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->