### PR TITLE
Create ProductTransitions after delete if needed

### DIFF
--- a/src/lib/server/job-executors/userTasks.ts
+++ b/src/lib/server/job-executors/userTasks.ts
@@ -75,7 +75,8 @@ export async function modify(job: Job<BullMQ.UserTasks.Modify>): Promise<unknown
         count: (
           await DatabaseWrites.userTasks.updateMany({
             where: {
-              UserId: u.from
+              UserId: u.from,
+              ProductId: { in: productIds }
             },
             data: {
               UserId: u.to,
@@ -178,11 +179,12 @@ export async function modify(job: Job<BullMQ.UserTasks.Modify>): Promise<unknown
                 Comment: job.data.comment,
                 Role: r
               }))
-            );
+            )
+            .filter((t) => allUsers[t.UserId].has(t.Role));
           await DatabaseWrites.userTasks.createMany({
             data: toCreate
           });
-          createdTasks.concat(toCreate);
+          createdTasks = createdTasks.concat(toCreate);
           job.updateProgress(40 + ((i + 0.67) * 40) / products.length);
         }
         // create ProductTransitions if user tasks still exist


### PR DESCRIPTION
Fixes #1269 

The mentioned issue, as best as I can tell, was caused by ProductTransitions being deleted, then not recreated because of the author being deleted.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevents incorrect task reassignment by narrowing which user tasks are affected and ensures transitions are only created when tasks exist.

* **Performance**
  * Reduces redundant lookups and consolidates writes into bulk operations for faster batch processing.

* **Refactor**
  * Simplifies per-item processing and improves role/user selection to create only valid assignments.

* **UX**
  * More accurate, incremental progress updates and consistent notifications after task creation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->