### PR TITLE
Submit page form after archive/reactivate

### DIFF
--- a/src/lib/projects/components/ProjectActionMenu.svelte
+++ b/src/lib/projects/components/ProjectActionMenu.svelte
@@ -19,6 +19,7 @@
     userGroups: number[];
     endpoint?: string;
     orgId: number;
+    onUpdated?: (operation: string) => void;
   }
 
   let {
@@ -28,7 +29,8 @@
     allowReactivate = true,
     userGroups,
     endpoint = 'projectAction',
-    orgId
+    orgId,
+    onUpdated
   }: Props = $props();
 
   const { form, enhance, submit } = superForm(data, {
@@ -44,6 +46,9 @@
       if (result.status === 503) {
         toast('error', m.system_unavailable());
       }
+    },
+    onUpdated: ({ form }) => {
+      onUpdated?.(form.data.operation!);
     }
   });
 </script>

--- a/src/lib/projects/components/ProjectActionMenu.svelte
+++ b/src/lib/projects/components/ProjectActionMenu.svelte
@@ -35,7 +35,7 @@
 
   const { form, enhance, submit } = superForm(data, {
     dataType: 'json',
-    invalidateAll: true,
+    invalidateAll: false,
     warnings: { duplicateId: false },
     onChange: (event) => {
       if (event.paths.includes('operation') && $form.operation) {

--- a/src/routes/(authenticated)/projects/[filter=projectSelector]/[id]/+page.svelte
+++ b/src/routes/(authenticated)/projects/[filter=projectSelector]/[id]/+page.svelte
@@ -112,16 +112,13 @@
     // this way worked much better for our use case
     projects = data.projects;
     count = data.count;
-    $pageForm.organizationId = parseInt(navigation.to!.params!.id);
   });
 
-  const organizationId = $derived(parseInt(page.params.id));
-
   let canArchiveSelected = $derived(
-    selectedProjects.every((p) => canArchive(p, page.data.session, organizationId))
+    selectedProjects.every((p) => canArchive(p, page.data.session, $orgActive))
   );
   let canReactivateSelected = $derived(
-    selectedProjects.every((p) => canReactivate(p, page.data.session, organizationId))
+    selectedProjects.every((p) => canReactivate(p, page.data.session, $orgActive))
   );
 
   const {
@@ -151,8 +148,8 @@
   const mobileSizing = 'w-full max-w-xs md:w-auto md:max-w-none';
 
   const canModifyProjects = $derived(
-    isAdminForOrg(organizationId, data.session?.user.roles) ||
-      hasRoleForOrg(RoleId.AppBuilder, organizationId, data.session?.user.roles)
+    isAdminForOrg($orgActive, data.session?.user.roles) ||
+      hasRoleForOrg(RoleId.AppBuilder, $orgActive, data.session?.user.roles)
   );
 </script>
 
@@ -379,7 +376,7 @@
           {/snippet}
           <a
             class="btn btn-outline {mobileSizing}"
-            href={localizeHref(`/projects/import/${$pageForm.organizationId}`)}
+            href={localizeHref(`/projects/import/${$orgActive}`)}
           >
             {@render altContent()}
           </a>
@@ -390,7 +387,7 @@
           {/snippet}
           <a
             class="btn btn-outline {mobileSizing}"
-            href={localizeHref(`/projects/new/${$pageForm.organizationId}`)}
+            href={localizeHref(`/projects/new/${$orgActive}`)}
           >
             {@render altContent()}
           </a>
@@ -414,14 +411,14 @@
             {/if}
           {/snippet}
           {#snippet actions()}
-            {#if canModifyProjects || canClaimProject(data.session, project.OwnerId, organizationId, project.GroupId, data.userGroups)}
+            {#if canModifyProjects || canClaimProject(data.session, project.OwnerId, $orgActive, project.GroupId, data.userGroups)}
               <ProjectActionMenu
                 data={data.actionForm}
                 {project}
                 allowActions={data.allowActions}
                 allowReactivate={data.allowReactivate}
                 userGroups={data.userGroups}
-                orgId={organizationId}
+                orgId={$orgActive}
                 onUpdated={(operation) => {
                   if (operation === 'archive' || operation === 'reactivate') {
                     pageSubmit();

--- a/src/routes/(authenticated)/projects/[filter=projectSelector]/[id]/+page.svelte
+++ b/src/routes/(authenticated)/projects/[filter=projectSelector]/[id]/+page.svelte
@@ -69,6 +69,7 @@
     submit: actionSubmit
   } = superForm(data.actionForm, {
     dataType: 'json',
+    invalidateAll: false,
     onChange: (event) => {
       if (
         event.paths.includes('operation') &&

--- a/src/routes/(authenticated)/projects/[filter=projectSelector]/[id]/+page.svelte
+++ b/src/routes/(authenticated)/projects/[filter=projectSelector]/[id]/+page.svelte
@@ -69,7 +69,6 @@
     submit: actionSubmit
   } = superForm(data.actionForm, {
     dataType: 'json',
-    invalidateAll: true,
     onChange: (event) => {
       if (
         event.paths.includes('operation') &&
@@ -85,6 +84,11 @@
     onError: ({ result }) => {
       if (result.status === 503) {
         toast('error', m.system_unavailable());
+      }
+    },
+    onUpdated: ({ form }) => {
+      if (form.data.operation === 'archive' || form.data.operation === 'reactivate') {
+        pageSubmit();
       }
     }
   });
@@ -421,6 +425,11 @@
                 allowReactivate={data.allowReactivate}
                 userGroups={data.userGroups}
                 orgId={organizationId}
+                onUpdated={(operation) => {
+                  if (operation === 'archive' || operation === 'reactivate') {
+                    pageSubmit();
+                  }
+                }}
               />
             {/if}
           {/snippet}

--- a/src/routes/(authenticated)/projects/[filter=projectSelector]/[id]/+page.svelte
+++ b/src/routes/(authenticated)/projects/[filter=projectSelector]/[id]/+page.svelte
@@ -19,7 +19,7 @@
   import ProjectActionMenu from '$lib/projects/components/ProjectActionMenu.svelte';
   import ProjectCard from '$lib/projects/components/ProjectCard.svelte';
   import ProjectFilterSelector from '$lib/projects/components/ProjectFilterSelector.svelte';
-  import { orgActive, orgLastSelected } from '$lib/stores';
+  import { orgActive } from '$lib/stores';
   import { toast } from '$lib/utils';
   import { hasRoleForOrg, isAdminForOrg } from '$lib/utils/roles';
   import { byName, byString } from '$lib/utils/sorting';
@@ -148,9 +148,6 @@
     $productForm.products = selectedProducts.map((p) => p.Id);
   });
 
-  $effect(() => {
-    $orgActive = $pageForm.organizationId || $orgLastSelected;
-  });
   const mobileSizing = 'w-full max-w-xs md:w-auto md:max-w-none';
 
   const canModifyProjects = $derived(
@@ -179,8 +176,8 @@
         <OrganizationDropdown
           className={mobileSizing}
           organizations={data.organizations}
-          bind:value={$pageForm.organizationId}
-          onchange={() => goto($pageForm.organizationId + '')}
+          bind:value={$orgActive}
+          onchange={() => goto(localizeHref(`/projects/${page.params.filter}/${$orgActive}`))}
         />
         <Tooltip className="tooltip-bottom {mobileSizing}">
           <div class="tooltip-content text-left">


### PR DESCRIPTION
Fixes #1289 

This seemed like the best way to refresh data while preserving the pagination.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Project actions now auto-refresh the page after archive or reactivate, keeping lists and permissions up to date.
- Refactor
  - Unified organization context to a single active organization across the projects page and action menu.
  - Organization selector now drives navigation and all visibility/permission checks via the active organization.
- Bug Fixes
  - Reduced unnecessary form invalidation during updates, resulting in fewer UI disruptions and smoother interactions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->