### PR TITLE
Mark `AutomaticBuilds` as invalid when parsing project import JSON

### DIFF
--- a/src/lib/projects/index.ts
+++ b/src/lib/projects/index.ts
@@ -140,6 +140,8 @@ export const importJSONSchema = v.pipe(
   })
 );
 
+export type ProjectImportJSON = v.InferOutput<typeof importJSONSchema>;
+
 export const projectActionSchema = v.object({
   operation: v.nullable(v.picklist(['archive', 'reactivate', 'claim'])),
   // used to distinguish between single and bulk. will be null if bulk

--- a/src/lib/projects/index.ts
+++ b/src/lib/projects/index.ts
@@ -122,8 +122,7 @@ export const importJSONSchema = v.pipe(
       v.array(
         v.strictObject({
           ...projectSchemaBase.entries,
-          AllowDownloads: v.optional(v.boolean()),
-          AutomaticBuilds: v.never('AutomaticBuilds is deprecated')
+          AllowDownloads: v.optional(v.boolean())
           // ISSUE #1303 Add new fields here
         })
       ),

--- a/src/lib/projects/index.ts
+++ b/src/lib/projects/index.ts
@@ -123,7 +123,7 @@ export const importJSONSchema = v.pipe(
         v.strictObject({
           ...projectSchemaBase.entries,
           AllowDownloads: v.optional(v.boolean()),
-          AutomaticBuilds: v.optional(v.boolean())
+          AutomaticBuilds: v.never('AutomaticBuilds is deprecated')
         })
       ),
       v.minLength(1)

--- a/src/lib/projects/index.ts
+++ b/src/lib/projects/index.ts
@@ -124,6 +124,7 @@ export const importJSONSchema = v.pipe(
           ...projectSchemaBase.entries,
           AllowDownloads: v.optional(v.boolean()),
           AutomaticBuilds: v.never('AutomaticBuilds is deprecated')
+          // ISSUE #1303 Add new fields here
         })
       ),
       v.minLength(1)

--- a/src/lib/server/job-executors/email.ts
+++ b/src/lib/server/job-executors/email.ts
@@ -13,6 +13,7 @@ import {
 } from '../email-service/EmailTemplates';
 import { getOwnerAdminVariantKeys, translate } from '../email-service/locales/locale';
 import { RoleId } from '$lib/prisma';
+import type { ProjectImportJSON } from '$lib/projects';
 
 export async function inviteUser(job: Job<BullMQ.Email.InviteUser>): Promise<unknown> {
   const inviteInformation = await DatabaseReads.organizationMembershipInvites.findFirstOrThrow({
@@ -304,20 +305,7 @@ export async function reportProjectImport(
       ImportId: job.data.importId
     }
   });
-  const importJSON: {
-    Projects: {
-      Name: string;
-      Description: string;
-      Language: string;
-      IsPublic: boolean;
-      AllowDownloads: boolean;
-      AutomaticBuilds: boolean;
-    }[];
-    Products: {
-      Name: string;
-      Store: string;
-    }[];
-  } = JSON.parse(projectImport.ImportData!);
+  const importJSON: ProjectImportJSON = JSON.parse(projectImport.ImportData!);
   const existingProjects = await DatabaseReads.projects.findMany({
     where: {
       OrganizationId: projectImport.Organizations!.Id,

--- a/src/routes/(authenticated)/projects/import/[id=idNumber]/+page.server.ts
+++ b/src/routes/(authenticated)/projects/import/[id=idNumber]/+page.server.ts
@@ -218,6 +218,7 @@ export const actions: Actions = {
             TypeId: form.data.type,
             Description: pj.Description ?? '',
             IsPublic: pj.IsPublic,
+            // ISSUE #1303 Add new fields here
             ImportId: imp.Id
           };
         })


### PR DESCRIPTION
Initial contribution to #1303 

This should not affect existing project import JSONs in the database, only new uploads.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Project import now rejects the AutomaticBuilds field and displays a deprecation notice; other import fields and validations are unchanged.

- Chores
  - Internal typing and exports standardized and minor non-functional comments added; no user-facing behavior changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->