### PR TITLE
Use $orgActive in /users and /users/invite

### DIFF
--- a/src/routes/(authenticated)/users/+page.server.ts
+++ b/src/routes/(authenticated)/users/+page.server.ts
@@ -138,7 +138,7 @@ export const load = (async ({ locals }) => {
         organizations,
         groups: await DatabaseReads.groups.findMany({
           where: {
-            OwnerId: { in: orgIds },
+            OwnerId: locals.security.isSuperAdmin ? undefined : { in: orgIds },
             GroupMemberships: {
               some: {}
             }

--- a/src/routes/(authenticated)/users/+page.svelte
+++ b/src/routes/(authenticated)/users/+page.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+  import { onMount } from 'svelte';
   import { type FormResult, superForm } from 'sveltekit-superforms';
   import type { PageData } from './$types';
   import type { MinifiedUser } from './common';
@@ -10,6 +11,7 @@
   import SearchBar from '$lib/components/SearchBar.svelte';
   import { m } from '$lib/paraglide/messages';
   import { getLocale, localizeHref } from '$lib/paraglide/runtime';
+  import { orgActive } from '$lib/stores';
   import { toast } from '$lib/utils';
   import { isAdminForAny } from '$lib/utils/roles';
   import { byName, byString } from '$lib/utils/sorting';
@@ -43,6 +45,18 @@
         users = data.query.data;
         count = data.query.count;
       }
+    }
+  });
+
+  $effect(() => {
+    if ($form.organizationId) {
+      $orgActive = $form.organizationId;
+    }
+  });
+
+  onMount(() => {
+    if ($form.organizationId && $orgActive) {
+      $form.organizationId = $orgActive;
     }
   });
 

--- a/src/routes/(authenticated)/users/invite/+page.svelte
+++ b/src/routes/(authenticated)/users/invite/+page.svelte
@@ -10,6 +10,7 @@
   import LabeledFormInput from '$lib/components/settings/LabeledFormInput.svelte';
   import { m } from '$lib/paraglide/messages';
   import { localizeHref } from '$lib/paraglide/runtime';
+  import { orgActive } from '$lib/stores';
   import { toast } from '$lib/utils';
 
   interface Props {
@@ -41,7 +42,7 @@
   );
 
   onMount(() => {
-    $form.organizationId = data.groupsByOrg[0].Id;
+    $form.organizationId = $orgActive;
   });
 </script>
 


### PR DESCRIPTION
Fixes #1316 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * User and Invite pages now prefill the organization field with your currently active organization for faster, more consistent setup.
  * Organization selection in forms is restored from your active organization when returning to these pages.

* **Bug Fixes**
  * Super admin view of groups no longer applies the owner restriction, ensuring correct group listings for super admins.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->