### PR TITLE
Block npm run dev if db differs from schema

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "node": "22.19.0"
   },
   "scripts": {
-    "dev": "vite dev",
+    "dev": "npm run diff-db && vite dev",
     "build": "vite build",
     "preview": "vite preview",
     "test": "npm run test:integration && npm run test:unit",
@@ -18,7 +18,8 @@
     "test:integration": "playwright test",
     "test:unit": "vitest run",
     "prepare": "svelte-kit sync",
-    "fix-sourcemaps": "node --experimental-strip-types fixSourcemaps.cts"
+    "fix-sourcemaps": "node --experimental-strip-types fixSourcemaps.cts",
+    "diff-db": "prisma migrate diff --from-schema-datasource src/lib/prisma/schema.prisma --to-schema-datamodel src/lib/prisma/schema.prisma --exit-code"
   },
   "prisma": {
     "seed": "node --experimental-strip-types src/lib/prisma/seed.ts -o",


### PR DESCRIPTION
Fixes #1319 

Do we want to have a similar check before any of the other scripts? (i.e. build? test?)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced development workflow with an automated database schema consistency check that runs before the local server starts.
  * Updated the development start command to include the new pre-check for improved reliability and faster feedback during development.
  * No user-facing changes; interface and functionality remain the same.
  * No impact on production behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->