### PR TITLE
Fix project search

### DIFF
--- a/src/lib/components/SearchBar.svelte
+++ b/src/lib/components/SearchBar.svelte
@@ -49,6 +49,11 @@
           timeout = setTimeout(requestSubmit, requestDelay);
         }
       }}
+      onfocus={(e) => {
+        const target = e.currentTarget;
+        // https://stackoverflow.com/a/10576409
+        setTimeout(() => target.setSelectionRange(value.length, value.length), 0);
+      }}
     />
     <IconContainer icon="mdi:search" class="ml-auto cursor-pointer" width={24} />
   </label>

--- a/src/lib/components/SearchBar.svelte
+++ b/src/lib/components/SearchBar.svelte
@@ -5,9 +5,18 @@
   interface Props {
     className?: string;
     value: string;
+    requestSubmit?: () => void;
+    requestDelay?: number;
   }
 
-  let { className = '', value = $bindable() }: Props = $props();
+  let {
+    className = '',
+    value = $bindable(),
+    requestSubmit,
+    requestDelay = 1_000
+  }: Props = $props();
+
+  let timeout: ReturnType<typeof setTimeout> | null = $state(null);
 </script>
 
 <div class={className} data-html="true">
@@ -18,6 +27,14 @@
       aria-label={m.common_search()}
       class="grow"
       bind:value
+      oninput={(e) => {
+        if (requestSubmit) {
+          if (timeout) {
+            clearTimeout(timeout);
+          }
+          timeout = setTimeout(requestSubmit, requestDelay);
+        }
+      }}
     />
     <IconContainer icon="mdi:search" class="ml-auto cursor-pointer" width={24} />
   </label>

--- a/src/lib/components/SearchBar.svelte
+++ b/src/lib/components/SearchBar.svelte
@@ -6,6 +6,7 @@
 </script>
 
 <script lang="ts">
+  import { onDestroy } from 'svelte';
   import IconContainer from './IconContainer.svelte';
   import { m } from '$lib/paraglide/messages';
 
@@ -24,6 +25,12 @@
   }: Props = $props();
 
   let timeout: ReturnType<typeof setTimeout> | null = $state(null);
+
+  onDestroy(() => {
+    if (timeout) {
+      clearTimeout(timeout);
+    }
+  });
 </script>
 
 <div class={className} data-html="true">

--- a/src/lib/components/SearchBar.svelte
+++ b/src/lib/components/SearchBar.svelte
@@ -1,3 +1,10 @@
+<script module lang="ts">
+  /** Make sure to call this in SuperForms onUpdate**d**() */
+  export function focusSearchBar() {
+    (document.querySelector('input[type="search"]') as HTMLInputElement)?.focus?.();
+  }
+</script>
+
 <script lang="ts">
   import IconContainer from './IconContainer.svelte';
   import { m } from '$lib/paraglide/messages';

--- a/src/lib/locales/en-US.json
+++ b/src/lib/locales/en-US.json
@@ -354,7 +354,6 @@
   "projects_filter_all": "All Projects",
   "projects_bulk_buildModal_title": "Perform Bulk Rebuild/Republish",
   "filters_allProdDefs": "All projects that contain...",
-  "filters_org_label": "Filter organization",
   "filters_dateRange": "Last Updated Date Between",
   "projectImport_title": "Import Projects",
   "projectImport_help": "Import Projects Help",

--- a/src/lib/locales/es-419.json
+++ b/src/lib/locales/es-419.json
@@ -354,7 +354,6 @@
   "projects_filter_all": "Todos los proyecto",
   "projects_bulk_buildModal_title": "Perform Bulk Rebuild/Republish",
   "filters_allProdDefs": "Todos los proyectos que contienen...",
-  "filters_org_label": "Filter organization",
   "filters_dateRange": "Rango de Fechas",
   "projectImport_title": "Import Projects",
   "projectImport_help": "Import Projects Help",

--- a/src/lib/locales/fr-FR.json
+++ b/src/lib/locales/fr-FR.json
@@ -330,7 +330,6 @@
   "projects_filter_all": "All Projects",
   "projects_bulk_buildModal_title": "Perform Bulk Rebuild/Republish",
   "filters_allProdDefs": "All projects that contain...",
-  "filters_org_label": "Filter organization",
   "filters_dateRange": "Last Updated Date Between",
   "projectImport_title": "Import Projects",
   "projectImport_help": "Import Projects Help",

--- a/src/lib/products/index.ts
+++ b/src/lib/products/index.ts
@@ -58,10 +58,18 @@ export async function getFileInfo(url: string) {
 
 export async function fetchPackageName(Url: string | null) {
   if (Url) {
-    const name = (await fetch(Url).then((r) => r.text())).trim();
-    // regex match just in case fetch returns an error HTML
-    // regex slightly modified from: https://stackoverflow.com/a/69168419
-    return name.match(/^[a-z][a-z0-9_]*(\.[a-z0-9_]+)*$/i)?.at(0) ?? null;
+    try {
+      const response = await fetch(Url);
+      if (!response.ok) {
+        return null;
+      }
+      const name = (await response.text()).trim();
+      // regex match just in case fetch returns an error HTML
+      // regex slightly modified from: https://stackoverflow.com/a/69168419
+      return name.match(/^[a-z][a-z0-9_]*(\.[a-z0-9_]+)*$/i)?.at(0) ?? null;
+    } catch {
+      return null;
+    }
   }
   return null;
 }

--- a/src/lib/products/index.ts
+++ b/src/lib/products/index.ts
@@ -56,10 +56,6 @@ export async function getFileInfo(url: string) {
   };
 }
 
-export function extractPackageName(PublishLink: string | null) {
-  return PublishLink?.match(/[?&]id=([^&#/]+)/i)?.at(1) ?? null;
-}
-
 export async function fetchPackageName(Url: string | null) {
   if (Url) {
     const name = (await fetch(Url).then((r) => r.text())).trim();

--- a/src/lib/products/index.ts
+++ b/src/lib/products/index.ts
@@ -59,3 +59,13 @@ export async function getFileInfo(url: string) {
 export function extractPackageName(PublishLink: string | null) {
   return PublishLink?.match(/[?&]id=([^&#/]+)/i)?.at(1) ?? null;
 }
+
+export async function fetchPackageName(Url: string | null) {
+  if (Url) {
+    const name = (await fetch(Url).then((r) => r.text())).trim();
+    // regex match just in case fetch returns an error HTML
+    // regex slightly modified from: https://stackoverflow.com/a/69168419
+    return name.match(/^[a-z][a-z0-9_]*(\.[a-z0-9_]+)*$/i)?.at(0) ?? null;
+  }
+  return null;
+}

--- a/src/lib/projects/index.ts
+++ b/src/lib/projects/index.ts
@@ -192,10 +192,11 @@ export function canClaimProject(
   userGroupIds: number[]
 ) {
   if (security.userId === projectOwnerId) return false;
-  if (security.roles.some(([_, r]) => r === RoleId.SuperAdmin)) return true;
+  if (security.roles.some(([, r]) => r === RoleId.SuperAdmin)) return true;
   return (
-    canModifyProject(security, projectOwnerId, organizationId) &&
-    userGroupIds.includes(projectGroupId)
+    canModifyProject(security, projectOwnerId, organizationId) ||
+    (userGroupIds.includes(projectGroupId) &&
+      security.roles.some(([, r]) => r === RoleId.AppBuilder))
   );
 }
 

--- a/src/lib/server/database/Products.ts
+++ b/src/lib/server/database/Products.ts
@@ -3,7 +3,6 @@ import { BullMQ, getQueues } from '../bullmq/index';
 import { delete as deleteInstance } from './WorkflowInstances';
 import prisma from './prisma';
 import type { RequirePrimitive } from './utility';
-import { extractPackageName } from '$lib/products';
 
 export async function create(
   productData: RequirePrimitive<Prisma.ProductsUncheckedCreateInput>
@@ -58,11 +57,6 @@ export async function update(
     return false;
 
   // No additional verification steps
-
-  // write package name whenever publish link is updated
-  if (productData.PublishLink) {
-    productData.PackageName = extractPackageName(productData.PublishLink);
-  }
 
   try {
     await prisma.products.update({

--- a/src/lib/server/job-executors/build.ts
+++ b/src/lib/server/job-executors/build.ts
@@ -136,7 +136,6 @@ export async function postProcess(job: Job<BullMQ.Build.PostProcess>): Promise<u
     select: {
       WorkflowJobId: true,
       WorkflowBuildId: true,
-      PublishLink: true,
       ProductDefinition: {
         select: {
           Name: true
@@ -217,7 +216,7 @@ export async function postProcess(job: Job<BullMQ.Build.PostProcess>): Promise<u
         if (type === 'package_name' && res.headers.get('Content-Type') === 'text/plain') {
           const PackageName = await fetchPackageName(url);
           // populate package name if publish link is not set
-          if (!product.PublishLink && PackageName) {
+          if (PackageName) {
             await DatabaseWrites.products.update(job.data.productId, { PackageName });
           }
         }

--- a/src/lib/server/job-executors/system.ts
+++ b/src/lib/server/job-executors/system.ts
@@ -1,3 +1,4 @@
+import type { Prisma } from '@prisma/client';
 import type { Job } from 'bullmq';
 import { XMLParser } from 'fast-xml-parser';
 import { existsSync } from 'fs';
@@ -8,7 +9,7 @@ import { BullMQ, getQueues } from '../bullmq';
 import { DatabaseReads, DatabaseWrites } from '../database';
 import { Workflow } from '../workflow';
 import { WorkflowType, WorkflowTypeString } from '$lib/prisma';
-import { extractPackageName } from '$lib/products';
+import { extractPackageName, fetchPackageName } from '$lib/products';
 import {
   ENVKeys,
   ProductType,
@@ -620,7 +621,7 @@ export async function migrate(job: Job<BullMQ.System.Migrate>): Promise<unknown>
   job.updateProgress(60);
 
   // 4. Populate Product.PackageName
-  const updatedPackages = await Promise.all(
+  const fromPublishLink = await Promise.all(
     (
       await DatabaseReads.products.findMany({
         where: {
@@ -643,8 +644,57 @@ export async function migrate(job: Job<BullMQ.System.Migrate>): Promise<unknown>
       return pname;
     })
   );
+
+  const artifactWhere: Prisma.ProductArtifactsWhereInput = {
+    ArtifactType: 'package_name',
+    ContentType: 'text/plain'
+  };
+
+  const buildWhere: Prisma.ProductBuildsWhereInput = {
+    Success: true,
+    ProductArtifacts: {
+      some: artifactWhere
+    }
+  };
+
+  const fromArtifact = await Promise.all(
+    (
+      await DatabaseReads.products.findMany({
+        where: {
+          PackageName: null,
+          PublishLink: null,
+          ProductBuilds: {
+            some: buildWhere
+          }
+        },
+        select: {
+          Id: true,
+          ProductBuilds: {
+            where: buildWhere,
+            select: {
+              ProductArtifacts: {
+                where: artifactWhere,
+                take: 1
+              }
+            },
+            orderBy: { DateUpdated: 'desc' },
+            take: 1
+          }
+        }
+      })
+    ).map(async (p) => {
+      const PackageName = await fetchPackageName(p.ProductBuilds[0].ProductArtifacts[0].Url);
+      // populate package name if publish link is not set
+      if (PackageName) {
+        await DatabaseWrites.products.update(p.Id, { PackageName });
+      }
+      return PackageName;
+    })
+  );
+
   job.updateProgress(80);
 
+  // 5. delete users with no org membership
   const deletedUsers = await DatabaseReads.users.findMany({
     where: {
       NOT: { OrganizationMemberships: { some: {} } }
@@ -673,7 +723,8 @@ export async function migrate(job: Job<BullMQ.System.Migrate>): Promise<unknown>
     migrationErrors,
     orphanedWPIs: orphanedInstances.reduce((p, c) => p + (c?.at(-1)?.count ?? 0), 0),
     updatedWorkflowDefinitions: workflowDefsNeedUpdate,
-    updatedPackages,
+    fromPublishLink,
+    fromArtifact,
     deletedUsers: {
       users: deletedUsers,
       count: deleteCount,

--- a/src/routes/(authenticated)/directory/+page.svelte
+++ b/src/routes/(authenticated)/directory/+page.svelte
@@ -6,7 +6,7 @@
   import LanguageCodeTypeahead from '$lib/components/LanguageCodeTypeahead.svelte';
   import OrganizationDropdown from '$lib/components/OrganizationDropdown.svelte';
   import Pagination from '$lib/components/Pagination.svelte';
-  import SearchBar from '$lib/components/SearchBar.svelte';
+  import SearchBar, { focusSearchBar } from '$lib/components/SearchBar.svelte';
   import Tooltip from '$lib/components/Tooltip.svelte';
   import { m } from '$lib/paraglide/messages';
   import { getLocale } from '$lib/paraglide/runtime';
@@ -38,6 +38,11 @@
       if (event.form.valid && data.query) {
         projects = data.query.data;
         count = data.query.count;
+      }
+    },
+    onUpdated() {
+      if ($form.search) {
+        focusSearchBar();
       }
     }
   });

--- a/src/routes/(authenticated)/directory/+page.svelte
+++ b/src/routes/(authenticated)/directory/+page.svelte
@@ -75,7 +75,7 @@
             <!-- eslint-disable-next-line svelte/no-at-html-tags -->
             {@html m.directory_searchHelp()}
           </div>
-          <SearchBar bind:value={$form.search} />
+          <SearchBar bind:value={$form.search} requestSubmit={submit} />
         </Tooltip>
       </div>
     </div>

--- a/src/routes/(authenticated)/projects/[filter=projectSelector]/[[orgId=idNumber]]/+page.svelte
+++ b/src/routes/(authenticated)/projects/[filter=projectSelector]/[[orgId=idNumber]]/+page.svelte
@@ -196,7 +196,7 @@
             <!-- eslint-disable-next-line svelte/no-at-html-tags -->
             {@html m.directory_searchHelp()}
           </div>
-          <SearchBar bind:value={$pageForm.search} />
+          <SearchBar bind:value={$pageForm.search} requestSubmit={pageSubmit} />
         </Tooltip>
       </div>
     </div>

--- a/src/routes/(authenticated)/projects/[filter=projectSelector]/[[orgId=idNumber]]/+page.svelte
+++ b/src/routes/(authenticated)/projects/[filter=projectSelector]/[[orgId=idNumber]]/+page.svelte
@@ -8,7 +8,7 @@
   import BlockIfJobsUnavailable from '$lib/components/BlockIfJobsUnavailable.svelte';
   import IconContainer from '$lib/components/IconContainer.svelte';
   import Pagination from '$lib/components/Pagination.svelte';
-  import SearchBar from '$lib/components/SearchBar.svelte';
+  import SearchBar, { focusSearchBar } from '$lib/components/SearchBar.svelte';
   import Tooltip from '$lib/components/Tooltip.svelte';
   import { getIcon } from '$lib/icons/productDefinitionIcon';
   import { m } from '$lib/paraglide/messages';
@@ -59,6 +59,11 @@
       if (event.form.valid && returnedData.query) {
         projects = returnedData.query.data;
         count = returnedData.query.count;
+      }
+    },
+    onUpdated() {
+      if ($pageForm.search) {
+        focusSearchBar();
       }
     }
   });

--- a/src/routes/(authenticated)/users/+page.svelte
+++ b/src/routes/(authenticated)/users/+page.svelte
@@ -6,7 +6,7 @@
   import BlockIfJobsUnavailable from '$lib/components/BlockIfJobsUnavailable.svelte';
   import IconContainer from '$lib/components/IconContainer.svelte';
   import Pagination from '$lib/components/Pagination.svelte';
-  import SearchBar from '$lib/components/SearchBar.svelte';
+  import SearchBar, { focusSearchBar } from '$lib/components/SearchBar.svelte';
   import { m } from '$lib/paraglide/messages';
   import { getLocale, localizeHref } from '$lib/paraglide/runtime';
   import { orgActive } from '$lib/stores';
@@ -42,6 +42,11 @@
       if (event.form.valid && data.query) {
         users = data.query.data;
         count = data.query.count;
+      }
+    },
+    onUpdated() {
+      if ($form.search) {
+        focusSearchBar();
       }
     }
   });

--- a/src/routes/(authenticated)/users/+page.svelte
+++ b/src/routes/(authenticated)/users/+page.svelte
@@ -87,7 +87,7 @@
       use:enhance
       class="flex flex-row flex-wrap place-content-end items-center p-2 gap-1"
     >
-      <SearchBar bind:value={$form.search} className={mobileSizing} />
+      <SearchBar bind:value={$form.search} className={mobileSizing} requestSubmit={submit} />
     </form>
   </div>
   <div class="m-4 relative mt-0">

--- a/src/routes/(authenticated)/workflow-instances/+page.svelte
+++ b/src/routes/(authenticated)/workflow-instances/+page.svelte
@@ -4,7 +4,7 @@
   import type { PageData } from './$types';
   import DateRangePicker from '$lib/components/DateRangePicker.svelte';
   import Pagination from '$lib/components/Pagination.svelte';
-  import SearchBar from '$lib/components/SearchBar.svelte';
+  import SearchBar, { focusSearchBar } from '$lib/components/SearchBar.svelte';
   import SortTable from '$lib/components/SortTable.svelte';
   import Tooltip from '$lib/components/Tooltip.svelte';
   import { m } from '$lib/paraglide/messages';
@@ -38,6 +38,11 @@
       if (event.form.valid && data.query) {
         instances = data.query.data;
         count = data.query.count;
+      }
+    },
+    onUpdated() {
+      if ($form.search) {
+        focusSearchBar();
       }
     }
   });

--- a/src/routes/(authenticated)/workflow-instances/+page.svelte
+++ b/src/routes/(authenticated)/workflow-instances/+page.svelte
@@ -68,7 +68,7 @@
       <div
         class="flex flex-row flex-wrap md:flex-nowrap place-content-end items-center gap-1 {mobileSizing}"
       >
-        <SearchBar bind:value={$form.search} className={mobileSizing} />
+        <SearchBar bind:value={$form.search} className={mobileSizing} requestSubmit={submit} />
       </div>
     </div>
     <div class="flex flex-row flex-wrap gap-1 place-content-start px-4 pt-1 {mobileSizing}">


### PR DESCRIPTION
Fixes #1313. Search bar now request parent page to submit after 1s delay. Implemented in /directory, /projects, /users, and /workflow-instances. Search bar is *not* cleared.

Fixes #1314. Populate `Product.PackageName` from artifact both in build postprocess and in startup migration.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Search bars now support programmatic focus and optional debounced auto-submit, improving search flow across directory, users, workflow instances, and projects.
  - Project claiming expanded: users in the same group with the App Builder role can claim projects.

- Bug Fixes
  - Package names are now derived from build artifacts for more accurate and consistent population during builds and migrations.

- Chores
  - Removed an unused “Filter organization” translation key across supported locales.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->