### PR TITLE
Fix dependencies issue with Docker build

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -81,7 +81,8 @@
         "valibot": "^1.0.0-beta.14",
         "vite": "^6.3.6",
         "vitest": "^3.0.4",
-        "xstate": "^5.20.1"
+        "xstate": "^5.20.1",
+        "zod": "^3.25.76"
       }
     },
     "node_modules/@ark/schema": {
@@ -5729,6 +5730,19 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/class-validator": {
+      "version": "0.14.2",
+      "resolved": "https://registry.npmjs.org/class-validator/-/class-validator-0.14.2.tgz",
+      "integrity": "sha512-3kMVRF2io8N8pY1IFIXlho9r8IPUUIfHe2hYVtiebvAzU2XeQFXTv+XI4WX+TnXmtwXMDcjngcpkiPM0O9PvLw==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@types/validator": "^13.11.8",
+        "libphonenumber-js": "^1.11.1",
+        "validator": "^13.9.0"
+      }
+    },
     "node_modules/cliui": {
       "version": "8.0.1",
       "resolved": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
@@ -8338,6 +8352,14 @@
       "engines": {
         "node": ">= 0.8.0"
       }
+    },
+    "node_modules/libphonenumber-js": {
+      "version": "1.12.24",
+      "resolved": "https://registry.npmjs.org/libphonenumber-js/-/libphonenumber-js-1.12.24.tgz",
+      "integrity": "sha512-l5IlyL9AONj4voSd7q9xkuQOL4u8Ty44puTic7J88CmdXkxfGsRfoVLXHCxppwehgpb/Chdb80FFehHqjN3ItQ==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true
     },
     "node_modules/lightningcss": {
       "version": "1.30.1",
@@ -12031,7 +12053,6 @@
       "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
       "dev": true,
       "license": "MIT",
-      "optional": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "seed": "node --experimental-strip-types src/lib/prisma/seed.ts -o",
     "schema": "src/lib/prisma/schema.prisma"
   },
+  "//": "sveltekit-superforms has a peerDep on zod, but it isn't installed in Docker for some reason",
   "devDependencies": {
     "@auth/core": "^0.40.0",
     "@auth/sveltekit": "^1.7.4",
@@ -94,7 +95,8 @@
     "valibot": "^1.0.0-beta.14",
     "vite": "^6.3.6",
     "vitest": "^3.0.4",
-    "xstate": "^5.20.1"
+    "xstate": "^5.20.1",
+    "zod": "^3.25.76"
   },
   "dependencies": {
     "@grpc/grpc-js": "^1.13.4",


### PR DESCRIPTION
sveltekit-superforms depends on zod, even though we don't otherwise use it. For some reason, running `npm i` in Docker fails to install zod, and so builds were failing. This appears to fix the issue.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added a schema validation library as a development dependency.
  * Included a descriptive comment in the project configuration.
  * No changes to existing runtime dependencies.
  * Build and runtime behavior remain unchanged for end users.
  * Improves consistency of local development environments.
  * No user-facing features were added or modified.
  * This update is limited to configuration and development tooling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->