### PR TITLE
Allow ProductDefinition to be configured to start manual rebuilds at Synchronize Data

### DIFF
--- a/src/lib/locales/en-US.json
+++ b/src/lib/locales/en-US.json
@@ -534,6 +534,7 @@
   "prodDefs_emptyType": "Need to select an Application Type",
   "prodDefs_emptyFlow": "Need to select a Workflow definition",
   "prodDefs_noFlow": "No Workflow Required",
+  "prodDefs_startAt": "Start Manual Rebuilds at",
   "stores_emptyStoreType": "Need to select a store type for this store",
   "storeTypes_title": "Store Types",
   "storeTypes_name": "Store Type Name",

--- a/src/lib/locales/es-419.json
+++ b/src/lib/locales/es-419.json
@@ -535,7 +535,7 @@
   "prodDefs_emptyType": "Necesita seleccionar un tipo de aplicación",
   "prodDefs_emptyFlow": "Need to select a Workflow definition",
   "prodDefs_noFlow": "No Workflow Required",
-  "prodDefs_startAt": "Start Manual Rebuilds at",
+  "prodDefs_startAt": "Iniciar reconstrucciones manuales en",
   "storeTypes_title": "Tipos de tienda",
   "storeTypes_name": "Store Type Name",
   "storeTypes_add": "Añadir tipo de tienda",

--- a/src/lib/locales/es-419.json
+++ b/src/lib/locales/es-419.json
@@ -535,6 +535,7 @@
   "prodDefs_emptyType": "Necesita seleccionar un tipo de aplicación",
   "prodDefs_emptyFlow": "Need to select a Workflow definition",
   "prodDefs_noFlow": "No Workflow Required",
+  "prodDefs_startAt": "Start Manual Rebuilds at",
   "storeTypes_title": "Tipos de tienda",
   "storeTypes_name": "Store Type Name",
   "storeTypes_add": "Añadir tipo de tienda",

--- a/src/lib/locales/fr-FR.json
+++ b/src/lib/locales/fr-FR.json
@@ -509,6 +509,7 @@
   "prodDefs_emptyType": "Need to select an Application Type",
   "prodDefs_emptyFlow": "Need to select a Workflow definition",
   "prodDefs_noFlow": "No Workflow Required",
+  "prodDefs_startAt": "Start Manual Rebuilds at",
   "stores_emptyStoreType": "Need to select a store type for this store",
   "storeTypes_title": "Store Types",
   "storeTypes_name": "Store Type Name",

--- a/src/lib/prisma/migrations/14_start_rebuilds_at_state/migration.sql
+++ b/src/lib/prisma/migrations/14_start_rebuilds_at_state/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "ProductDefinitions" ADD COLUMN "StartManualRebuildAt" TEXT;

--- a/src/lib/prisma/schema.prisma
+++ b/src/lib/prisma/schema.prisma
@@ -219,7 +219,6 @@ model ProductDefinitions {
   WorkflowId                     Int
   RebuildWorkflowId              Int?
   StartManualRebuildAt           String?
-  AutoRebuildWorkflowId          Int?
   RepublishWorkflowId            Int?
   Properties                     String?
   OrganizationProductDefinitions OrganizationProductDefinitions[]

--- a/src/lib/prisma/schema.prisma
+++ b/src/lib/prisma/schema.prisma
@@ -218,6 +218,8 @@ model ProductDefinitions {
   Description                    String?
   WorkflowId                     Int
   RebuildWorkflowId              Int?
+  StartManualRebuildAt           String?
+  AutoRebuildWorkflowId          Int?
   RepublishWorkflowId            Int?
   Properties                     String?
   OrganizationProductDefinitions OrganizationProductDefinitions[]

--- a/src/lib/workflowTypes.ts
+++ b/src/lib/workflowTypes.ts
@@ -130,7 +130,7 @@ export type WorkflowInstanceContext = {
   )[];
   includeReviewers: boolean;
   includeArtifacts: ArtifactLists | null;
-  start?: WorkflowState;
+  start?: WorkflowState; // keep here too so it is still persisted in DB
   environment: Environment;
 };
 
@@ -181,6 +181,7 @@ export type WorkflowConfig = {
   options: Set<WorkflowOptions>;
   productType: ProductType;
   workflowType: WorkflowType;
+  start?: WorkflowState;
 };
 
 export type WorkflowInput = WorkflowConfig & {

--- a/src/routes/(authenticated)/admin/settings/product-definitions/edit/+page.server.ts
+++ b/src/routes/(authenticated)/admin/settings/product-definitions/edit/+page.server.ts
@@ -5,6 +5,7 @@ import * as v from 'valibot';
 import type { Actions, PageServerLoad } from './$types';
 import { localizeHref } from '$lib/paraglide/runtime';
 import { DatabaseReads, DatabaseWrites } from '$lib/server/database';
+import { WorkflowStateMachine } from '$lib/server/workflow/state-machine';
 import { idSchema, propertiesSchema } from '$lib/valibot';
 
 const editSchema = v.object({
@@ -13,6 +14,7 @@ const editSchema = v.object({
   applicationType: idSchema,
   workflow: idSchema,
   rebuildWorkflow: v.nullable(idSchema),
+  startManualRebuildAt: v.nullable(v.string()),
   republishWorkflow: v.nullable(idSchema),
   description: v.nullable(v.string()),
   properties: propertiesSchema
@@ -25,7 +27,8 @@ export const load = (async ({ url, locals }) => {
   }
   const options = {
     applicationTypes: await DatabaseReads.applicationTypes.findMany(),
-    workflows: await DatabaseReads.workflowDefinitions.findMany()
+    workflows: await DatabaseReads.workflowDefinitions.findMany(),
+    startAt: Object.keys(WorkflowStateMachine.states)
   };
   const data = await DatabaseReads.productDefinitions.findFirst({
     where: {
@@ -40,6 +43,7 @@ export const load = (async ({ url, locals }) => {
       applicationType: data.TypeId,
       workflow: data.WorkflowId,
       rebuildWorkflow: data.RebuildWorkflowId,
+      startManualRebuildAt: data.StartManualRebuildAt,
       republishWorkflow: data.RepublishWorkflowId,
       description: data.Description,
       properties: data.Properties
@@ -65,6 +69,7 @@ export const actions = {
         Name: form.data.name,
         WorkflowId: form.data.workflow,
         RebuildWorkflowId: form.data.rebuildWorkflow,
+        StartManualRebuildAt: form.data.startManualRebuildAt,
         RepublishWorkflowId: form.data.republishWorkflow,
         Description: form.data.description,
         Properties: form.data.properties

--- a/src/routes/(authenticated)/admin/settings/product-definitions/edit/+page.server.ts
+++ b/src/routes/(authenticated)/admin/settings/product-definitions/edit/+page.server.ts
@@ -5,8 +5,8 @@ import * as v from 'valibot';
 import type { Actions, PageServerLoad } from './$types';
 import { localizeHref } from '$lib/paraglide/runtime';
 import { DatabaseReads, DatabaseWrites } from '$lib/server/database';
-import { WorkflowStateMachine } from '$lib/server/workflow/state-machine';
 import { idSchema, propertiesSchema } from '$lib/valibot';
+import { WorkflowState } from '$lib/workflowTypes';
 
 const editSchema = v.object({
   id: idSchema,
@@ -14,7 +14,7 @@ const editSchema = v.object({
   applicationType: idSchema,
   workflow: idSchema,
   rebuildWorkflow: v.nullable(idSchema),
-  startManualRebuildAt: v.nullable(v.string()),
+  startManualRebuildAt: v.nullable(v.literal(String(WorkflowState.Synchronize_Data))),
   republishWorkflow: v.nullable(idSchema),
   description: v.nullable(v.string()),
   properties: propertiesSchema
@@ -27,8 +27,7 @@ export const load = (async ({ url, locals }) => {
   }
   const options = {
     applicationTypes: await DatabaseReads.applicationTypes.findMany(),
-    workflows: await DatabaseReads.workflowDefinitions.findMany(),
-    startAt: Object.keys(WorkflowStateMachine.states)
+    workflows: await DatabaseReads.workflowDefinitions.findMany()
   };
   const data = await DatabaseReads.productDefinitions.findFirst({
     where: {

--- a/src/routes/(authenticated)/admin/settings/product-definitions/edit/+page.svelte
+++ b/src/routes/(authenticated)/admin/settings/product-definitions/edit/+page.svelte
@@ -95,6 +95,21 @@
     </select>
     <span class="validator-hint">&nbsp;</span>
   </LabeledFormInput>
+  {#if $form.rebuildWorkflow}
+    <LabeledFormInput key="prodDefs_startAt">
+      <select
+        class="select select-bordered"
+        name="startManualRebuildAt"
+        bind:value={$form.startManualRebuildAt}
+      >
+        <option value={null}>{m.common_default()}</option>
+        {#each data.options.startAt as startAt}
+          <option value={startAt}>{startAt}</option>
+        {/each}
+      </select>
+      <span class="validator-hint">&nbsp;</span>
+    </LabeledFormInput>
+  {/if}
   <LabeledFormInput key="prodDefs_republishFlow">
     <select
       class="select select-bordered"

--- a/src/routes/(authenticated)/admin/settings/product-definitions/edit/+page.svelte
+++ b/src/routes/(authenticated)/admin/settings/product-definitions/edit/+page.svelte
@@ -8,6 +8,7 @@
   import { getLocale, localizeHref } from '$lib/paraglide/runtime';
   import { toast } from '$lib/utils';
   import { byName } from '$lib/utils/sorting';
+  import { WorkflowState } from '$lib/workflowTypes';
 
   interface Props {
     data: PageData;
@@ -102,10 +103,8 @@
         name="startManualRebuildAt"
         bind:value={$form.startManualRebuildAt}
       >
-        <option value={null}>{m.common_default()}</option>
-        {#each data.options.startAt as startAt}
-          <option value={startAt}>{startAt}</option>
-        {/each}
+        <option value={null}>{WorkflowState.Product_Build}</option>
+        <option value={WorkflowState.Synchronize_Data}>{WorkflowState.Synchronize_Data}</option>
       </select>
       <span class="validator-hint">&nbsp;</span>
     </LabeledFormInput>

--- a/src/routes/(authenticated)/admin/settings/product-definitions/new/+page.server.ts
+++ b/src/routes/(authenticated)/admin/settings/product-definitions/new/+page.server.ts
@@ -4,15 +4,15 @@ import { valibot } from 'sveltekit-superforms/adapters';
 import * as v from 'valibot';
 import type { Actions, PageServerLoad } from './$types';
 import { DatabaseReads, DatabaseWrites } from '$lib/server/database';
-import { WorkflowStateMachine } from '$lib/server/workflow/state-machine';
 import { propertiesSchema } from '$lib/valibot';
+import { WorkflowState } from '$lib/workflowTypes';
 
 const createSchema = v.object({
   name: v.nullable(v.string()),
   applicationType: v.pipe(v.number(), v.minValue(1), v.integer()),
   workflow: v.pipe(v.number(), v.minValue(1), v.integer()),
   rebuildWorkflow: v.nullable(v.pipe(v.number(), v.minValue(1), v.integer())),
-  startManualRebuildAt: v.nullable(v.string()),
+  startManualRebuildAt: v.nullable(v.literal(String(WorkflowState.Synchronize_Data))),
   republishWorkflow: v.nullable(v.pipe(v.number(), v.minValue(1), v.integer())),
   description: v.nullable(v.string()),
   properties: propertiesSchema
@@ -23,8 +23,7 @@ export const load = (async ({ url, locals }) => {
   const form = await superValidate(valibot(createSchema));
   const options = {
     applicationTypes: await DatabaseReads.applicationTypes.findMany(),
-    workflows: await DatabaseReads.workflowDefinitions.findMany(),
-    startAt: Object.keys(WorkflowStateMachine.states)
+    workflows: await DatabaseReads.workflowDefinitions.findMany()
   };
   return { form, options };
 }) satisfies PageServerLoad;

--- a/src/routes/(authenticated)/admin/settings/product-definitions/new/+page.svelte
+++ b/src/routes/(authenticated)/admin/settings/product-definitions/new/+page.svelte
@@ -93,6 +93,21 @@
     </select>
     <span class="validator-hint">&nbsp;</span>
   </LabeledFormInput>
+  {#if $form.rebuildWorkflow}
+    <LabeledFormInput key="prodDefs_startAt">
+      <select
+        class="select select-bordered"
+        name="startManualRebuildAt"
+        bind:value={$form.startManualRebuildAt}
+      >
+        <option value={null}>{m.common_default()}</option>
+        {#each data.options.startAt as startAt}
+          <option value={startAt}>{startAt}</option>
+        {/each}
+      </select>
+      <span class="validator-hint">&nbsp;</span>
+    </LabeledFormInput>
+  {/if}
   <LabeledFormInput key="prodDefs_republishFlow">
     <select
       class="select select-bordered"

--- a/src/routes/(authenticated)/admin/settings/product-definitions/new/+page.svelte
+++ b/src/routes/(authenticated)/admin/settings/product-definitions/new/+page.svelte
@@ -8,6 +8,7 @@
   import { getLocale, localizeHref } from '$lib/paraglide/runtime';
   import { toast } from '$lib/utils';
   import { byName } from '$lib/utils/sorting';
+  import { WorkflowState } from '$lib/workflowTypes';
 
   interface Props {
     data: PageData;
@@ -100,10 +101,8 @@
         name="startManualRebuildAt"
         bind:value={$form.startManualRebuildAt}
       >
-        <option value={null}>{m.common_default()}</option>
-        {#each data.options.startAt as startAt}
-          <option value={startAt}>{startAt}</option>
-        {/each}
+        <option value={null}>{WorkflowState.Product_Build}</option>
+        <option value={WorkflowState.Synchronize_Data}>{WorkflowState.Synchronize_Data}</option>
       </select>
       <span class="validator-hint">&nbsp;</span>
     </LabeledFormInput>


### PR DESCRIPTION
Fixes #1333 

Below screenshot shows product definition automatically updated by startup migration task

<img width="940" height="715" alt="Screenshot 2025-10-20 at 3 41 10 PM" src="https://github.com/user-attachments/assets/071f3852-2d5d-4283-bccb-46944a0146d6" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Admins can set a configurable "Start Manual Rebuilds at" state for product definitions; option appears when a rebuild workflow is selected.

* **Chores**
  * Added translations for the new UI string in multiple languages.
  * A data migration populates the new field for existing product definitions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->