### PR TITLE
Add support for new auto-publish and rebuild fields in JSON import

### DIFF
--- a/src/lib/projects/index.ts
+++ b/src/lib/projects/index.ts
@@ -134,8 +134,8 @@ export const importJSONSchema = v.pipe(
         v.strictObject({
           ...projectSchemaBase.entries,
           AllowDownloads: v.optional(v.boolean()),
-          AutoPublishAfterRebuild: v.optional(v.boolean()),
-          TriggerRebuildOnSoftwareUpdate: v.optional(v.boolean())
+          AutoPublishOnRebuild: v.optional(v.boolean()),
+          RebuildOnSoftwareUpdate: v.optional(v.boolean())
         })
       ),
       v.minLength(1)

--- a/src/routes/(authenticated)/projects/import/[id=idNumber]/+page.server.ts
+++ b/src/routes/(authenticated)/projects/import/[id=idNumber]/+page.server.ts
@@ -218,8 +218,9 @@ export const actions: Actions = {
             TypeId: form.data.type,
             Description: pj.Description ?? '',
             IsPublic: pj.IsPublic,
-            AutoPublishAfterRebuild: pj.AutoPublishAfterRebuild ?? false,
-            TriggerRebuildOnSoftwareUpdate: pj.TriggerRebuildOnSoftwareUpdate ?? false,
+            AllowDownloads: pj.AllowDownloads ?? true,
+            AutoPublishOnRebuild: pj.AutoPublishOnRebuild ?? false,
+            RebuildOnSoftwareUpdate: pj.RebuildOnSoftwareUpdate ?? false,
             ImportId: imp.Id
           };
         })


### PR DESCRIPTION
This update modifies the following files to include support for new boolean fields (autoPublishAfterRebuild and autoRebuildOnSoftwareUpdate) in the project import process:

src/routes/(authenticated)/projects/import/[id=idNumber]/+page.server.ts
- Updated schema validation to accept the new boolean fields when parsing uploaded JSON files.

src/lib/projects/index.ts
- Updated the project schema definition to align with the new model structure introduced in PR #1300.

These changes ensure that importing projects with the new automation settings succeeds without errors and that old field (AutomaticBuilds) is no longer expected.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added two optional project settings: "Auto-publish after rebuild" and "Rebuild on software update" — both default to false when not specified.
  * Import now respects an "Allow downloads" setting, defaulting to true during project import.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->