### PR TITLE
Filter reassigned tasks by role

### DIFF
--- a/src/lib/server/bullmq/types.ts
+++ b/src/lib/server/bullmq/types.ts
@@ -194,7 +194,7 @@ export namespace UserTasks {
       }
     | {
         type: OpType.Reassign;
-        userMapping: { from: number; to: number }[];
+        userMapping: { from: number; to: number; withRole?: RoleId }[];
         roles?: never;
         users?: never;
       };

--- a/src/lib/server/database/Projects.ts
+++ b/src/lib/server/database/Projects.ts
@@ -74,7 +74,7 @@ export async function update(
         projectId: id,
         operation: {
           type: BullMQ.UserTasks.OpType.Reassign,
-          userMapping: [{ from: existing!.OwnerId, to: ownerId }]
+          userMapping: [{ from: existing!.OwnerId, to: ownerId, withRole: RoleId.AppBuilder }]
         }
       });
     }


### PR DESCRIPTION
Fixes a reported bug where the owner was an org admin while a project's product was in a step requiring an org admin and then reassigned project ownership to a non-org admin. All tasks, including the org admin ones, were transferred to the new owner, who was then unable to complete said tasks.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Task reassignment now supports role-based constraints. When project ownership changes, tasks are intelligently reassigned to users who possess the specified role, ensuring proper access control and permissions.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->