### PR TITLE
Add table to track completed/paused/in progress software updates

### DIFF
--- a/src/lib/prisma/migrations/19_track_updates/migration.sql
+++ b/src/lib/prisma/migrations/19_track_updates/migration.sql
@@ -1,0 +1,38 @@
+-- CreateTable
+CREATE TABLE "SoftwareUpdates" (
+    "Id" SERIAL NOT NULL,
+    "InitiatedById" INTEGER NOT NULL,
+    "Comment" TEXT NOT NULL,
+    "Paused" BOOLEAN NOT NULL DEFAULT false,
+    "DateCreated" TIMESTAMP(6) DEFAULT CURRENT_TIMESTAMP,
+    "DateUpdated" TIMESTAMP(6),
+    "DateCompleted" TIMESTAMP(6),
+    "BuildEngineUrl" TEXT NOT NULL,
+    "ApplicationTypeId" INTEGER NOT NULL,
+    "Version" TEXT NOT NULL,
+
+    CONSTRAINT "PK_SoftwareUpdates" PRIMARY KEY ("Id")
+);
+
+-- CreateTable
+CREATE TABLE "_ProductsToSoftwareUpdates" (
+    "A" UUID NOT NULL,
+    "B" INTEGER NOT NULL,
+
+    CONSTRAINT "_ProductsToSoftwareUpdates_AB_pkey" PRIMARY KEY ("A","B")
+);
+
+-- CreateIndex
+CREATE INDEX "_ProductsToSoftwareUpdates_B_index" ON "_ProductsToSoftwareUpdates"("B");
+
+-- AddForeignKey
+ALTER TABLE "SoftwareUpdates" ADD CONSTRAINT "SoftwareUpdates_InitiatedById_fkey" FOREIGN KEY ("InitiatedById") REFERENCES "Users"("Id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "SoftwareUpdates" ADD CONSTRAINT "SoftwareUpdates_ApplicationTypeId_fkey" FOREIGN KEY ("ApplicationTypeId") REFERENCES "ApplicationTypes"("Id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "_ProductsToSoftwareUpdates" ADD CONSTRAINT "_ProductsToSoftwareUpdates_A_fkey" FOREIGN KEY ("A") REFERENCES "Products"("Id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "_ProductsToSoftwareUpdates" ADD CONSTRAINT "_ProductsToSoftwareUpdates_B_fkey" FOREIGN KEY ("B") REFERENCES "SoftwareUpdates"("Id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/src/lib/prisma/schema.prisma
+++ b/src/lib/prisma/schema.prisma
@@ -17,6 +17,7 @@ model ApplicationTypes {
   ProjectImports     ProjectImports[]
   Projects           Projects[]
   SystemVersions     SystemVersions[]
+  SoftwareUpdates    SoftwareUpdates[]
 }
 
 model Authors {
@@ -305,6 +306,7 @@ model Products {
   UserTasks           UserTasks[]
   WorkflowInstance    WorkflowInstances?
   ProductUserChanges  ProductUserChanges[]
+  SoftwareUpdates     SoftwareUpdates[]
 
   @@index([ProductDefinitionId], map: "IX_Products_ProductDefinitionId")
   @@index([ProjectId], map: "IX_Products_ProjectId")
@@ -440,6 +442,24 @@ model SystemVersions {
   @@id([BuildEngineUrl, ApplicationTypeId], map: "PK_SystemVersions_BuildEngineUrl_ApplicationTypeId")
 }
 
+model SoftwareUpdates {
+  Id                Int              @id(map: "PK_SoftwareUpdates") @default(autoincrement())
+  InitiatedById     Int
+  Comment           String
+  Paused            Boolean          @default(false)
+  DateCreated       DateTime?        @default(now()) @db.Timestamp(6)
+  DateUpdated       DateTime?        @updatedAt @db.Timestamp(6)
+  DateCompleted     DateTime?        @db.Timestamp(6)
+  // Version information
+  BuildEngineUrl    String
+  ApplicationTypeId Int
+  Version           String
+  InitiatedBy       Users            @relation(fields: [InitiatedById], references: [Id])
+  ApplicationType   ApplicationTypes @relation(fields: [ApplicationTypeId], references: [Id])
+  // Implicit m-n table. Org and project reachable through this relation
+  Products          Products[]
+}
+
 model UserRoles {
   // ISSUE: #1102 composite keys?
   Id             Int           @id(map: "PK_UserRoles") @default(autoincrement())
@@ -498,6 +518,7 @@ model Users {
   UserRoles                     UserRoles[]
   UserTasks                     UserTasks[]
   ProductTransitions            ProductTransitions[]
+  SoftwareUpdates               SoftwareUpdates[]
 
   @@index([WorkflowUserId], map: "IX_Users_WorkflowUserId")
 }


### PR DESCRIPTION
Per #1249 
See [comment](https://github.com/sillsdev/appbuilder-portal/issues/1249#issuecomment-3514246503).

One record should be created for each relevant system version (BuildEngine and ApplicationType).

Tracks:
- User that initiated update
- Pause state
- Completion Date
- BuildEngine (default, fcbh, etc.) (loosely associated with org(s))
- ApplicationType (SAB, DAB, etc.)
- Version being updated to
- List of affected products

For future PRs:
- either all of this data should be present on software update job, or the id should be passed.
- Ideally, the id of this entry should be same as id of job or part of id of job, so it can be linked to in display for super admins.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Software update tracking system introduced, providing administrators with comprehensive update management capabilities including status control with pause functionality, version tracking, initiator identification, product and application type associations, build engine URL configuration, and detailed audit logs with creation, modification, and completion timestamps for compliance and troubleshooting purposes.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->