### PR TITLE
Include projects where user is author in "My Projects"

### DIFF
--- a/src/routes/(authenticated)/projects/[filter=projectSelector]/[[orgId=idNumber]]/+page.server.ts
+++ b/src/routes/(authenticated)/projects/[filter=projectSelector]/[[orgId=idNumber]]/+page.server.ts
@@ -83,8 +83,19 @@ function filter(filter: string, orgIds?: number[], userId?: number): Prisma.Proj
     case 'own':
       return {
         OrganizationId: orgIds ? { in: orgIds } : undefined,
-        OwnerId: userId,
-        DateArchived: null
+        DateArchived: null,
+        OR: [
+          {
+            OwnerId: userId
+          },
+          {
+            Authors: {
+              some: {
+                UserId: userId
+              }
+            }
+          }
+        ]
       };
   }
 }


### PR DESCRIPTION
Exactly what the title says. Based on feature request from email.

There is no substantive UI difference. Since projects already display the owner name, this should be enough to visually distinguish between projects that the user owns and projects that the user is an author for.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the "own" projects filter to also include projects where you are listed as an author (in addition to projects you own), while still excluding archived projects.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->