### PR TITLE
Download Google Play Store Listing during build for existing apps

### DIFF
--- a/src/routes/(authenticated)/tasks/[product_id]/instructions/GooglePlay_Configuration.svelte
+++ b/src/routes/(authenticated)/tasks/[product_id]/instructions/GooglePlay_Configuration.svelte
@@ -77,7 +77,6 @@
         <strong>Enter App Project URL</strong>
         field.
       </li>
-      <li>For existing apps, if you have previously</li>
       <li>
         Click <strong>Login...</strong>
         to connect to Scriptoria.

--- a/src/routes/(authenticated)/tasks/[product_id]/instructions/GooglePlay_Verify_And_Publish.svelte
+++ b/src/routes/(authenticated)/tasks/[product_id]/instructions/GooglePlay_Verify_And_Publish.svelte
@@ -28,7 +28,7 @@
   </li>
   <li>
     If you set <strong>BUILD_DOWNLOAD_PLAY_LISTING</strong>
-    to have Scriptoria down the Google Play Store Listing information during the buid, it is available
+    to have Scriptoria download the Google Play Store Listing information during the buid, it is available
     in the
     <strong>Product Files</strong>
     as


### PR DESCRIPTION
Build Engine supports the Publishing Property BUILD_DOWNLOAD_PLAY_LISTING. When this is set, during the build, it will download the current Google Play Store Listing for an existing app and use it for publishing. The user can download the `play-listing-download` product file and use it in the "Import From Google Play" wizard.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added an introduction explaining Google Play Store Listing management and where to configure it under Publishing > App Store > Google Play Store Listing.
  * Clarified Publishing navigation to the App Store > App Publishing hierarchy and updated Scriptoria and other path references.
  * Expanded keystore guidance and added steps for enabling play-listing download for existing apps.
  * Added a reminder to disable the download setting after import to avoid repeated downloads.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->