### PR TITLE
Update wording on Google Play instructions for downloading listing

### DIFF
--- a/src/routes/(authenticated)/tasks/[product_id]/instructions/GooglePlay_Configuration.svelte
+++ b/src/routes/(authenticated)/tasks/[product_id]/instructions/GooglePlay_Configuration.svelte
@@ -1,6 +1,13 @@
 <h3>Introduction</h3>
 <div class="space-y-2">
   <p>
+    The App Builders can use Scriptoria to manage the publishing of the app to Google Play. Go to
+    the <strong>Publishing &gt; App Store &gt; App Publishing</strong>
+    configuration page and select
+    <strong>We would like to use Scriptoria</strong>
+    radio button. This will enable the Scriptoria integration and display additional configuration pages.
+  </p>
+  <p>
     Scriptoria manages the Google Play Store Listing for the app. This information is stored in the
     project in the
     <strong>Publishing &gt; App Store &gt; Google Play Store Listing</strong>
@@ -48,16 +55,6 @@
 </ul>
 <h3>Instructions</h3>
 <ul>
-  <li>
-    In the <strong>Publishing &gt; App Store &gt; App Publishing</strong>
-    configuration page:
-    <ul>
-      <li>
-        Enable Scriptoria by selecting the <strong>We would like to use Scriptoria</strong>
-        option.
-      </li>
-    </ul>
-  </li>
   <li>
     In the <strong>Publishing &gt; App Store &gt; Publishing Properties</strong>
     configuration page:

--- a/src/routes/(authenticated)/tasks/[product_id]/instructions/GooglePlay_Verify_And_Publish.svelte
+++ b/src/routes/(authenticated)/tasks/[product_id]/instructions/GooglePlay_Verify_And_Publish.svelte
@@ -27,9 +27,8 @@
     grid view.
   </li>
   <li>
-    If you set <strong>BUILD_DOWNLOAD_PLAY_LISTING</strong>
-    to have Scriptoria download the Google Play Store Listing information during the buid, it is available
-    in the
+    If you requested Scriptoria to download the Google Play Store Listing information during the
+    buid, it is available in the
     <strong>Product Files</strong>
     as
     <strong>play-listing-download</strong>
@@ -39,13 +38,14 @@
     <strong>Import From Google Play...</strong>
     button. This will start a wizard where you can select
     <strong>Import from a download of the Google Play listing from Scriptoria</strong>
-    .
+    and complete the wizard.
   </li>
   <li>
-    <strong>IMPORTANT!</strong>
-    Make sure to remove the
-    <strong>BUILD_DOWNLOAD_PLAY_LISTING</strong>
-    entry from the Publishing Properties to avoid downloading the listing on every build.
+    Make sure to re-enable the
+    <strong>Verify Google Play Store listing when sending app data</strong>
+    checkbox on the
+    <strong>Publishing &gt; App Store &gt; Scriptoria</strong>
+    configuration page.
   </li>
   <li>
     Click <strong>Approve</strong>


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated Google Play publishing configuration instructions to clarify how the platform manages app publishing
  * Enhanced guidance on downloading and importing Google Play app listings, now available in Product Files
  * Refined configuration steps for Google Play Store integration, including updated checkbox settings in the publishing workflow

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->