### PR TITLE
Add default config for number of jobs to keep

### DIFF
--- a/src/lib/server/bullmq/queues.ts
+++ b/src/lib/server/bullmq/queues.ts
@@ -107,11 +107,17 @@ export const getQueueConfig = () => {
     prefix: 'scriptoria',
     telemetry: new BullMQOtel('scriptoria'),
     defaultJobOptions: {
-      // default # jobs to keep
       // https://docs.bullmq.io/guide/queues/auto-removal-of-jobs#keep-a-certain-number-of-jobs
-      // we probably don't need to keep more than this number of jobs
-      removeOnComplete: 500,
-      removeOnFail: 1000
+      removeOnComplete: {
+        // 2 weeks
+        age: 2 * 7 * 24 * 60 * 60,
+        count: 1000
+      },
+      removeOnFail: {
+        // 2 weeks
+        age: 2 * 7 * 24 * 60 * 60,
+        count: 2000
+      }
     }
   } as QueueOptions;
 };


### PR DESCRIPTION
On December 19, Scriptoria crashed with an out of memory error from Valkey.
As a temporary measure, the instance size used for Valkey was given increased memory.
This PR introduces changes to limit the number of completed BullMQ jobs that Valkey will keep track of, which will ultimately reduce the amount of memory required.

As of the PR being opened, production has 110k completed jobs recorded across 10 queues, this PR will limit each queue to 3k (1k complete, 2k failed) recorded jobs each, for a maximum of two weeks. This should be sufficient for all our purposes and also little enough that we can downgrade the instance size to what it was before (cost reduction).
<img width="1146" height="583" alt="Screenshot 2026-01-06 at 11 13 01 AM" src="https://github.com/user-attachments/assets/dc13692d-4f54-4e39-8650-09ea2b426e60" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated queue cleanup defaults: completed jobs are automatically removed after 2 weeks (or 1000 retained operations) and failed jobs are removed after 2 weeks (or 2000 retained operations).

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->