### PR TITLE
Filter certain email tasks for locked users

### DIFF
--- a/src/lib/server/job-executors/email.ts
+++ b/src/lib/server/job-executors/email.ts
@@ -160,6 +160,7 @@ export async function sendBatchUserTaskNotifications(
     const user = await DatabaseReads.users.findUnique({
       where: {
         Id: notification.userId,
+        IsLocked: false,
         EmailNotification: true
       }
     });
@@ -292,6 +293,8 @@ export async function sendNotificationToUser(
     }
   });
   if (!user) return `User ${job.data.userId} has disabled Email Notifications`;
+  if (user.IsLocked)
+    return `User ${job.data.userId} is locked and will not be sent Email Notifications`;
   return await sendEmail(
     [{ email: user.Email!, name: user.Name! }],
     translate(
@@ -435,6 +438,7 @@ export async function sendNotificationToOrgAdminsAndOwner(
   });
   const orgAdmins = await DatabaseReads.users.findMany({
     where: {
+      IsLocked: false,
       UserRoles: {
         some: {
           RoleId: RoleId.OrgAdmin,


### PR DESCRIPTION
Fixes #1423 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Email notifications now correctly exclude locked user accounts from receiving notification messages.
  * Enhanced notification handling to distinguish between users with disabled email notifications and those with locked accounts, providing appropriate status messages for each scenario.
  * Fixed organization admin notification queries to ensure locked administrators do not receive admin-level notifications.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->