### PR TITLE
Add helper function to filter administrated orgs

### DIFF
--- a/src/routes/(authenticated)/organizations/+layout.server.ts
+++ b/src/routes/(authenticated)/organizations/+layout.server.ts
@@ -1,21 +1,12 @@
 import type { LayoutServerLoad } from './$types';
-import { RoleId } from '$lib/prisma';
 import { DatabaseReads } from '$lib/server/database';
+import { filterAdminOrgs } from '$lib/utils/roles';
 
 export const load = (async (event) => {
   event.locals.security.requireAdminOfAny();
 
   const organizations = await DatabaseReads.organizations.findMany({
-    where: event.locals.security.isSuperAdmin
-      ? {}
-      : {
-          UserRoles: {
-            some: {
-              UserId: event.locals.security.userId,
-              RoleId: RoleId.OrgAdmin
-            }
-          }
-        },
+    where: filterAdminOrgs(event.locals.security, undefined),
     select: {
       Id: true,
       LogoUrl: true,


### PR DESCRIPTION
Adds helper function to handle common functionality between multiple pages that need a list of organizations that a user is an admin for (or all organizations if user is a SuperAdmin).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Centralized organization filtering logic into a shared utility function.
  * Updated authentication routes to use the new utility function instead of duplicate local implementations.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->