### PR TITLE
Allow only *project* authors in project token

### DIFF
--- a/src/routes/(unauthenticated)/api/projects/[id=idNumber]/token/+server.ts
+++ b/src/routes/(unauthenticated)/api/projects/[id=idNumber]/token/+server.ts
@@ -39,6 +39,11 @@ export async function POST({ params, locals, request }) {
           ExternalId: true
         }
       },
+      Authors: {
+        select: {
+          UserId: true
+        }
+      },
       OrganizationId: true
     }
   });
@@ -69,7 +74,9 @@ export async function POST({ params, locals, request }) {
       locals.security.requireHasRole(project.OrganizationId, RoleId.Author, false);
       // ISSUE: #1101 Kalaam now wants authors to be able to update at any time.  In the future, we can add a setting on the author to whether they are a restricted author or not. I don't have time to add the UI at the moment.
       //readOnly = !author.CanUpdate;
-      readOnly = false;
+      if (project.Authors.some(({ UserId }) => UserId === locals.security.userId)) {
+        readOnly = false;
+      }
     } catch {
       /* empty */
     }


### PR DESCRIPTION
Fixes small security bug reported by @chrisvire 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Fixed project access control to properly recognize authorized co-authors, ensuring they retain appropriate read-write permissions when accessing projects.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->