### PR TITLE
Update Google Play Title text

### DIFF
--- a/src/lib/locales/en-US.json
+++ b/src/lib/locales/en-US.json
@@ -22,8 +22,13 @@
   "localePicker_placeholder": "Search by Language...",
   "localePicker_region": [
     {
-      "declarations": ["input count", "local countPlural = count: plural"],
-      "selectors": ["countPlural"],
+      "declarations": [
+        "input count",
+        "local countPlural = count: plural"
+      ],
+      "selectors": [
+        "countPlural"
+      ],
       "match": {
         "countPlural=one": "Region",
         "countPlural=other": "Regions"
@@ -32,8 +37,13 @@
   ],
   "localePicker_name": [
     {
-      "declarations": ["input count", "local countPlural = count: plural"],
-      "selectors": ["countPlural"],
+      "declarations": [
+        "input count",
+        "local countPlural = count: plural"
+      ],
+      "selectors": [
+        "countPlural"
+      ],
       "match": {
         "countPlural=one": "Name",
         "countPlural=other": "Names"
@@ -42,8 +52,13 @@
   ],
   "localePicker_tag": [
     {
-      "declarations": ["input count", "local countPlural = count: plural"],
-      "selectors": ["countPlural"],
+      "declarations": [
+        "input count",
+        "local countPlural = count: plural"
+      ],
+      "selectors": [
+        "countPlural"
+      ],
       "match": {
         "countPlural=one": "Tag",
         "countPlural=other": "Tags"
@@ -52,8 +67,13 @@
   ],
   "localePicker_variant": [
     {
-      "declarations": ["input count", "local countPlural = count: plural"],
-      "selectors": ["countPlural"],
+      "declarations": [
+        "input count",
+        "local countPlural = count: plural"
+      ],
+      "selectors": [
+        "countPlural"
+      ],
       "match": {
         "countPlural=one": "Variant",
         "countPlural=other": "Variants"
@@ -250,8 +270,12 @@
   "products_unpublished": "Unpublished",
   "products_numArtifacts": [
     {
-      "declarations": ["local countPlural = amount: plural"],
-      "selectors": ["countPlural"],
+      "declarations": [
+        "local countPlural = amount: plural"
+      ],
+      "selectors": [
+        "countPlural"
+      ],
       "match": {
         "amount=0": "No Product Files",
         "countPlural=one": "{amount} Product File",
@@ -464,8 +488,8 @@
   "stores_listTitle": "Stores",
   "stores_publisherId": "Publisher Id",
   "stores_publisherIdEmpty": "Publisher Id cannot be empty",
-  "stores_gpTitle": "GooglePlay Title",
-  "stores_gpTitleEmpty": "GooglePlay Title cannot be empty",
+  "stores_gpTitle": "Google Play Owner Name",
+  "stores_gpTitleEmpty": "Google Play Owner Name cannot be empty",
   "storeTypes_listTitle": "Store Types",
   "admin_title": "Admin settings",
   "admin_nav_orgs": "Organizations",

--- a/src/lib/locales/es-419.json
+++ b/src/lib/locales/es-419.json
@@ -22,8 +22,13 @@
   "localePicker_placeholder": "Buscar por idioma...",
   "localePicker_region": [
     {
-      "declarations": ["input count", "local countPlural = count: plural"],
-      "selectors": ["countPlural"],
+      "declarations": [
+        "input count",
+        "local countPlural = count: plural"
+      ],
+      "selectors": [
+        "countPlural"
+      ],
       "match": {
         "countPlural=one": "Region",
         "countPlural=other": "Region"
@@ -32,8 +37,13 @@
   ],
   "localePicker_name": [
     {
-      "declarations": ["input count", "local countPlural = count: plural"],
-      "selectors": ["countPlural"],
+      "declarations": [
+        "input count",
+        "local countPlural = count: plural"
+      ],
+      "selectors": [
+        "countPlural"
+      ],
       "match": {
         "countPlural=one": "Name",
         "countPlural=other": "Names"
@@ -42,8 +52,13 @@
   ],
   "localePicker_tag": [
     {
-      "declarations": ["input count", "local countPlural = count: plural"],
-      "selectors": ["countPlural"],
+      "declarations": [
+        "input count",
+        "local countPlural = count: plural"
+      ],
+      "selectors": [
+        "countPlural"
+      ],
       "match": {
         "countPlural=one": "Tag",
         "countPlural=other": "Tags"
@@ -52,8 +67,13 @@
   ],
   "localePicker_variant": [
     {
-      "declarations": ["input count", "local countPlural = count: plural"],
-      "selectors": ["countPlural"],
+      "declarations": [
+        "input count",
+        "local countPlural = count: plural"
+      ],
+      "selectors": [
+        "countPlural"
+      ],
       "match": {
         "countPlural=one": "Variant",
         "countPlural=other": "Variants"
@@ -250,8 +270,12 @@
   "products_unpublished": "Sin publicar",
   "products_numArtifacts": [
     {
-      "declarations": ["local countPlural = amount: plural"],
-      "selectors": ["countPlural"],
+      "declarations": [
+        "local countPlural = amount: plural"
+      ],
+      "selectors": [
+        "countPlural"
+      ],
       "match": {
         "amount=0": "No hay archivos de producto",
         "countPlural=one": "{amount} Product File",
@@ -464,8 +488,8 @@
   "stores_listTitle": "Tiendas",
   "stores_publisherId": "ID del editor",
   "stores_publisherIdEmpty": "ID del editor no puede estar vacío",
-  "stores_gpTitle": "Título en Google Play",
-  "stores_gpTitleEmpty": "Título en Google Play no puede estar vacío",
+  "stores_gpTitle": "Nombre del propietario de Google Play",
+  "stores_gpTitleEmpty": "Nombre del propietario de Google Play no puede estar vacío",
   "stores_emptyStoreType": "Necesita seleccionar un tipo de tienda para esta tienda",
   "storeTypes_listTitle": "Tipos de tienda",
   "admin_title": "Configuración del administrador",

--- a/src/lib/locales/fr-FR.json
+++ b/src/lib/locales/fr-FR.json
@@ -22,8 +22,13 @@
   "localePicker_placeholder": "Search by Language...",
   "localePicker_region": [
     {
-      "declarations": ["input count", "local countPlural = count: plural"],
-      "selectors": ["countPlural"],
+      "declarations": [
+        "input count",
+        "local countPlural = count: plural"
+      ],
+      "selectors": [
+        "countPlural"
+      ],
       "match": {
         "countPlural=one": "Region",
         "countPlural=other": "Regions"
@@ -32,8 +37,13 @@
   ],
   "localePicker_name": [
     {
-      "declarations": ["input count", "local countPlural = count: plural"],
-      "selectors": ["countPlural"],
+      "declarations": [
+        "input count",
+        "local countPlural = count: plural"
+      ],
+      "selectors": [
+        "countPlural"
+      ],
       "match": {
         "countPlural=one": "Name",
         "countPlural=other": "Names"
@@ -42,8 +52,13 @@
   ],
   "localePicker_tag": [
     {
-      "declarations": ["input count", "local countPlural = count: plural"],
-      "selectors": ["countPlural"],
+      "declarations": [
+        "input count",
+        "local countPlural = count: plural"
+      ],
+      "selectors": [
+        "countPlural"
+      ],
       "match": {
         "countPlural=one": "Tag",
         "countPlural=other": "Tags"
@@ -52,8 +67,13 @@
   ],
   "localePicker_variant": [
     {
-      "declarations": ["input count", "local countPlural = count: plural"],
-      "selectors": ["countPlural"],
+      "declarations": [
+        "input count",
+        "local countPlural = count: plural"
+      ],
+      "selectors": [
+        "countPlural"
+      ],
       "match": {
         "countPlural=one": "Variant",
         "countPlural=other": "Variants"
@@ -250,8 +270,12 @@
   "products_unpublished": "Unpublished",
   "products_numArtifacts": [
     {
-      "declarations": ["local countPlural = amount: plural"],
-      "selectors": ["countPlural"],
+      "declarations": [
+        "local countPlural = amount: plural"
+      ],
+      "selectors": [
+        "countPlural"
+      ],
       "match": {
         "amount=0": "No Product Files",
         "countPlural=one": "{amount} Product File",
@@ -463,8 +487,8 @@
   "stores_listTitle": "Stores",
   "stores_publisherId": "Publisher Id",
   "stores_publisherIdEmpty": "Publisher Id cannot be empty",
-  "stores_gpTitle": "GooglePlay Title",
-  "stores_gpTitleEmpty": "GooglePlay Title cannot be empty",
+  "stores_gpTitle": "Google Play Owner Name",
+  "stores_gpTitleEmpty": "Google Play Owner Name cannot be empty",
   "storeTypes_listTitle": "Store Types",
   "admin_title": "Admin settings",
   "admin_nav_orgs": "Organizations",


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Localization**
  * Updated English, Spanish (es-419) and French locale labels for Google Play: "GooglePlay Title" → "Google Play Owner Name" and corresponding empty-state messaging updated for clarity.
  * Reorganized locale entries for region, name, tag, variant and artifact count into a consistent multi-line structure across locales for improved maintainability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->