### PR TITLE
Fixed a typo in Create_App_Entry

### DIFF
--- a/src/routes/(authenticated)/tasks/[product_id]/instructions/Create_App_Entry.svelte
+++ b/src/routes/(authenticated)/tasks/[product_id]/instructions/Create_App_Entry.svelte
@@ -309,7 +309,7 @@
       </li>
 
       <li>
-        Under the <strong>Health</strong>
+        Under the <strong>Health apps</strong>
         section, click the
         <strong>Start declaration</strong>
         button.


### PR DESCRIPTION
Simple typo section was labeled Financial features and in the Google Play console it is simply Health. There is another Financial features section above this in the instructions.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected a typo in the Data Safety step ("Data Safey" → "Data Safety"), improving clarity in the declaration flow.
* **Documentation / UI**
  * Updated headings and instructions: the Start declaration flow is now labeled under "Health apps" instead of "Financial features," aligning section labels with content.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->