### PR TITLE
Only send ProductNotFound emails when product actually can't be found

### DIFF
--- a/src/lib/bullmq.ts
+++ b/src/lib/bullmq.ts
@@ -15,6 +15,7 @@ export enum JobType {
   // Build Jobs
   Build_Product = 'Build Product',
   Build_PostProcess = 'Postprocess Build',
+  Build_Delete = 'Delete Build - BuildEngine',
   // Polling Jobs
   Poll_Build = 'Check Product Build',
   Poll_Project = 'Check Project Creation',
@@ -31,6 +32,7 @@ export enum JobType {
   // Publishing Jobs
   Publish_Product = 'Publish Product',
   Publish_PostProcess = 'Postprocess Publish',
+  Publish_Delete = 'Delete Release - BuildEngine',
   // System Jobs
   System_CheckEngineStatuses = 'Check BuildEngine Statuses',
   System_RefreshLangTags = 'Refresh langtags.json',

--- a/src/lib/server/bullmq/BullWorker.ts
+++ b/src/lib/server/bullmq/BullWorker.ts
@@ -61,6 +61,8 @@ export class Builds<J extends BullMQ.BuildJob> extends BullWorker<J> {
         return Executor.Build.product(job as Job<BullMQ.Build.Product>);
       case BullMQ.JobType.Build_PostProcess:
         return Executor.Build.postProcess(job as Job<BullMQ.Build.PostProcess>);
+      case BullMQ.JobType.Build_Delete:
+        return Executor.Build.deleteBuild(job as Job<BullMQ.Build.Delete>);
     }
   }
 }
@@ -194,6 +196,8 @@ export class Publishing<J extends BullMQ.PublishJob> extends BullWorker<J> {
         return Executor.Publish.product(job as Job<BullMQ.Publish.Product>);
       case BullMQ.JobType.Publish_PostProcess:
         return Executor.Publish.postProcess(job as Job<BullMQ.Publish.PostProcess>);
+      case BullMQ.JobType.Publish_Delete:
+        return Executor.Publish.deleteRelease(job as Job<BullMQ.Publish.Delete>);
     }
   }
 }

--- a/src/lib/server/bullmq/types.ts
+++ b/src/lib/server/bullmq/types.ts
@@ -40,6 +40,13 @@ export namespace Build {
     productBuildId: number;
     build: BuildResponse;
   }
+
+  export interface Delete extends BaseJob {
+    type: JobType.Build_Delete;
+    organizationId: number;
+    buildEngineJobId: number;
+    buildEngineBuildId: number;
+  }
 }
 
 export namespace Polling {
@@ -127,6 +134,14 @@ export namespace Publish {
     productId: string;
     productBuildId: number;
     release: ReleaseResponse;
+  }
+
+  export interface Delete extends BaseJob {
+    type: JobType.Publish_Delete;
+    organizationId: number;
+    buildEngineJobId: number;
+    buildEngineBuildId: number;
+    buildEngineReleaseId: number;
   }
 }
 
@@ -256,7 +271,10 @@ export namespace SvelteProjectSSE {
 
 export type Job = JobTypeMap[keyof JobTypeMap];
 
-export type BuildJob = JobTypeMap[JobType.Build_Product | JobType.Build_PostProcess];
+export type BuildJob = JobTypeMap[
+  | JobType.Build_Product
+  | JobType.Build_PostProcess
+  | JobType.Build_Delete];
 export type RecurringJob = JobTypeMap[
   | JobType.System_CheckEngineStatuses
   | JobType.System_RefreshLangTags];
@@ -264,7 +282,10 @@ export type StartupJob = JobTypeMap[
   | JobType.System_CheckEngineStatuses
   | JobType.System_RefreshLangTags
   | JobType.System_Migrate];
-export type PublishJob = JobTypeMap[JobType.Publish_Product | JobType.Publish_PostProcess];
+export type PublishJob = JobTypeMap[
+  | JobType.Publish_Product
+  | JobType.Publish_PostProcess
+  | JobType.Publish_Delete];
 export type PollJob = JobTypeMap[JobType.Poll_Build | JobType.Poll_Publish | JobType.Poll_Project];
 export type UserTasksJob = JobTypeMap[JobType.UserTasks_Modify];
 export type EmailJob = JobTypeMap[
@@ -291,6 +312,7 @@ export type ProjectJob = JobTypeMap[JobType.Project_Create | JobType.Project_Imp
 export type JobTypeMap = {
   [JobType.Build_Product]: Build.Product;
   [JobType.Build_PostProcess]: Build.PostProcess;
+  [JobType.Build_Delete]: Build.Delete;
   [JobType.Poll_Build]: Polling.Build;
   [JobType.Poll_Project]: Polling.Project;
   [JobType.Poll_Publish]: Polling.Publish;
@@ -303,6 +325,7 @@ export type JobTypeMap = {
   [JobType.Project_ImportProducts]: Project.ImportProducts;
   [JobType.Publish_Product]: Publish.Product;
   [JobType.Publish_PostProcess]: Publish.PostProcess;
+  [JobType.Publish_Delete]: Publish.Delete;
   [JobType.System_CheckEngineStatuses]: System.CheckEngineStatuses;
   [JobType.System_RefreshLangTags]: System.RefreshLangTags;
   [JobType.System_Migrate]: System.Migrate;

--- a/src/lib/server/job-executors/build.ts
+++ b/src/lib/server/job-executors/build.ts
@@ -341,6 +341,23 @@ export async function postProcess(job: Job<BullMQ.Build.PostProcess>): Promise<u
   };
 }
 
+// This shouldn't need any notifications
+export async function deleteBuild(job: Job<BullMQ.Build.Delete>): Promise<unknown> {
+  const response = await BuildEngine.Requests.deleteBuild(
+    { type: 'query', organizationId: job.data.organizationId },
+    job.data.buildEngineJobId,
+    job.data.buildEngineBuildId
+  );
+  job.updateProgress(50);
+  if (response.responseType === 'error') {
+    job.log(response.message);
+    throw new Error(response.message);
+  } else {
+    job.updateProgress(100);
+    return response.status;
+  }
+}
+
 async function notifyConnectionFailed(
   productId: string,
   projectId: number,

--- a/src/lib/server/job-executors/publish.ts
+++ b/src/lib/server/job-executors/publish.ts
@@ -279,6 +279,24 @@ export async function postProcess(job: Job<BullMQ.Publish.PostProcess>): Promise
   return { publication };
 }
 
+// This shouldn't need any notifications
+export async function deleteRelease(job: Job<BullMQ.Publish.Delete>): Promise<unknown> {
+  const response = await BuildEngine.Requests.deleteRelease(
+    { type: 'query', organizationId: job.data.organizationId },
+    job.data.buildEngineJobId,
+    job.data.buildEngineBuildId,
+    job.data.buildEngineReleaseId
+  );
+  job.updateProgress(50);
+  if (response.responseType === 'error') {
+    job.log(response.message);
+    throw new Error(response.message);
+  } else {
+    job.updateProgress(100);
+    return response.status;
+  }
+}
+
 async function notifyConnectionFailed(
   productId: string,
   projectId: number,


### PR DESCRIPTION
These emails used to be sent whenever the BuildEngineBuildId or BuildEngineReleaseId did not match. This has been fixed.

Also in the portion of the branch where these emails are no longer sent from, I added some code to delete the associated ProductBuilds/ProductPublications, so they no longer falsely show up as pending.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Consistently cleans up orphaned build and publish records when external IDs no longer match, ensuring jobs conclude and progress shows complete.
  * Removes lingering polling tasks for missing workflow instances or ID mismatches.

* **Improvements**
  * More robust validation and clearer logging/notifications for build and publish job outcomes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->