### PR TITLE
Filter stores in Org Settings for ownership

### DIFF
--- a/src/lib/server/database/Stores.ts
+++ b/src/lib/server/database/Stores.ts
@@ -3,12 +3,22 @@ import prisma from './prisma';
 import type { RequirePrimitive } from './utility';
 
 export async function toggleForOrg(StoreId: number, OrganizationId: number, enabled: boolean) {
-  return !!(await prisma.organizations.update({
-    where: { Id: OrganizationId },
+  return !!(await prisma.stores.update({
+    where: {
+      Id: StoreId,
+      OR: [
+        {
+          OwnerId: null
+        },
+        {
+          OwnerId: OrganizationId
+        }
+      ]
+    },
     data: {
-      Stores: {
+      Organizations: {
         [enabled ? 'connect' : 'disconnect']: {
-          Id: StoreId
+          Id: OrganizationId
         }
       }
     },

--- a/src/routes/(authenticated)/organizations/[id=idNumber]/settings/stores/+page.server.ts
+++ b/src/routes/(authenticated)/organizations/[id=idNumber]/settings/stores/+page.server.ts
@@ -16,6 +16,16 @@ export const load = (async (event) => {
   return {
     stores: (
       await DatabaseReads.stores.findMany({
+        where: {
+          OR: [
+            {
+              OwnerId: null
+            },
+            {
+              OwnerId: organization.Id
+            }
+          ]
+        },
         include: {
           Organizations: { where: { Id: organization.Id }, select: { Id: true } },
           StoreType: true,

--- a/src/routes/(authenticated)/organizations/[id=idNumber]/settings/stores/transfer/+page.server.ts
+++ b/src/routes/(authenticated)/organizations/[id=idNumber]/settings/stores/transfer/+page.server.ts
@@ -18,7 +18,15 @@ export const load = (async (event) => {
     storeTypes: await DatabaseReads.storeTypes.findMany(),
     stores: await DatabaseReads.stores.findMany({
       where: {
-        Organizations: { some: { Id: organization.Id } }
+        Organizations: { some: { Id: organization.Id } },
+        OR: [
+          {
+            OwnerId: null
+          },
+          {
+            OwnerId: organization.Id
+          }
+        ]
       },
       include: {
         Products: {
@@ -60,7 +68,15 @@ export const actions = {
         Id: form.data.source,
         Organizations: {
           some: { Id: orgId }
-        }
+        },
+        OR: [
+          {
+            OwnerId: null
+          },
+          {
+            OwnerId: orgId
+          }
+        ]
       },
       select: {
         Products: {
@@ -75,7 +91,15 @@ export const actions = {
         Id: form.data.destination,
         Organizations: {
           some: { Id: orgId }
-        }
+        },
+        OR: [
+          {
+            OwnerId: null
+          },
+          {
+            OwnerId: orgId
+          }
+        ]
       }
     });
 


### PR DESCRIPTION
Organizations should only be able to access stores which they either own, or are shared site-wide

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Refined store ownership handling to support both unowned and organization-owned stores.
  * Enhanced visibility and filtering of accessible stores in organization settings.
  * Improved store transfer functionality to properly manage different ownership scenarios.
  * Better access control for store management operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->