### PR TITLE
Redo Retry Build messages to use i18n and include Console Text link

### DIFF
--- a/src/lib/locales/en-US.json
+++ b/src/lib/locales/en-US.json
@@ -608,6 +608,7 @@
   "orgMembership_joined": "Organization joined!",
   "orgMembership_returnToDashboard": "Go to dashboard",
   "system_buildFailed": "Build failed",
+  "system_buildRetry": "Build may have failed due to insufficient memory. Retrying with medium compute type.",
   "system_publishFailed": "Publish failed",
   "system_unavailable": "Scriptoria is currently unable to process background tasks"
 }

--- a/src/lib/locales/en-US.json
+++ b/src/lib/locales/en-US.json
@@ -609,6 +609,7 @@
   "orgMembership_joined": "Organization joined!",
   "orgMembership_returnToDashboard": "Go to dashboard",
   "system_buildFailed": "Build failed",
+  "system_buildRetry": "Build may have failed due to insufficient memory. Retrying with medium compute type.",
   "system_publishFailed": "Publish failed",
   "system_unavailable": "Scriptoria is currently unable to process background tasks",
   "downloads_title": "Downloads",

--- a/src/lib/locales/es-419.json
+++ b/src/lib/locales/es-419.json
@@ -609,6 +609,7 @@
   "orgMembership_joined": "¡Se unió a la organización!",
   "orgMembership_returnToDashboard": "Go to dashboard",
   "system_buildFailed": "Build failed",
+  "system_buildRetry": "Build may have failed due to insufficient memory. Retrying with medium compute type.",
   "system_publishFailed": "Publish failed",
   "system_unavailable": "Scriptoria actualmente no puede procesar tareas",
   "downloads_title": "Downloads",

--- a/src/lib/locales/es-419.json
+++ b/src/lib/locales/es-419.json
@@ -608,6 +608,7 @@
   "orgMembership_joined": "¡Se unió a la organización!",
   "orgMembership_returnToDashboard": "Go to dashboard",
   "system_buildFailed": "Build failed",
+  "system_buildRetry": "Build may have failed due to insufficient memory. Retrying with medium compute type.",
   "system_publishFailed": "Publish failed",
   "system_unavailable": "Scriptoria actualmente no puede procesar tareas"
 }

--- a/src/lib/locales/fr-FR.json
+++ b/src/lib/locales/fr-FR.json
@@ -607,6 +607,7 @@
   "orgMembership_joined": "Organization joined!",
   "orgMembership_returnToDashboard": "Go to dashboard",
   "system_buildFailed": "Build failed",
+  "system_buildRetry": "Build may have failed due to insufficient memory. Retrying with medium compute type.",
   "system_publishFailed": "Publish failed",
   "system_unavailable": "Scriptoria is currently unable to process background tasks"
 }

--- a/src/lib/locales/fr-FR.json
+++ b/src/lib/locales/fr-FR.json
@@ -608,6 +608,7 @@
   "orgMembership_joined": "Organization joined!",
   "orgMembership_returnToDashboard": "Go to dashboard",
   "system_buildFailed": "Build failed",
+  "system_buildRetry": "Build may have failed due to insufficient memory. Retrying with medium compute type.",
   "system_publishFailed": "Publish failed",
   "system_unavailable": "Scriptoria is currently unable to process background tasks",
   "downloads_title": "Downloads",

--- a/src/lib/products/components/TaskComment.svelte
+++ b/src/lib/products/components/TaskComment.svelte
@@ -12,10 +12,14 @@
 
 <div class={['comment m-1 mx-2 p-1', classes]}>
   {#if comment?.startsWith('system.')}
-    {@const href = comment.replace(/system\.(build|publish)-failed,/, '')}
+    {@const href = comment.replace(/system\.(build|publish)-(failed|retry),/, '')}
     {#if comment.startsWith('system.build-failed')}
       <span>
         {m.system_buildFailed()}
+      </span>
+    {:else if comment.startsWith('system.build-retry')}
+      <span>
+        {m.system_buildRetry()}
       </span>
     {:else if comment.startsWith('system.publish-failed')}
       <span>

--- a/src/lib/server/bullmq/BullWorker.ts
+++ b/src/lib/server/bullmq/BullWorker.ts
@@ -108,7 +108,8 @@ export class SystemRecurring<J extends BullMQ.RecurringJob> extends BullWorker<J
           type: BullMQ.JobType.System_Migrate,
           steps: [
             'Patch ProductPublications.LogUrl',
-            'Backfill Remaining ProductBuilds.AppBuilderVersion'
+            'Backfill Remaining ProductBuilds.AppBuilderVersion',
+            'Rename Retry Comments'
           ]
         }
       }

--- a/src/lib/server/bullmq/BullWorker.ts
+++ b/src/lib/server/bullmq/BullWorker.ts
@@ -106,7 +106,12 @@ export class SystemRecurring<J extends BullMQ.RecurringJob> extends BullWorker<J
         name: 'Migrate Features (chunked)',
         data: {
           type: BullMQ.JobType.System_Migrate,
-          steps: ['Associate Builds', 'Associate Releases', 'Add PackageName']
+          steps: [
+            'Associate Builds',
+            'Associate Releases',
+            'Add PackageName',
+            'Rename Retry Comments'
+          ]
         }
       }
     );

--- a/src/lib/server/job-executors/build.ts
+++ b/src/lib/server/job-executors/build.ts
@@ -327,8 +327,7 @@ export async function postProcess(job: Job<BullMQ.Build.PostProcess>): Promise<u
         flow.send({
           type: action,
           userId: null,
-          comment:
-            'Build may have failed due to insufficient memory. Retrying with medium compute type.'
+          comment: `system.build-retry,${job.data.build.artifacts['consoleText'] ?? ''}`
         });
       }
     }

--- a/src/lib/server/job-executors/build.ts
+++ b/src/lib/server/job-executors/build.ts
@@ -4,7 +4,11 @@ import { BuildEngine } from '../build-engine-api';
 import { BullMQ, getQueues } from '../bullmq';
 import { DatabaseReads, DatabaseWrites } from '../database';
 import { Workflow } from '../workflow';
-import { addProductPropertiesToEnvironment, getWorkflowParameters } from './common.build-publish';
+import {
+  addProductPropertiesToEnvironment,
+  checkBuildRetryCondition,
+  getWorkflowParameters
+} from './common.build-publish';
 import { BuildStatus, ProductTransitionType } from '$lib/prisma';
 import { fetchPackageName, getComputeType, updateComputeType } from '$lib/products';
 import { projectUrl } from '$lib/projects/server';
@@ -277,8 +281,7 @@ export async function postProcess(job: Job<BullMQ.Build.PostProcess>): Promise<u
       const currentCompute = getComputeType(product.Properties);
       if (currentCompute !== 'medium') {
         try {
-          const text = await fetch(job.data.build.artifacts['consoleText']).then((r) => r.text());
-          if (text.match('Gradle build daemon disappeared unexpectedly')) {
+          if (await checkBuildRetryCondition(job.data.build.artifacts['consoleText'])) {
             const newProps = updateComputeType(product.Properties, 'medium');
             // make sure props are actually updated...
             // we don't want infinite retries if this somehow fails...

--- a/src/lib/server/job-executors/build.ts
+++ b/src/lib/server/job-executors/build.ts
@@ -328,8 +328,7 @@ export async function postProcess(job: Job<BullMQ.Build.PostProcess>): Promise<u
         flow.send({
           type: action,
           userId: null,
-          comment:
-            'Build may have failed due to insufficient memory. Retrying with medium compute type.'
+          comment: `system.build-retry,${job.data.build.artifacts['consoleText'] ?? ''}`
         });
       }
     }

--- a/src/lib/server/job-executors/build.ts
+++ b/src/lib/server/job-executors/build.ts
@@ -4,7 +4,11 @@ import { BuildEngine } from '../build-engine-api';
 import { BullMQ, getQueues } from '../bullmq';
 import { DatabaseReads, DatabaseWrites } from '../database';
 import { Workflow } from '../workflow';
-import { addProductPropertiesToEnvironment, getWorkflowParameters } from './common.build-publish';
+import {
+  addProductPropertiesToEnvironment,
+  checkBuildRetryCondition,
+  getWorkflowParameters
+} from './common.build-publish';
 import { BuildStatus, ProductTransitionType } from '$lib/prisma';
 import { fetchPackageName, getComputeType, updateComputeType } from '$lib/products';
 import { projectUrl } from '$lib/projects/server';
@@ -276,8 +280,7 @@ export async function postProcess(job: Job<BullMQ.Build.PostProcess>): Promise<u
       const currentCompute = getComputeType(product.Properties);
       if (currentCompute !== 'medium') {
         try {
-          const text = await fetch(job.data.build.artifacts['consoleText']).then((r) => r.text());
-          if (text.match('Gradle build daemon disappeared unexpectedly')) {
+          if (await checkBuildRetryCondition(job.data.build.artifacts['consoleText'])) {
             const newProps = updateComputeType(product.Properties, 'medium');
             // make sure props are actually updated...
             // we don't want infinite retries if this somehow fails...

--- a/src/lib/server/job-executors/common.build-publish.ts
+++ b/src/lib/server/job-executors/common.build-publish.ts
@@ -164,3 +164,9 @@ export async function getWorkflowParameters(
 
   return { ...result, environment: environment };
 }
+
+export async function checkBuildRetryCondition(consoleTextUrl: string) {
+  return fetch(consoleTextUrl)
+    .then((r) => r.text())
+    .then((t) => !!t.match('Gradle build daemon disappeared unexpectedly'));
+}

--- a/src/lib/server/job-executors/system/migrate.ts
+++ b/src/lib/server/job-executors/system/migrate.ts
@@ -5,6 +5,7 @@ import * as v from 'valibot';
 import { BuildEngine } from '../../build-engine-api';
 import { BullMQ, getQueues } from '../../bullmq';
 import { DatabaseReads, DatabaseWrites } from '../../database';
+import { checkBuildRetryCondition } from '../common.build-publish';
 import { JobSchedulerId } from '$lib/bullmq';
 import { fetchPublicationDetails } from '$lib/products/server';
 import { getRelease } from '$lib/server/build-engine-api/requests';
@@ -336,7 +337,7 @@ async function renameRetryComments() {
   const filter: Prisma.ProductTransitionsWhereInput = {
     Comment: 'Build may have failed due to insufficient memory. Retrying with medium compute type.'
   };
-  const chunkSize = 100;
+  const chunkSize = 20;
 
   const before = await DatabaseReads.productTransitions.count({
     where: filter
@@ -359,16 +360,14 @@ async function renameRetryComments() {
             where: {
               ArtifactType: 'consoleText'
             },
-
             select: {
               Url: true
             }
           }
         },
         orderBy: {
-          DateCreated: 'asc'
-        },
-        take: 1
+          DateCreated: 'desc'
+        }
       }
     },
     take: chunkSize,
@@ -378,14 +377,18 @@ async function renameRetryComments() {
   const fixed = await Promise.all(
     chunk.map(async (p) => {
       try {
-        const url = p.ProductBuilds.at(0)?.ProductArtifacts?.at(0)?.Url ?? '';
+        const urls = p.ProductBuilds.map((b) => b.ProductArtifacts?.at(0)?.Url ?? '');
+        let matchingUrl = '';
+        for (const url of urls) {
+          if (url && (await checkBuildRetryCondition(url))) matchingUrl = url;
+        }
         await DatabaseWrites.productTransitions.update({
           where: { Id: p.Id },
           data: {
-            Comment: `system.build-retry,${url}`
+            Comment: `system.build-retry,${matchingUrl}`
           }
         });
-        return { ...p, ConsoleText: url };
+        return { ...p, ConsoleText: matchingUrl };
       } catch (e) {
         return { ...p, Error: e };
       }

--- a/src/lib/server/job-executors/system/migrate.ts
+++ b/src/lib/server/job-executors/system/migrate.ts
@@ -332,9 +332,77 @@ async function backfillAppBuilderVersion(): Promise<MigrationOutput> {
   return { before, chunk, after };
 }
 
+async function renameRetryComments() {
+  const filter: Prisma.ProductTransitionsWhereInput = {
+    Comment: 'Build may have failed due to insufficient memory. Retrying with medium compute type.'
+  };
+  const chunkSize = 100;
+
+  const before = await DatabaseReads.productTransitions.count({
+    where: filter
+  });
+  const chunk = await DatabaseReads.productTransitions.findMany({
+    where: filter,
+    select: {
+      Id: true,
+      ProductBuilds: {
+        where: {
+          Success: false,
+          ProductArtifacts: {
+            some: {
+              ArtifactType: 'consoleText'
+            }
+          }
+        },
+        select: {
+          ProductArtifacts: {
+            where: {
+              ArtifactType: 'consoleText'
+            },
+
+            select: {
+              Url: true
+            }
+          }
+        },
+        orderBy: {
+          DateCreated: 'asc'
+        },
+        take: 1
+      }
+    },
+    take: chunkSize,
+    skip: Math.max(0, randomInt(before || 1) - chunkSize)
+  });
+
+  const fixed = await Promise.all(
+    chunk.map(async (p) => {
+      try {
+        const url = p.ProductBuilds.at(0)?.ProductArtifacts?.at(0)?.Url ?? '';
+        await DatabaseWrites.productTransitions.update({
+          where: { Id: p.Id },
+          data: {
+            Comment: `system.build-retry,${url}`
+          }
+        });
+        return { ...p, ConsoleText: url };
+      } catch (e) {
+        return { ...p, Error: e };
+      }
+    })
+  );
+
+  const after = await DatabaseReads.productTransitions.count({
+    where: filter
+  });
+
+  return { before, chunk, fixed, after };
+}
+
 const migrationSteps = {
   'Patch ProductPublications.LogUrl': backfillPublicationLogUrl,
-  'Backfill Remaining ProductBuilds.AppBuilderVersion': backfillAppBuilderVersion
+  'Backfill Remaining ProductBuilds.AppBuilderVersion': backfillAppBuilderVersion,
+  'Rename Retry Comments': renameRetryComments
 } as const satisfies Record<string, () => Promise<MigrationOutput>>;
 
 export type MigrationStep = keyof typeof migrationSteps;

--- a/src/lib/server/job-executors/system/migrate.ts
+++ b/src/lib/server/job-executors/system/migrate.ts
@@ -4,6 +4,7 @@ import { randomInt } from 'crypto';
 import { BuildEngine } from '../../build-engine-api';
 import { BullMQ, getQueues } from '../../bullmq';
 import { DatabaseReads, DatabaseWrites } from '../../database';
+import { checkBuildRetryCondition } from '../common.build-publish';
 import { JobSchedulerId } from '$lib/bullmq';
 import { type WorkflowInstanceContext, WorkflowState } from '$lib/workflowTypes';
 
@@ -259,7 +260,7 @@ async function renameRetryComments() {
   const filter: Prisma.ProductTransitionsWhereInput = {
     Comment: 'Build may have failed due to insufficient memory. Retrying with medium compute type.'
   };
-  const chunkSize = 100;
+  const chunkSize = 20;
 
   const before = await DatabaseReads.productTransitions.count({
     where: filter
@@ -282,16 +283,14 @@ async function renameRetryComments() {
             where: {
               ArtifactType: 'consoleText'
             },
-
             select: {
               Url: true
             }
           }
         },
         orderBy: {
-          DateCreated: 'asc'
-        },
-        take: 1
+          DateCreated: 'desc'
+        }
       }
     },
     take: chunkSize,
@@ -301,14 +300,18 @@ async function renameRetryComments() {
   const fixed = await Promise.all(
     chunk.map(async (p) => {
       try {
-        const url = p.ProductBuilds.at(0)?.ProductArtifacts?.at(0)?.Url ?? '';
+        const urls = p.ProductBuilds.map((b) => b.ProductArtifacts?.at(0)?.Url ?? '');
+        let matchingUrl = '';
+        for (const url of urls) {
+          if (url && (await checkBuildRetryCondition(url))) matchingUrl = url;
+        }
         await DatabaseWrites.productTransitions.update({
           where: { Id: p.Id },
           data: {
-            Comment: `system.build-retry,${url}`
+            Comment: `system.build-retry,${matchingUrl}`
           }
         });
-        return { ...p, ConsoleText: url };
+        return { ...p, ConsoleText: matchingUrl };
       } catch (e) {
         return { ...p, Error: e };
       }

--- a/src/lib/server/job-executors/system/migrate.ts
+++ b/src/lib/server/job-executors/system/migrate.ts
@@ -142,7 +142,7 @@ async function associateBuildsOrReleases<Scope extends 'build' | 'release'>(scop
   const before = await DatabaseReads.products.count({
     where: { [member]: { some: filter } }
   });
-  const orphaned = (await DatabaseReads.products.findMany({
+  const chunk = (await DatabaseReads.products.findMany({
     where: { [member]: { some: filter } },
     select: {
       Id: true,
@@ -178,8 +178,8 @@ async function associateBuildsOrReleases<Scope extends 'build' | 'release'>(scop
     };
   }> & { ProductBuilds: Build[]; ProductPublications: Release[] })[];
 
-  const associated = await Promise.all(
-    orphaned.map(async (p) => ({
+  const fixed = await Promise.all(
+    chunk.map(async (p) => ({
       Id: p.Id,
       // find first transition where DateTransition is greater than Build.DateCreated
       // problem, date transition isn't set until build is completed... so we only do this for completed builds
@@ -210,7 +210,7 @@ async function associateBuildsOrReleases<Scope extends 'build' | 'release'>(scop
     where: { [member]: { some: filter } }
   });
 
-  return { before, orphaned, associated, after };
+  return { before, chunk, fixed, after };
 }
 
 async function addPackageNameFiles() {
@@ -223,7 +223,7 @@ async function addPackageNameFiles() {
   const before = await DatabaseReads.workflowInstances.count({
     where: filter
   });
-  const orphaned = await DatabaseReads.workflowInstances.findMany({
+  const chunk = await DatabaseReads.workflowInstances.findMany({
     where: filter,
     select: {
       ProductId: true,
@@ -233,8 +233,8 @@ async function addPackageNameFiles() {
     skip: Math.max(0, randomInt(before || 1) - chunkSize)
   });
 
-  const associated = await Promise.all(
-    orphaned.map(async (p) => {
+  const fixed = await Promise.all(
+    chunk.map(async (p) => {
       try {
         const parsed = JSON.parse(p.Context) as WorkflowInstanceContext;
         parsed.includeFields.push('packageName');
@@ -252,13 +252,81 @@ async function addPackageNameFiles() {
     where: filter
   });
 
-  return { before, orphaned, associated, after };
+  return { before, chunk, fixed, after };
+}
+
+async function renameRetryComments() {
+  const filter: Prisma.ProductTransitionsWhereInput = {
+    Comment: 'Build may have failed due to insufficient memory. Retrying with medium compute type.'
+  };
+  const chunkSize = 100;
+
+  const before = await DatabaseReads.productTransitions.count({
+    where: filter
+  });
+  const chunk = await DatabaseReads.productTransitions.findMany({
+    where: filter,
+    select: {
+      Id: true,
+      ProductBuilds: {
+        where: {
+          Success: false,
+          ProductArtifacts: {
+            some: {
+              ArtifactType: 'consoleText'
+            }
+          }
+        },
+        select: {
+          ProductArtifacts: {
+            where: {
+              ArtifactType: 'consoleText'
+            },
+
+            select: {
+              Url: true
+            }
+          }
+        },
+        orderBy: {
+          DateCreated: 'asc'
+        },
+        take: 1
+      }
+    },
+    take: chunkSize,
+    skip: Math.max(0, randomInt(before || 1) - chunkSize)
+  });
+
+  const fixed = await Promise.all(
+    chunk.map(async (p) => {
+      try {
+        const url = p.ProductBuilds.at(0)?.ProductArtifacts?.at(0)?.Url ?? '';
+        await DatabaseWrites.productTransitions.update({
+          where: { Id: p.Id },
+          data: {
+            Comment: `system.build-retry,${url}`
+          }
+        });
+        return { ...p, ConsoleText: url };
+      } catch (e) {
+        return { ...p, Error: e };
+      }
+    })
+  );
+
+  const after = await DatabaseReads.productTransitions.count({
+    where: filter
+  });
+
+  return { before, chunk, fixed, after };
 }
 
 const migrationSteps = {
   'Associate Builds': () => associateBuildsOrReleases('build'),
   'Associate Releases': () => associateBuildsOrReleases('release'),
-  'Add PackageName': addPackageNameFiles
+  'Add PackageName': addPackageNameFiles,
+  'Rename Retry Comments': renameRetryComments
 } as const;
 
 export type MigrationStep = keyof typeof migrationSteps;


### PR DESCRIPTION
Changes:
- Convert retry build messages to use i18n like other build failure message, and have a link to the relevant console text

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Build system now notifies when retrying with increased compute resources due to memory issues

* **Localization**
  * Added translated retry messages in English, Spanish, and French

<!-- end of auto-generated comment: release notes by coderabbit.ai -->