### PR TITLE
Show help when database is out of date

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,8 @@
     "test:unit": "vitest run",
     "prepare": "svelte-kit sync",
     "fix-sourcemaps": "node --experimental-strip-types fixSourcemaps.cts",
-    "diff-db": "prisma migrate diff --from-schema-datasource src/lib/prisma/schema.prisma --to-schema-datamodel src/lib/prisma/schema.prisma --exit-code"
+    "diff-db": "prisma migrate diff --from-schema-datasource src/lib/prisma/schema.prisma --to-schema-datamodel src/lib/prisma/schema.prisma --exit-code || (echo '⚠️ Database is out of date. Run `npm run migrate-db` to update.' && exit 1)",
+    "migrate-db": "prisma migrate dev"
   },
   "//zod": "sveltekit-superforms has a peerDep on zod, but it isn't installed in Docker for some reason",
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "test:unit": "vitest run",
     "prepare": "svelte-kit sync",
     "fix-sourcemaps": "node --experimental-strip-types fixSourcemaps.cts",
-    "diff-db": "prisma migrate diff --from-schema-datasource src/lib/prisma/schema.prisma --to-schema-datamodel src/lib/prisma/schema.prisma --exit-code || (echo '⚠️ Database is out of date. Run `npm run migrate-db` to update.' && exit 1)",
+    "diff-db": "prisma migrate diff --from-schema-datasource src/lib/prisma/schema.prisma --to-schema-datamodel src/lib/prisma/schema.prisma --exit-code; EXIT=$?; [ $EXIT -eq 2 ] && echo '⚠️  Database is out of date. Run `npm run migrate-db` to update.'; exit $EXIT",
     "migrate-db": "prisma migrate dev"
   },
   "//zod": "sveltekit-superforms has a peerDep on zod, but it isn't installed in Docker for some reason",


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the database diff command to detect an out-of-date database, display a clear warning to run the migration command, and exit with the appropriate failure status.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->