### PR TITLE
Hide Software Updates page based on org whitelist for feature

### DIFF
--- a/src/lib/admin-settings/index.ts
+++ b/src/lib/admin-settings/index.ts
@@ -15,8 +15,13 @@ export const AdminSettingsKeys = {
 export const defaultSoftwareUpdatesRateLimit = 20;
 
 export const softwareUpdatesParametersSchema = v.strictObject({
-  'rate-limit': v.optional(v.number(), defaultSoftwareUpdatesRateLimit),
-  'allow-orgs': v.optional(v.union([v.array(v.number()), v.picklist(['all'])]))
+  [AdminSettingsKeys[AdminSettings.SoftwareUpdates].RateLimit]: v.optional(
+    v.number(),
+    defaultSoftwareUpdatesRateLimit
+  ),
+  [AdminSettingsKeys[AdminSettings.SoftwareUpdates].AllowOrgs]: v.optional(
+    v.union([v.array(v.number()), v.picklist(['all'])])
+  )
 });
 
 export function getSchemaForSetting(setting: string) {

--- a/src/lib/admin-settings/index.ts
+++ b/src/lib/admin-settings/index.ts
@@ -1,19 +1,24 @@
 import * as v from 'valibot';
 
 export const AdminSettings = {
-  SoftwareUpdates: 'software-updates'
+  SoftwareUpdates: {
+    Key: 'software-updates',
+    RateLimit: 'rate-limit',
+    AllowOrgs: 'allow-orgs'
+  }
 } as const;
-export type AdminSetting = (typeof AdminSettings)[keyof typeof AdminSettings];
+export type AdminSetting = (typeof AdminSettings)[keyof typeof AdminSettings]['Key'];
 
 export const defaultSoftwareUpdatesRateLimit = 20;
 
-export const softwareUpdatesParametersSchema = v.looseObject({
-  'rate-limit': v.optional(v.number(), defaultSoftwareUpdatesRateLimit)
+export const softwareUpdatesParametersSchema = v.strictObject({
+  'rate-limit': v.optional(v.number(), defaultSoftwareUpdatesRateLimit),
+  'allow-orgs': v.optional(v.union([v.array(v.number()), v.picklist(['all'])]))
 });
 
 export function getSchemaForSetting(setting: string) {
   switch (setting) {
-    case AdminSettings.SoftwareUpdates:
+    case AdminSettings.SoftwareUpdates.Key:
       return v.nullish(softwareUpdatesParametersSchema);
     default:
       return v.nullable(v.looseObject({}));

--- a/src/lib/admin-settings/index.ts
+++ b/src/lib/admin-settings/index.ts
@@ -20,7 +20,8 @@ export const softwareUpdatesParametersSchema = v.strictObject({
     defaultSoftwareUpdatesRateLimit
   ),
   [AdminSettingsKeys[AdminSettings.SoftwareUpdates].AllowOrgs]: v.optional(
-    v.union([v.array(v.number()), v.picklist(['all'])])
+    v.union([v.array(v.number()), v.picklist(['all'])]),
+    []
   )
 });
 

--- a/src/lib/admin-settings/index.ts
+++ b/src/lib/admin-settings/index.ts
@@ -1,13 +1,16 @@
 import * as v from 'valibot';
 
 export const AdminSettings = {
-  SoftwareUpdates: {
-    Key: 'software-updates',
+  SoftwareUpdates: 'software-updates'
+} as const;
+export type AdminSetting = (typeof AdminSettings)[keyof typeof AdminSettings];
+
+export const AdminSettingsKeys = {
+  [AdminSettings.SoftwareUpdates]: {
     RateLimit: 'rate-limit',
     AllowOrgs: 'allow-orgs'
   }
 } as const;
-export type AdminSetting = (typeof AdminSettings)[keyof typeof AdminSettings]['Key'];
 
 export const defaultSoftwareUpdatesRateLimit = 20;
 
@@ -18,7 +21,7 @@ export const softwareUpdatesParametersSchema = v.strictObject({
 
 export function getSchemaForSetting(setting: string) {
   switch (setting) {
-    case AdminSettings.SoftwareUpdates.Key:
+    case AdminSettings.SoftwareUpdates:
       return v.nullish(softwareUpdatesParametersSchema);
     default:
       return v.nullable(v.looseObject({}));

--- a/src/lib/admin-settings/server.ts
+++ b/src/lib/admin-settings/server.ts
@@ -6,21 +6,32 @@ import {
 } from '$lib/admin-settings';
 import { DatabaseReads } from '$lib/server/database';
 
-/**
- * return stored rate limit from DB (default: 20)
- */
-export async function getSoftwareUpdatesRateLimit() {
-  const record = v.safeParse(
+async function getSoftwareUpdatesSettings() {
+  return v.safeParse(
     v.pipe(v.nullish(v.string(), ''), v.parseJson(), softwareUpdatesParametersSchema),
     (
       await DatabaseReads.adminSettings.findUnique({
-        where: { Key: AdminSettings.SoftwareUpdates },
+        where: { Key: AdminSettings.SoftwareUpdates.Key },
         select: {
           Value: true
         }
       })
     )?.Value
   );
+}
 
-  return record.success ? record.output['rate-limit'] : defaultSoftwareUpdatesRateLimit;
+/**
+ * return stored rate limit from DB (default: 20)
+ */
+export async function getSoftwareUpdatesRateLimit() {
+  const record = await getSoftwareUpdatesSettings();
+
+  return record.success
+    ? record.output[AdminSettings.SoftwareUpdates.RateLimit]
+    : defaultSoftwareUpdatesRateLimit;
+}
+
+export async function getOrgAllowlist() {
+  const record = await getSoftwareUpdatesSettings();
+  return record.success ? (record.output[AdminSettings.SoftwareUpdates.AllowOrgs] ?? []) : [];
 }

--- a/src/lib/admin-settings/server.ts
+++ b/src/lib/admin-settings/server.ts
@@ -35,6 +35,6 @@ export async function getSoftwareUpdatesRateLimit() {
 export async function getOrgAllowlist() {
   const record = await getSoftwareUpdatesSettings();
   return record.success
-    ? (record.output[AdminSettingsKeys[AdminSettings.SoftwareUpdates].AllowOrgs] ?? [])
+    ? record.output[AdminSettingsKeys[AdminSettings.SoftwareUpdates].AllowOrgs]
     : [];
 }

--- a/src/lib/admin-settings/server.ts
+++ b/src/lib/admin-settings/server.ts
@@ -1,6 +1,7 @@
 import * as v from 'valibot';
 import {
   AdminSettings,
+  AdminSettingsKeys,
   defaultSoftwareUpdatesRateLimit,
   softwareUpdatesParametersSchema
 } from '$lib/admin-settings';
@@ -11,7 +12,7 @@ async function getSoftwareUpdatesSettings() {
     v.pipe(v.nullish(v.string(), ''), v.parseJson(), softwareUpdatesParametersSchema),
     (
       await DatabaseReads.adminSettings.findUnique({
-        where: { Key: AdminSettings.SoftwareUpdates.Key },
+        where: { Key: AdminSettings.SoftwareUpdates },
         select: {
           Value: true
         }
@@ -27,11 +28,13 @@ export async function getSoftwareUpdatesRateLimit() {
   const record = await getSoftwareUpdatesSettings();
 
   return record.success
-    ? record.output[AdminSettings.SoftwareUpdates.RateLimit]
+    ? record.output[AdminSettingsKeys[AdminSettings.SoftwareUpdates].RateLimit]
     : defaultSoftwareUpdatesRateLimit;
 }
 
 export async function getOrgAllowlist() {
   const record = await getSoftwareUpdatesSettings();
-  return record.success ? (record.output[AdminSettings.SoftwareUpdates.AllowOrgs] ?? []) : [];
+  return record.success
+    ? (record.output[AdminSettingsKeys[AdminSettings.SoftwareUpdates].AllowOrgs] ?? [])
+    : [];
 }

--- a/src/lib/components/settings/JSONEditor.svelte
+++ b/src/lib/components/settings/JSONEditor.svelte
@@ -2,6 +2,8 @@
   import { onMount } from 'svelte';
   import type { ClassValue } from 'svelte/elements';
   import { flatten, safeParse } from 'valibot';
+  import { m } from '$lib/paraglide/messages';
+  import type { ValueKey } from '$lib/utils';
   import { type JsonSchema } from '$lib/valibot';
 
   interface Props {
@@ -10,9 +12,17 @@
     class?: ClassValue;
     ok?: boolean;
     schema: V;
+    hint?: ValueKey;
   }
 
-  let { value = $bindable(), name, class: classes, ok = $bindable(true), schema }: Props = $props();
+  let {
+    value = $bindable(),
+    name,
+    class: classes,
+    ok = $bindable(true),
+    schema,
+    hint
+  }: Props = $props();
 
   let parsed = $state(safeParse(schema, value));
 
@@ -48,6 +58,10 @@
   {#if showErrors && parsed.issues}
     {@const parseErrors = flatten<V>(parsed.issues)}
     <ul>
+      {#if hint}
+        <!-- eslint-disable-next-line @typescript-eslint/no-explicit-any -->
+        <li>{m[hint.key](hint.params as any)}</li>
+      {/if}
       {#each parseErrors.root ?? [] as error}
         <li class="text-red-500">
           <b>{error}</b>

--- a/src/lib/prisma/seed.ts
+++ b/src/lib/prisma/seed.ts
@@ -1,10 +1,6 @@
 import { PrismaClient } from '@prisma/client';
 import { Command, Option } from 'commander';
 
-const AdminSettings = {
-  SoftwareUpdates: 'software-updates'
-};
-
 const ProductType = {
   Android_GooglePlay: 0,
   Android_S3: 1,
@@ -29,12 +25,6 @@ if (options.verbose) console.log(options);
 
 const prisma = new PrismaClient();
 async function main() {
-  await prisma.adminSettings.upsert({
-    where: { Key: AdminSettings.SoftwareUpdates },
-    create: { Key: AdminSettings.SoftwareUpdates, Value: '{ "rate-limit": 20 }' },
-    update: { Value: '{ "rate-limit": 20 }' }
-  });
-
   type ApplicationType = [number, string, string];
   const applicationTypes: ApplicationType[] = [
     [1, 'scriptureappbuilder', 'Scripture App Builder'],

--- a/src/lib/server/database/AdminSettings.ts
+++ b/src/lib/server/database/AdminSettings.ts
@@ -29,7 +29,7 @@ export async function update(
 export async function insertPlaceholders() {
   return await prisma.adminSettings.createMany({
     data: Object.values(AdminSettings).map((v) => ({
-      Key: v,
+      Key: v.Key,
       Value: '{}',
       ModifiedById: null
     })),

--- a/src/lib/server/database/AdminSettings.ts
+++ b/src/lib/server/database/AdminSettings.ts
@@ -29,7 +29,7 @@ export async function update(
 export async function insertPlaceholders() {
   return await prisma.adminSettings.createMany({
     data: Object.values(AdminSettings).map((v) => ({
-      Key: v.Key,
+      Key: v,
       Value: '{}',
       ModifiedById: null
     })),

--- a/src/routes/(authenticated)/+layout.server.ts
+++ b/src/routes/(authenticated)/+layout.server.ts
@@ -3,6 +3,7 @@ import { readFile } from 'fs/promises';
 import { join } from 'path';
 import { array, safeParse } from 'valibot';
 import type { LayoutServerLoad } from './$types';
+import { getOrgAllowlist } from '$lib/admin-settings/server';
 import { langtagSchema } from '$lib/ldml';
 import { readLDML } from '$lib/ldml/server';
 import { locales } from '$lib/paraglide/runtime';
@@ -29,6 +30,8 @@ export const load: LayoutServerLoad = async (event) => {
 
   const localDir = join(process.cwd(), 'languages');
 
+  const updatesAllowList = await getOrgAllowlist();
+
   return {
     organizations,
     userTasks: await getUserTasks(sec.userId),
@@ -43,6 +46,10 @@ export const load: LayoutServerLoad = async (event) => {
         return [];
       }),
     l10nMap: await readLDML(localDir, locales),
-    jobsAvailable: QueueConnected()
+    jobsAvailable: QueueConnected(),
+    updatesAllowList,
+    anyAllowedForUpdates:
+      updatesAllowList === 'all' ||
+      !new Set(updatesAllowList).isDisjointFrom(new Set(organizations.map((o) => o.Id)))
   };
 };

--- a/src/routes/(authenticated)/+layout.svelte
+++ b/src/routes/(authenticated)/+layout.svelte
@@ -221,17 +221,19 @@
                     {m.sidebar_orgSettings()}
                   </a>
                 </li>
-                <li>
-                  <a
-                    class="rounded-none"
-                    class:active-menu-item={isUrlActive('/software-update')}
-                    href={activeOrgUrl('/software-update')}
-                    onclick={closeDrawer}
-                  >
-                    <IconContainer icon={Icons.UpdateOn} width={24} />
-                    {m.softwareUpdate()}
-                  </a>
-                </li>
+                {#if data.updatesAllowList && (data.updatesAllowList === 'all' || ($orgActive ? data.updatesAllowList.includes($orgActive) : data.anyAllowedForUpdates))}
+                  <li>
+                    <a
+                      class="rounded-none"
+                      class:active-menu-item={isUrlActive('/software-update')}
+                      href={activeOrgUrl('/software-update')}
+                      onclick={closeDrawer}
+                    >
+                      <IconContainer icon={Icons.UpdateOn} width={24} />
+                      {m.softwareUpdate()}
+                    </a>
+                  </li>
+                {/if}
               {/if}
               {#if isSuperAdmin(data.session.user.roles)}
                 <li>

--- a/src/routes/(authenticated)/admin/settings/params/+page.svelte
+++ b/src/routes/(authenticated)/admin/settings/params/+page.svelte
@@ -2,7 +2,7 @@
   import { superForm } from 'sveltekit-superforms';
   import type { PageData } from './$types';
   import { invalidate } from '$app/navigation';
-  import { AdminSettings } from '$lib/admin-settings';
+  import { AdminSettings, AdminSettingsKeys } from '$lib/admin-settings';
   import JSONEditor from '$lib/components/settings/JSONEditor.svelte';
   import LabeledFormInput from '$lib/components/settings/LabeledFormInput.svelte';
   import SubmitButton from '$lib/components/settings/SubmitButton.svelte';
@@ -38,12 +38,9 @@
 <form class="m-4" method="post" action="" use:enhance>
   {#each data.settings.toSorted((a, b) => byString(a.Key, b.Key, getLocale())) as setting, i}
     {@const user = setting.ModifiedBy}
-    {@const validKeys = Object.entries(
-      Object.values(AdminSettings).find((s) => s.Key === setting.Key) ?? {}
-    )
-      .filter(([key, _]) => key !== 'Key')
-      .map(([_, value]) => value)
-      .join(', ')}
+    {@const validKeys = Object.values(AdminSettingsKeys[AdminSettings.SoftwareUpdates] ?? {}).join(
+      ', '
+    )}
     <LabeledFormInput
       key="common_passThrough"
       params={{

--- a/src/routes/(authenticated)/admin/settings/params/+page.svelte
+++ b/src/routes/(authenticated)/admin/settings/params/+page.svelte
@@ -2,6 +2,7 @@
   import { superForm } from 'sveltekit-superforms';
   import type { PageData } from './$types';
   import { invalidate } from '$app/navigation';
+  import { AdminSettings } from '$lib/admin-settings';
   import JSONEditor from '$lib/components/settings/JSONEditor.svelte';
   import LabeledFormInput from '$lib/components/settings/LabeledFormInput.svelte';
   import SubmitButton from '$lib/components/settings/SubmitButton.svelte';
@@ -37,6 +38,12 @@
 <form class="m-4" method="post" action="" use:enhance>
   {#each data.settings.toSorted((a, b) => byString(a.Key, b.Key, getLocale())) as setting, i}
     {@const user = setting.ModifiedBy}
+    {@const validKeys = Object.entries(
+      Object.values(AdminSettings).find((s) => s.Key === setting.Key) ?? {}
+    )
+      .filter(([key, _]) => key !== 'Key')
+      .map(([_, value]) => value)
+      .join(', ')}
     <LabeledFormInput
       key="common_passThrough"
       params={{
@@ -49,6 +56,14 @@
         bind:value={$form.entries[setting.Key]}
         bind:ok={ok[i]}
         schema={siteParamsSchema(setting.Key)}
+        hint={validKeys
+          ? {
+              key: 'common_passThrough',
+              params: {
+                value: `Valid keys: ${validKeys}`
+              }
+            }
+          : undefined}
       />
       <span class="validator-hint">&nbsp;</span>
     </LabeledFormInput>

--- a/src/routes/(authenticated)/projects/[id=number]/+page.server.ts
+++ b/src/routes/(authenticated)/projects/[id=number]/+page.server.ts
@@ -4,7 +4,7 @@ import { valibot } from 'sveltekit-superforms/adapters';
 import * as v from 'valibot';
 import type { Actions, PageServerLoad, RequestEvent } from './$types';
 import { addAuthorSchema, addReviewerSchema } from './forms/valibot';
-import { env } from '$env/dynamic/private';
+import { getOrgAllowlist } from '$lib/admin-settings/server';
 import { baseLocale } from '$lib/paraglide/runtime';
 import {
   ProductTransitionType,
@@ -41,22 +41,25 @@ const productActionSchema = v.object({
 });
 
 export const load = (async ({ locals, params }) => {
-  const projectId = Number(params.id);
-  if (isNaN(projectId)) throw error(404, 'Not Found');
   // Check authentication first, before any db calls
   // If the user is not logged in at all (locals.security.userId === null),
   // groups.findMany will error and security will not be handled
   locals.security.requireAuthenticated();
+  const projectId = Number(params.id);
+  const check = await DatabaseReads.projects.findUnique({
+    where: { Id: projectId },
+    select: { OwnerId: true, OrganizationId: true, GroupId: true }
+  });
+  if (!check) throw error(404, 'Not Found');
   locals.security.requireProjectReadAccess(
     await DatabaseReads.groups.findMany({
       where: { Users: { some: { Id: locals.security.userId } } },
       select: { Id: true }
     }),
-    await DatabaseReads.projects.findUnique({
-      where: { Id: projectId },
-      select: { OwnerId: true, OrganizationId: true, GroupId: true }
-    })
+    check
   );
+
+  const allowlist = await getOrgAllowlist();
 
   return {
     projectData: await getProjectDetails(projectId, locals.security.sessionForm),
@@ -64,7 +67,7 @@ export const load = (async ({ locals, params }) => {
     reviewerForm: await superValidate({ language: baseLocale }, valibot(addReviewerSchema)),
     actionForm: await superValidate(valibot(projectActionSchema)),
     jobsAvailable: QueueConnected(),
-    showRebuildToggles: env.APP_ENV !== 'prd'
+    showRebuildToggles: allowlist === 'all' || allowlist.includes(check!.OrganizationId)
   };
 }) satisfies PageServerLoad;
 

--- a/src/routes/(authenticated)/software-update/[[orgId=number]]/+page.server.ts
+++ b/src/routes/(authenticated)/software-update/[[orgId=number]]/+page.server.ts
@@ -1,7 +1,8 @@
-import { fail } from '@sveltejs/kit';
+import { error, fail } from '@sveltejs/kit';
 import { superValidate } from 'sveltekit-superforms';
 import { valibot } from 'sveltekit-superforms/adapters';
 import type { Actions, PageServerLoad } from './$types';
+import { getOrgAllowlist } from '$lib/admin-settings/server';
 import { mapSystems } from '$lib/organizations/server';
 import { ProductActionType } from '$lib/products';
 import { doProductAction } from '$lib/products/server';
@@ -21,6 +22,11 @@ export const load = (async ({ locals, params }) => {
     locals.security.requireAdminOfAny();
   }
 
+  const allowlist = await getOrgAllowlist();
+  if (orgId && allowlist !== 'all' && !allowlist?.includes(orgId)) {
+    return error(403);
+  }
+
   return {
     form: await superValidate(valibot(startFormSchema)),
     applicationTypes: await DatabaseReads.applicationTypes.findMany({
@@ -33,8 +39,14 @@ export const load = (async ({ locals, params }) => {
         })
       ).map((pd) => [pd.Id, pd])
     ),
-    products: await getProducts(locals.security, orgId ? [orgId] : undefined),
-    updates: await getUpdates(locals.security, orgId ? [orgId] : undefined),
+    products: await getProducts(
+      locals.security,
+      orgId ? [orgId] : allowlist !== 'all' ? allowlist : undefined
+    ),
+    updates: await getUpdates(
+      locals.security,
+      orgId ? [orgId] : allowlist !== 'all' ? allowlist : undefined
+    ),
     user: await DatabaseReads.users.findUniqueOrThrow({
       where: { Id: locals.security.userId },
       select: { Name: true }
@@ -44,10 +56,16 @@ export const load = (async ({ locals, params }) => {
 
 export const actions = {
   async start({ request, locals, params }) {
-    if (params.orgId) {
-      locals.security.requireAdminOfOrg(Number(params.orgId));
+    const orgId = params.orgId ? Number(params.orgId) : undefined;
+    if (orgId) {
+      locals.security.requireAdminOfOrg(orgId);
     } else {
       locals.security.requireAdminOfAny();
+    }
+
+    const allowlist = await getOrgAllowlist();
+    if (orgId && allowlist !== 'all' && !allowlist?.includes(orgId)) {
+      return error(403);
     }
 
     const form = await superValidate(request, valibot(startFormSchema));
@@ -57,7 +75,12 @@ export const actions = {
 
     const systems = await mapSystems(
       await DatabaseReads.organizations.findMany({
-        where: filterAdminOrgs(locals.security, params.orgId ? Number(params.orgId) : undefined),
+        where: {
+          AND: [
+            allowlist !== 'all' ? { Id: { in: allowlist } } : {},
+            filterAdminOrgs(locals.security, orgId)
+          ]
+        },
         select: {
           Id: true,
           UseDefaultBuildEngine: true,
@@ -82,10 +105,12 @@ export const actions = {
             updatableProductsFilter,
             {
               Project: {
-                Organization: filterAdminOrgs(
-                  locals.security,
-                  params.orgId ? Number(params.orgId) : undefined
-                )
+                Organization: {
+                  AND: [
+                    allowlist !== 'all' ? { Id: { in: allowlist } } : {},
+                    filterAdminOrgs(locals.security, orgId)
+                  ]
+                }
               }
             }
           ]
@@ -161,6 +186,8 @@ export const actions = {
     } else {
       locals.security.requireAdminOfAny();
     }
+
+    // I don't think we need to check the allowlist for cancellation. - Aidan
 
     const form = await superValidate(request, valibot(deleteSchema));
     if (!form.valid) {

--- a/src/routes/(authenticated)/software-update/[[orgId=number]]/+page.server.ts
+++ b/src/routes/(authenticated)/software-update/[[orgId=number]]/+page.server.ts
@@ -138,36 +138,40 @@ export const actions = {
       return targetVersion && targetVersion !== p.ProductBuilds[0].AppBuilderVersion;
     });
 
-    const update = await DatabaseWrites.softwareUpdates.create(
-      {
-        InitiatedById: locals.security.userId,
-        Comment: form.data.comment
-      },
-      products.map((p) => ({
-        ProductId: p.Id,
-        PreviousVersion: p.ProductBuilds[0].AppBuilderVersion,
-        Version: systems.get(p.Project.OrganizationId)!.get(p.Project.TypeId)!,
-        Status: WorkflowState.Start
-      }))
-    );
+    let results: PromiseSettledResult<unknown>[] = [];
 
-    const results = await Promise.allSettled(
-      products.map((p) =>
-        doProductAction(
-          p.Id,
-          ProductActionType.Rebuild,
-          locals.security.userId,
-          form.data.comment,
-          true,
-          update.Id
-        ).then(() => p.Id)
-      )
-    );
+    if (products.length) {
+      const update = await DatabaseWrites.softwareUpdates.create(
+        {
+          InitiatedById: locals.security.userId,
+          Comment: form.data.comment
+        },
+        products.map((p) => ({
+          ProductId: p.Id,
+          PreviousVersion: p.ProductBuilds[0].AppBuilderVersion,
+          Version: systems.get(p.Project.OrganizationId)!.get(p.Project.TypeId)!,
+          Status: WorkflowState.Start
+        }))
+      );
 
-    getQueues().SvelteSSE.add(`Update Updatable Products (update #${update.Id} started)`, {
-      type: BullMQ.JobType.SvelteSSE_UpdateUpdatableProducts,
-      orgIds: Array.from(new Set(products.map((p) => p.Project.OrganizationId)))
-    });
+      results = await Promise.allSettled(
+        products.map((p) =>
+          doProductAction(
+            p.Id,
+            ProductActionType.Rebuild,
+            locals.security.userId,
+            form.data.comment,
+            true,
+            update.Id
+          ).then(() => p.Id)
+        )
+      );
+
+      getQueues().SvelteSSE.add(`Update Updatable Products (update #${update.Id} started)`, {
+        type: BullMQ.JobType.SvelteSSE_UpdateUpdatableProducts,
+        orgIds: Array.from(new Set(products.map((p) => p.Project.OrganizationId)))
+      });
+    }
 
     return {
       form,


### PR DESCRIPTION
Changes:
- add 'allow-orgs' key to AdminSettings 'software-updates'
  - 'allow-orgs' is either an array of IDs or the string `all`
- Hide Software Updates in sidebar if not allowed
- 403 on updates page if not allowed
- 403 on start action in updates page if not allowed
- cancel action in updates page is allowed through for now, I didn't want to waste unnecessary time implementing it...
- rebuild settings toggles are hidden if not allowed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added organization-based access controls for software updates.
  * Software update navigation and project rebuild options now appear only for permitted organizations.
  * Added support for configuring update access for all organizations or a specific allowlist.
  * Added clearer validation hints for accepted administrator setting keys.

* **Bug Fixes**
  * Prevented unauthorized organizations from viewing or starting software updates.
  * Improved handling of software update settings and rate limits.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->