### PR TITLE
chore: fix playwright CI

### DIFF
--- a/.github/workflows/setup.yml
+++ b/.github/workflows/setup.yml
@@ -128,9 +128,6 @@ jobs:
           path: node_modules
           key: ${{ runner.os }}-node-modules-${{ hashFiles('package-lock.json', 'src/lib/prisma/schema.prisma') }}
 
-      # TODO: Playwright install/tests are temporarily disabled because installing
-      # Playwright in CI takes too long and times out build-and-test. Re-enable
-      # once CI switches to the Playwright docker image instead of installing it.
       - name: Build and seed database
         run: |
           timeout 10m bash <<'EOF'
@@ -196,11 +193,11 @@ jobs:
             exit 1
           }
           npx svelte-kit sync
-          # TODO: Playwright (test:integration) is temporarily disabled, see setup.yml build step.
-          echo "Running unit tests..."
-          npm run test:unit || {
+          echo "Running tests..."
+          npm run test || {
             echo "Tests failed"
             ./run ci logs portal
+            ./run ci logs playwright
             exit 1
           }
         env:
@@ -211,6 +208,7 @@ jobs:
           MAIL_SENDER: 'AmazonSES'
           ADMIN_NAME: 'Scriptoria Staging'
           ADMIN_EMAIL: 'noreply@scriptoria.io'
+          PW_TEST_CONNECT_WS_ENDPOINT: ws://127.0.0.1:3000
       - name: Upload test results
         if: ${{ !cancelled() }}
         uses: actions/upload-artifact@v6

--- a/README.md
+++ b/README.md
@@ -107,7 +107,7 @@ The `stg-tunnel` container can establish a tunnel to the build engine in your lo
 # Testing and linting
 
 ```bash
-CI_EMAIL= CI_PASSWORD= npm run test
+CI_EMAIL= CI_PASSWORD= PW_TEST_CONNECT_WS_ENDPOINT=ws://127.0.0.1:3000 npm run test
 npm run lint
 ```
 

--- a/deployment/ci/docker-compose.yml
+++ b/deployment/ci/docker-compose.yml
@@ -31,7 +31,7 @@ services:
       AUTH0_DOMAIN: "${AUTH0_DOMAIN}"
       AUTH0_CONNECTION: "${AUTH0_CONNECTION}"
       # MUST be included (the path the application will be accessed on) and MUST NOT have a trailing slash
-      ORIGIN: "http://localhost:6173"
+      ORIGIN: "http://portal:6173"
   valkey:
     image: valkey/valkey:latest
     command: valkey-server --appendonly yes --appendfilename appendonly.aof --maxmemory-policy noeviction
@@ -43,3 +43,10 @@ services:
     command: bash -c "cp -r /root/ssh /root/.ssh; chmod -R 600 /root/.ssh; ssh -N -L \*:8443:localhost:\$(ssh aps-stg \"docker ps --format '{{.Names}} {{.Ports}}' | grep -E 'buildengine.*web' | awk -F '->' '{print \\$1}' | awk -F ':' '{print \\$2}'\") aps-stg"
     volumes:
       - ~/.ssh:/root/ssh
+  playwright:
+    # This tagged version should be the same as in package-lock.json
+    image: mcr.microsoft.com/playwright:v1.62.1-noble
+    ports: 
+      - "3000:3000"
+    command: npx -y playwright@1.62.1 run-server --port 3000 --host 0.0.0.0
+

--- a/deployment/development/docker-compose.yml
+++ b/deployment/development/docker-compose.yml
@@ -78,4 +78,4 @@ services:
     # This tagged version should be the same as in package-lock.json
     image: mcr.microsoft.com/playwright:v1.62.1-noble
     env_file: .env
-    command: npx -y playwright@1.62.1 run-server --port 3000 --host 0.0.0.0
+    command: npx -y playwright@1.62.1 run-server --port 3000 --host 127.0.0.1

--- a/deployment/development/docker-compose.yml
+++ b/deployment/development/docker-compose.yml
@@ -72,3 +72,10 @@ services:
     image: cr.jaegertracing.io/jaegertracing/jaeger:latest
     ports:
       - "16686:16686"
+  playwright:
+    # host only works on Linux or Docker Desktop 4.34+ (requires setting to be enabled)
+    network_mode: host
+    # This tagged version should be the same as in package-lock.json
+    image: mcr.microsoft.com/playwright:v1.62.1-noble
+    env_file: .env
+    command: npx -y playwright@1.62.1 run-server --port 3000 --host 0.0.0.0

--- a/package-lock.json
+++ b/package-lock.json
@@ -34,7 +34,7 @@
         "@opentelemetry/sdk-metrics": "^2.0.1",
         "@opentelemetry/sdk-node": "^0.205.0",
         "@opentelemetry/semantic-conventions": "^1.36.0",
-        "@playwright/test": "^1.60.0",
+        "@playwright/test": "^1.62.1",
         "@sveltejs/adapter-node": "^5.2.12",
         "@sveltejs/kit": "^2.43.2",
         "@sveltejs/vite-plugin-svelte": "^6.2.1",
@@ -2639,19 +2639,19 @@
       }
     },
     "node_modules/@playwright/test": {
-      "version": "1.60.0",
-      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.60.0.tgz",
-      "integrity": "sha512-O71yZIbAh/PxDMNGns37GHBIfrVkEVyn+AXyIa5dOTfb4/xNvRWV+Vv/NMbNCtODB/pO7vLlF2OTmMVLhmr7Ag==",
+      "version": "1.62.1",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.62.1.tgz",
+      "integrity": "sha512-DTcUc8qii+cpHvtOwggMtBRMjKZHXYWdw8syRYu2vtzuq4Wxphqq4NfCs5Zt44L6mA8rfDfj+PHnxFc/FeK6mQ==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "playwright": "1.60.0"
+        "playwright": "1.62.1"
       },
       "bin": {
         "playwright": "cli.js"
       },
       "engines": {
-        "node": ">=18"
+        "node": ">=20"
       }
     },
     "node_modules/@polka/url": {
@@ -9404,35 +9404,35 @@
       }
     },
     "node_modules/playwright": {
-      "version": "1.60.0",
-      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.60.0.tgz",
-      "integrity": "sha512-hheHdokM8cdqCb0lcE3s+zT4t4W+vvjpGxsZlDnikarzx8tSzMebh3UiFtgqwFwnTnjYQcsyMF8ei2mCO/tpeA==",
+      "version": "1.62.1",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.62.1.tgz",
+      "integrity": "sha512-0M+L3LAD8/nm554LOla9Ayx0j0tmFZ0FBcoQ7F1VuVHpM/XpiC8RcDzBQB8W5+hA8L22THxELzeF+2WcUzvcLg==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "playwright-core": "1.60.0"
+        "playwright-core": "1.62.1"
       },
       "bin": {
         "playwright": "cli.js"
       },
       "engines": {
-        "node": ">=18"
+        "node": ">=20"
       },
       "optionalDependencies": {
         "fsevents": "2.3.2"
       }
     },
     "node_modules/playwright-core": {
-      "version": "1.60.0",
-      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.60.0.tgz",
-      "integrity": "sha512-9bW6zvX/m0lEbgTKJ6YppOKx8H3VOPBMOCFh2irXFOT4BbHgrx5hPjwJYLT40Lu+4qtD36qKc/Hn56StUW57IA==",
+      "version": "1.62.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.62.1.tgz",
+      "integrity": "sha512-wPYSwEBJY9GHraISXqyqtx0na0LpO3XEX7jNDhntbex7tzUS7kLnZsOlFruFJB4Hi/rhDMjXGqHewDZ68nYZVw==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {
         "playwright-core": "cli.js"
       },
       "engines": {
-        "node": ">=18"
+        "node": ">=20"
       }
     },
     "node_modules/possible-typed-array-names": {

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "@opentelemetry/sdk-metrics": "^2.0.1",
     "@opentelemetry/sdk-node": "^0.205.0",
     "@opentelemetry/semantic-conventions": "^1.36.0",
-    "@playwright/test": "^1.60.0",
+    "@playwright/test": "^1.62.1",
     "@sveltejs/adapter-node": "^5.2.12",
     "@sveltejs/kit": "^2.43.2",
     "@sveltejs/vite-plugin-svelte": "^6.2.1",

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -25,7 +25,7 @@ const config: PlaywrightTestConfig = {
   },
   use: {
     baseURL: `http://${process.env.CI ? 'portal' : 'localhost'}:6173`,
-    trace: 'on-first-retry',
+    trace: 'retain-on-failure-and-retries',
     screenshot: 'only-on-failure'
   },
   testDir: 'tests',

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -24,7 +24,7 @@ const config: PlaywrightTestConfig = {
     }
   },
   use: {
-    baseURL: 'http://localhost:6173',
+    baseURL: `http://${process.env.CI ? 'portal' : 'localhost'}:6173`,
     trace: 'on-first-retry',
     screenshot: 'only-on-failure'
   },

--- a/run
+++ b/run
@@ -20,7 +20,7 @@ function runstuff {
     up:build) ${COMPOSE} up --build $arguments ;;
     up)       ${COMPOSE} up $arguments ;;
     local)
-      runstuff dc up -d db adminer valkey stg-tunnel otel jaeger
+      runstuff dc up -d db adminer valkey stg-tunnel otel jaeger playwright
     ;;
     down)
       ${COMPOSE} down $arguments

--- a/tests/auth.setup.ts
+++ b/tests/auth.setup.ts
@@ -10,6 +10,9 @@ setup('index page has expected h1', async ({ page }) => {
 });
 setup.describe('login setup', () => {
   setup('can login (full flow)', async ({ page }) => {
+    page.on('console', (msg) => {
+      console.log(msg.text());
+    });
     const { CI_EMAIL, CI_PASSWORD } = process.env;
     setup.skip(!CI_EMAIL || !CI_PASSWORD, 'CI credentials not set. Simulating logged in user.');
     await page.goto('/');
@@ -39,6 +42,9 @@ setup.describe('login setup', () => {
     await page.context().storageState({ path: authFile });
   });
   setup('setup login state', async ({ page }) => {
+    page.on('console', (msg) => {
+      console.log(msg.text());
+    });
     const { CI_EMAIL, CI_PASSWORD } = process.env;
     setup.skip(!!CI_EMAIL && !!CI_PASSWORD, 'CI credentials set. Skipping simulated login.');
     const token = await encode({

--- a/tests/auth.setup.ts
+++ b/tests/auth.setup.ts
@@ -62,7 +62,7 @@ setup.describe('login setup', () => {
       {
         name: 'authjs.session-token',
         value: token!,
-        domain: 'localhost',
+        domain: process.env.CI ? 'portal' : 'localhost',
         path: '/'
       }
     ]);

--- a/tests/test.ts
+++ b/tests/test.ts
@@ -1,6 +1,9 @@
 import { type Page, expect, test } from '@playwright/test';
 
 test('auth shared to tests', async ({ page }) => {
+  page.on('console', (msg) => {
+    console.log(msg.text());
+  });
   await page.goto('/'); // should redirect to /tasks
   // Wait for the page to load
   await expect(page.getByRole('heading', { name: 'My Tasks' })).toBeVisible();
@@ -13,6 +16,10 @@ test.describe('Create a Test Project', () => {
   test.beforeAll(async ({ browser }) => {
     page = await browser.newPage();
     projectName = `CI Test Project ${new Date().toLocaleString('en-US')}`;
+
+    page.on('console', (msg) => {
+      console.log(msg.text());
+    });
   });
 
   test.afterAll(async () => {


### PR DESCRIPTION
Changes:
- include playwright docker image in CI
- improve test logging

This will require our auth0 tenant to be updated to include portal as a valid callbackURL domain.
Rationale: when the playwright docker image accesses portal for testing, it uses the hostname `portal` instead of `localhost`, causing cross-site form post errors. This was resolved by changing the ORIGIN variable in the portal docker image from `http://localhost:6173` to `http://portal:6173`, which then caused issues with an invalid callbackUrl for the auth0 tenant.

To consider: is there a way we could remove external dependency on the auth0 tenant for CI?

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Improved automated browser testing reliability in local and continuous integration environments.
  * Added clearer browser console logging and enhanced diagnostics when authentication or portal tests fail.
  * Preserved test traces across failures and retries for easier troubleshooting.
  * Expanded test execution to include the full automated test suite.

* **Chores**
  * Added a dedicated browser testing service for local and continuous integration environments.
  * Updated browser testing tools and configuration for more consistent test execution.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->