### PR TITLE
Add type query string parameter

### DIFF
--- a/src/routes/(unauthenticated)/(google-play)/user-data/[productId=uuid]/+page.server.ts
+++ b/src/routes/(unauthenticated)/(google-play)/user-data/[productId=uuid]/+page.server.ts
@@ -6,7 +6,7 @@ import { valibot } from 'sveltekit-superforms/adapters';
 import * as v from 'valibot';
 import type { Actions, PageServerLoad } from './$types';
 import { env } from '$env/dynamic/private';
-import { deletionTypes, localizedEmailSchema, type DeletionType } from '$lib/google-play';
+import { type DeletionType, deletionTypes, localizedEmailSchema } from '$lib/google-play';
 import { m } from '$lib/google-play/paraglide/messages';
 import type { Locale } from '$lib/google-play/paraglide/runtime';
 import { saveDeleteRequestVerificationCode } from '$lib/google-play/server';

--- a/src/routes/(unauthenticated)/(google-play)/user-data/[productId=uuid]/+page.server.ts
+++ b/src/routes/(unauthenticated)/(google-play)/user-data/[productId=uuid]/+page.server.ts
@@ -6,7 +6,7 @@ import { valibot } from 'sveltekit-superforms/adapters';
 import * as v from 'valibot';
 import type { Actions, PageServerLoad } from './$types';
 import { env } from '$env/dynamic/private';
-import { localizedEmailSchema } from '$lib/google-play';
+import { deletionTypes, localizedEmailSchema, type DeletionType } from '$lib/google-play';
 import { m } from '$lib/google-play/paraglide/messages';
 import type { Locale } from '$lib/google-play/paraglide/runtime';
 import { saveDeleteRequestVerificationCode } from '$lib/google-play/server';
@@ -24,12 +24,17 @@ const localizedSchema = (locale: Locale) =>
     deletionType: v.picklist(['data', 'account'])
   });
 
-export const load: PageServerLoad = async ({ locals, parent }) => {
+export const load: PageServerLoad = async ({ locals, parent, url }) => {
   locals.security.requireNothing();
+
+  const requestedType = url.searchParams.get('type');
+  const deletionType: DeletionType = deletionTypes.includes(requestedType as DeletionType)
+    ? (requestedType as DeletionType)
+    : 'data';
 
   return {
     form: await superValidate(
-      { email: '', turnstileToken: '', deletionType: 'data' as const },
+      { email: '', turnstileToken: '', deletionType },
       valibot(localizedSchema(locals.locale as Locale))
     )
   };

--- a/src/routes/(unauthenticated)/(google-play)/user-data/[productId=uuid]/+page.svelte
+++ b/src/routes/(unauthenticated)/(google-play)/user-data/[productId=uuid]/+page.svelte
@@ -3,6 +3,7 @@
   import { superForm } from 'sveltekit-superforms';
   import type { ActionData, PageData } from './$types';
   import { goto } from '$app/navigation';
+  import { page } from '$app/state';
   import { env } from '$env/dynamic/public';
   import { confirmationStorageKey, deletionTypes } from '$lib/google-play';
   import LocaleSelector from '$lib/google-play/components/LocaleSelector.svelte';
@@ -123,7 +124,9 @@
     <div class="px-5">
       <a
         class="btn btn-ghost btn-sm mb-4 w-full border border-base-300"
-        href={localizeHref(`/user-data/${data.app.id}/about`, { locale: currentLocale })}
+        href={localizeHref(`/user-data/${data.app.id}/about${page.url.search}`, {
+          locale: currentLocale
+        })}
       >
         {m.about_app()}
       </a>

--- a/src/routes/(unauthenticated)/(google-play)/user-data/[productId=uuid]/about/+page.svelte
+++ b/src/routes/(unauthenticated)/(google-play)/user-data/[productId=uuid]/about/+page.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
   import type { PageData } from './$types';
+  import { page } from '$app/state';
   import { m } from '$lib/google-play/paraglide/messages';
   import type { Locale } from '$lib/google-play/paraglide/runtime';
   import { localizeHref } from '$lib/google-play/paraglide/runtime';
@@ -52,7 +53,9 @@
 
       <a
         class="btn btn-primary w-full mt-6"
-        href={localizeHref(`/user-data/${data.app.id}`, { locale: data.app.language as Locale })}
+        href={localizeHref(`/user-data/${data.app.id}${page.url.search}`, {
+          locale: data.app.language as Locale
+        })}
       >
         {m.back_to_manage_data()}
       </a>


### PR DESCRIPTION
In Google Play, there are two separate configuration fields for account deletion and data deletion.  With `/user-data`, it handles both and defaults to deleting data. With this query string parameter, we can fill in the data-safety.csv with separate URLs  for each. It will go to the same page, but default accordingly.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for selecting the data deletion type through a URL query parameter.
  * Preserved the selected deletion context when navigating between the data management and About pages.
  * Maintained the current language and query parameters across related links.

* **Bug Fixes**
  * Improved initialization of the deletion form when a valid deletion type is provided.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->