### PR TITLE
Fix console text backfill

### DIFF
--- a/src/lib/server/job-executors/system/migrate.ts
+++ b/src/lib/server/job-executors/system/migrate.ts
@@ -143,8 +143,9 @@ async function backfillPublicationLogUrl(): Promise<MigrationOutput> {
       { LogUrl: null },
       { LogUrl: '' },
       { LogUrl: { startsWith: 'https://console.aws.com' } },
-      { PublishLink: null },
-      { PublishLink: '' },
+      {
+        AND: [{ OR: [{ PublishLink: null }, { PublishLink: '' }] }, { Success: true }]
+      },
       {
         AND: [
           { OR: [{ Package: null }, { Package: '' }] },

--- a/src/lib/server/job-executors/system/migrate.ts
+++ b/src/lib/server/job-executors/system/migrate.ts
@@ -226,16 +226,16 @@ const vnum = /\d+\.\d+(\.\d+)?/;
 /** Preferred */
 const fromScriptVersion = new RegExp(`APPBUILDER_SCRIPT_VERSION=(${vnum.source})`);
 /** Alternates */
-const fromVersion_Parens = new RegExp(`Version (${vnum.source})`);
+const fromVersion = new RegExp(`Version (${vnum.source})`);
 const fromStarHeader = new RegExp(`\\*\\*\\* (${vnum.source}) \\*\\*\\*`);
-const manageVersionName = new RegExp('BUILD_MANAGE_VERSION_NAME=1');
-const fromVersionName = new RegExp(`VERSION_NAME=(${vnum.source})`);
+const manageVersionName = new RegExp('^BUILD_MANAGE_VERSION_NAME=1');
+const fromVersionName = new RegExp(`^VERSION_NAME=(${vnum.source})`);
 
 async function backfillAppBuilderVersion(): Promise<MigrationOutput> {
   const chunkSize = 20;
   const matchers: ((text: string) => string | undefined)[] = [
     (text) => text.match(fromScriptVersion)?.at(1),
-    (text) => text.match(fromVersion_Parens)?.at(1),
+    (text) => text.match(fromVersion)?.at(1),
     (text) => text.match(fromStarHeader)?.at(1),
     (text) => (text.match(manageVersionName) ? text.match(fromVersionName)?.at(1) : undefined)
   ];

--- a/src/lib/server/job-executors/system/migrate.ts
+++ b/src/lib/server/job-executors/system/migrate.ts
@@ -142,6 +142,7 @@ async function backfillPublicationLogUrl(): Promise<MigrationOutput> {
     OR: [
       { LogUrl: null },
       { LogUrl: '' },
+      { LogUrl: { startsWith: 'https://console.aws.com' } },
       { PublishLink: null },
       { PublishLink: '' },
       {

--- a/src/lib/server/job-executors/system/migrate.ts
+++ b/src/lib/server/job-executors/system/migrate.ts
@@ -220,15 +220,23 @@ async function backfillPublicationLogUrl(): Promise<MigrationOutput> {
   return { before, chunk, after };
 }
 
+const vnum = /\d+\.\d+(\.\d+)?/;
+
+/** Preferred */
+const fromScriptVersion = new RegExp(`APPBUILDER_SCRIPT_VERSION=(${vnum.source})`);
+/** Alternates */
+const fromVersion_Parens = new RegExp(`Version (${vnum.source})`);
+const fromStarHeader = new RegExp(`\\*\\*\\* (${vnum.source}) \\*\\*\\*`);
+const manageVersionName = new RegExp('BUILD_MANAGE_VERSION_NAME=1');
+const fromVersionName = new RegExp(`VERSION_NAME=(${vnum.source})`);
+
 async function backfillAppBuilderVersion(): Promise<MigrationOutput> {
   const chunkSize = 20;
-  const vnum = /\d+\.\d+(\.\d+)?/;
-  const matchers = [
-    /** Preferred */
-    new RegExp(`APPBUILDER_SCRIPT_VERSION=(${vnum.source})`),
-    /** Alternates */
-    new RegExp(`Version (${vnum.source})`),
-    new RegExp(`\\*\\*\\* (${vnum.source}) \\*\\*\\*`)
+  const matchers: ((text: string) => string | undefined)[] = [
+    (text) => text.match(fromScriptVersion)?.at(1),
+    (text) => text.match(fromVersion_Parens)?.at(1),
+    (text) => text.match(fromStarHeader)?.at(1),
+    (text) => (text.match(manageVersionName) ? text.match(fromVersionName)?.at(1) : undefined)
   ];
   const where = {
     Success: true,
@@ -309,7 +317,7 @@ async function backfillAppBuilderVersion(): Promise<MigrationOutput> {
           const log = await fetch(logUrl).then((r) => r.text());
 
           for (const matcher of matchers) {
-            const match = log.match(matcher)?.at(1);
+            const match = matcher(log);
             if (match) {
               appVersion = match;
               break;


### PR DESCRIPTION
Changes:
- Add extra filter to change publications that were backfilled with wrong url
- Tighten query to only try to update publish link for successful publications
- Get AppBuilder version from `VERSION_NAME` env var when `BUILD_MANAGE_VERSION_NAME` is `1`