### PR TITLE
feat: hide repository url in projects page

### DIFF
--- a/src/lib/admin-settings/index.ts
+++ b/src/lib/admin-settings/index.ts
@@ -1,7 +1,8 @@
 import * as v from 'valibot';
 
 export const AdminSettings = {
-  SoftwareUpdates: 'software-updates'
+  SoftwareUpdates: 'software-updates',
+  Projects: 'projects'
 } as const;
 export type AdminSetting = (typeof AdminSettings)[keyof typeof AdminSettings];
 
@@ -9,8 +10,13 @@ export const AdminSettingsKeys = {
   [AdminSettings.SoftwareUpdates]: {
     RateLimit: 'rate-limit',
     AllowOrgs: 'allow-orgs'
+  },
+  [AdminSettings.Projects]: {
+    ShowRepoURL: 'org-show-repo-url'
   }
-} as const;
+} as const satisfies Record<AdminSetting, Record<string, string>>;
+
+const whitelist = v.optional(v.union([v.array(v.number()), v.picklist(['all'])]), []);
 
 export const defaultSoftwareUpdatesRateLimit = 20;
 
@@ -19,16 +25,19 @@ export const softwareUpdatesParametersSchema = v.strictObject({
     v.number(),
     defaultSoftwareUpdatesRateLimit
   ),
-  [AdminSettingsKeys[AdminSettings.SoftwareUpdates].AllowOrgs]: v.optional(
-    v.union([v.array(v.number()), v.picklist(['all'])]),
-    []
-  )
+  [AdminSettingsKeys[AdminSettings.SoftwareUpdates].AllowOrgs]: whitelist
+});
+
+export const projectsParametersSchema = v.strictObject({
+  [AdminSettingsKeys[AdminSettings.Projects].ShowRepoURL]: whitelist
 });
 
 export function getSchemaForSetting(setting: string) {
   switch (setting) {
     case AdminSettings.SoftwareUpdates:
       return v.nullish(softwareUpdatesParametersSchema);
+    case AdminSettings.Projects:
+      return v.nullish(projectsParametersSchema);
     default:
       return v.nullable(v.looseObject({}));
   }

--- a/src/lib/admin-settings/server.ts
+++ b/src/lib/admin-settings/server.ts
@@ -3,6 +3,7 @@ import {
   AdminSettings,
   AdminSettingsKeys,
   defaultSoftwareUpdatesRateLimit,
+  projectsParametersSchema,
   softwareUpdatesParametersSchema
 } from '$lib/admin-settings';
 import { DatabaseReads } from '$lib/server/database';
@@ -32,9 +33,28 @@ export async function getSoftwareUpdatesRateLimit() {
     : defaultSoftwareUpdatesRateLimit;
 }
 
-export async function getOrgAllowlist() {
+export async function getSoftwareUpdatesWhitelist() {
   const record = await getSoftwareUpdatesSettings();
   return record.success
     ? record.output[AdminSettingsKeys[AdminSettings.SoftwareUpdates].AllowOrgs]
     : [];
+}
+
+async function getProjectsSettings() {
+  return v.safeParse(
+    v.pipe(v.nullish(v.string(), ''), v.parseJson(), projectsParametersSchema),
+    (
+      await DatabaseReads.adminSettings.findUnique({
+        where: { Key: AdminSettings.Projects },
+        select: {
+          Value: true
+        }
+      })
+    )?.Value
+  );
+}
+
+export async function getProjectRepoURLWhitelist() {
+  const record = await getProjectsSettings();
+  return record.success ? record.output[AdminSettingsKeys[AdminSettings.Projects].ShowRepoURL] : [];
 }

--- a/src/routes/(authenticated)/+layout.server.ts
+++ b/src/routes/(authenticated)/+layout.server.ts
@@ -3,7 +3,7 @@ import { readFile } from 'fs/promises';
 import { join } from 'path';
 import { array, safeParse } from 'valibot';
 import type { LayoutServerLoad } from './$types';
-import { getOrgAllowlist } from '$lib/admin-settings/server';
+import { getSoftwareUpdatesWhitelist } from '$lib/admin-settings/server';
 import { langtagSchema } from '$lib/ldml';
 import { readLDML } from '$lib/ldml/server';
 import { locales } from '$lib/paraglide/runtime';
@@ -30,7 +30,7 @@ export const load: LayoutServerLoad = async (event) => {
 
   const localDir = join(process.cwd(), 'languages');
 
-  const updatesAllowList = await getOrgAllowlist();
+  const updatesAllowList = await getSoftwareUpdatesWhitelist();
 
   return {
     organizations,

--- a/src/routes/(authenticated)/admin/settings/params/+page.svelte
+++ b/src/routes/(authenticated)/admin/settings/params/+page.svelte
@@ -2,7 +2,8 @@
   import { superForm } from 'sveltekit-superforms';
   import type { PageData } from './$types';
   import { invalidate } from '$app/navigation';
-  import { AdminSettings, AdminSettingsKeys } from '$lib/admin-settings';
+  import type { AdminSetting } from '$lib/admin-settings';
+  import { AdminSettingsKeys } from '$lib/admin-settings';
   import JSONEditor from '$lib/components/settings/JSONEditor.svelte';
   import LabeledFormInput from '$lib/components/settings/LabeledFormInput.svelte';
   import SubmitButton from '$lib/components/settings/SubmitButton.svelte';
@@ -38,7 +39,7 @@
 <form class="m-4" method="post" action="" use:enhance>
   {#each data.settings.toSorted((a, b) => byString(a.Key, b.Key, getLocale())) as setting, i}
     {@const user = setting.ModifiedBy}
-    {@const validKeys = Object.values(AdminSettingsKeys[AdminSettings.SoftwareUpdates] ?? {}).join(
+    {@const validKeys = Object.values(AdminSettingsKeys[setting.Key as AdminSetting] ?? {}).join(
       ', '
     )}
     <LabeledFormInput

--- a/src/routes/(authenticated)/projects/[id=number]/+page.server.ts
+++ b/src/routes/(authenticated)/projects/[id=number]/+page.server.ts
@@ -19,7 +19,7 @@ import {
 import { ProductActionType } from '$lib/products';
 import { doProductAction } from '$lib/products/server';
 import { projectActionSchema } from '$lib/projects';
-import { doProjectAction, userGroupsForOrg } from '$lib/projects/server';
+import { doProjectAction, projectUrl, userGroupsForOrg } from '$lib/projects/server';
 import { getProjectDetails } from '$lib/projects/sse';
 import { BullMQ, QueueConnected, getQueues } from '$lib/server/bullmq';
 import { DatabaseReads, DatabaseWrites } from '$lib/server/database';
@@ -76,7 +76,8 @@ export const load = (async ({ locals, params }) => {
     showRepoURL:
       repoAllowList === 'all' ||
       repoAllowList.includes(check!.OrganizationId) ||
-      locals.security.isSuperAdmin
+      locals.security.isSuperAdmin,
+    projectURL: projectUrl(projectId)
   };
 }) satisfies PageServerLoad;
 

--- a/src/routes/(authenticated)/projects/[id=number]/+page.server.ts
+++ b/src/routes/(authenticated)/projects/[id=number]/+page.server.ts
@@ -4,7 +4,10 @@ import { valibot } from 'sveltekit-superforms/adapters';
 import * as v from 'valibot';
 import type { Actions, PageServerLoad, RequestEvent } from './$types';
 import { addAuthorSchema, addReviewerSchema } from './forms/valibot';
-import { getOrgAllowlist } from '$lib/admin-settings/server';
+import {
+  getProjectRepoURLWhitelist,
+  getSoftwareUpdatesWhitelist
+} from '$lib/admin-settings/server';
 import { baseLocale } from '$lib/paraglide/runtime';
 import {
   ProductTransitionType,
@@ -59,7 +62,8 @@ export const load = (async ({ locals, params }) => {
     check
   );
 
-  const allowlist = await getOrgAllowlist();
+  const updatesAllowList = await getSoftwareUpdatesWhitelist();
+  const repoAllowList = await getProjectRepoURLWhitelist();
 
   return {
     projectData: await getProjectDetails(projectId, locals.security.sessionForm),
@@ -67,7 +71,12 @@ export const load = (async ({ locals, params }) => {
     reviewerForm: await superValidate({ language: baseLocale }, valibot(addReviewerSchema)),
     actionForm: await superValidate(valibot(projectActionSchema)),
     jobsAvailable: QueueConnected(),
-    showRebuildToggles: allowlist === 'all' || allowlist.includes(check!.OrganizationId)
+    showRebuildToggles:
+      updatesAllowList === 'all' || updatesAllowList.includes(check!.OrganizationId),
+    showRepoURL:
+      repoAllowList === 'all' ||
+      repoAllowList.includes(check!.OrganizationId) ||
+      locals.security.isSuperAdmin
   };
 }) satisfies PageServerLoad;
 

--- a/src/routes/(authenticated)/projects/[id=number]/+page.svelte
+++ b/src/routes/(authenticated)/projects/[id=number]/+page.svelte
@@ -167,27 +167,33 @@
             <br />
             <p>{projectData.project.Description}</p>
           </div>
-          <div>
-            <span>{m.project_location()}:</span>
-            <br />
-            <div class="flex rounded-md text-nowrap bg-base-200 p-3 pt-2 mt-2">
-              <IconContainer icon={Icons.URL} width={20} class="opacity-80 mr-1" />
-              <p>
-                {projectData.project.RepositoryUrl?.substring(0, 5) ?? ''}
-              </p>
-              {#if !projectData.project.RepositoryUrl}
-                <p class="italic">{m.project_location_placeholder()}</p>
-              {:else}
-                <p class="shrink overflow-hidden text-ellipsis">
-                  {projectData.project.RepositoryUrl.split('/').slice(2, -1).join('/')}
+          {#if data.showRepoURL}
+            <div>
+              <span>{m.project_location()}:</span>
+              <br />
+              <div class="flex rounded-md text-nowrap bg-base-200 p-3 pt-2 mt-2">
+                <IconContainer icon={Icons.URL} width={20} class="opacity-80 mr-1" />
+                <p>
+                  {projectData.project.RepositoryUrl?.substring(0, 5) ?? ''}
                 </p>
-                <p class="grow pr-2">
-                  /{projectData.project.RepositoryUrl.split('/').pop()}
-                </p>
-                <CopyField value={projectData.project.RepositoryUrl!} />
-              {/if}
+                {#if !projectData.project.RepositoryUrl}
+                  <p class="italic">{m.project_location_placeholder()}</p>
+                {:else}
+                  <p class="shrink overflow-hidden text-ellipsis">
+                    {projectData.project.RepositoryUrl.split('/').slice(2, -1).join('/')}
+                  </p>
+                  <p class="grow pr-2">
+                    /{projectData.project.RepositoryUrl.split('/').pop()}
+                  </p>
+                  <CopyField value={projectData.project.RepositoryUrl!} />
+                {/if}
+              </div>
             </div>
-          </div>
+          {:else if !projectData.project.RepositoryUrl}
+            <div class="flex rounded-md text-nowrap bg-base-200 p-3 pt-2 mt-2">
+              <p class="italic">{m.project_location_placeholder()}</p>
+            </div>
+          {/if}
         </div>
         <!-- Product List Header -->
         <div class="flex flex-row place-content-between items-end">

--- a/src/routes/(authenticated)/projects/[id=number]/+page.svelte
+++ b/src/routes/(authenticated)/projects/[id=number]/+page.svelte
@@ -167,6 +167,17 @@
             <br />
             <p>{projectData.project.Description}</p>
           </div>
+          <div>
+            <span>{m.tasks_appProjectURL()}:</span>
+            <br />
+            <div class="flex rounded-md text-nowrap bg-base-200 p-3 pt-2 mt-2">
+              <IconContainer icon={Icons.URL} width={20} class="opacity-80 mr-1" />
+              <p class="grow">
+                {data.projectURL}
+              </p>
+              <CopyField value={data.projectURL} />
+            </div>
+          </div>
           {#if data.showRepoURL}
             <div>
               <span>{m.project_location()}:</span>

--- a/src/routes/(authenticated)/software-update/[[orgId=number]]/+page.server.ts
+++ b/src/routes/(authenticated)/software-update/[[orgId=number]]/+page.server.ts
@@ -2,7 +2,7 @@ import { error, fail } from '@sveltejs/kit';
 import { superValidate } from 'sveltekit-superforms';
 import { valibot } from 'sveltekit-superforms/adapters';
 import type { Actions, PageServerLoad } from './$types';
-import { getOrgAllowlist } from '$lib/admin-settings/server';
+import { getSoftwareUpdatesWhitelist } from '$lib/admin-settings/server';
 import { mapSystems } from '$lib/organizations/server';
 import { ProductActionType } from '$lib/products';
 import { doProductAction } from '$lib/products/server';
@@ -22,7 +22,7 @@ export const load = (async ({ locals, params }) => {
     locals.security.requireAdminOfAny();
   }
 
-  const allowlist = await getOrgAllowlist();
+  const allowlist = await getSoftwareUpdatesWhitelist();
   if (orgId && allowlist !== 'all' && !allowlist?.includes(orgId)) {
     return error(403);
   }
@@ -63,7 +63,7 @@ export const actions = {
       locals.security.requireAdminOfAny();
     }
 
-    const allowlist = await getOrgAllowlist();
+    const allowlist = await getSoftwareUpdatesWhitelist();
     if (orgId && allowlist !== 'all' && !allowlist?.includes(orgId)) {
       return error(403);
     }


### PR DESCRIPTION
Changes:
- Add new site parameter: `'projects': 'org-show-repo-url'`
- Hide project repository url by default. 
  - It is only visible to super admins and users in white-listed orgs
  - Do we want to further limit this to, say, org admins, or only those with edit permissions?
- Show App Project URL in projects page

<img width="658" height="512" alt="Screenshot 2026-08-24 at 11 42 54 AM" src="https://github.com/user-attachments/assets/0154037c-fc95-492d-92b4-e89ffe38133d" />
