### PR TITLE
Clean up npm execution

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "test:unit": "vitest run",
     "prepare": "svelte-kit sync",
     "fix-sourcemaps": "node --experimental-strip-types fixSourcemaps.cts",
-    "diff-db": "prisma migrate diff --from-schema-datasource src/lib/prisma/schema.prisma --to-schema-datamodel src/lib/prisma/schema.prisma --exit-code; EXIT=$?; [ $EXIT -eq 2 ] && echo '⚠️  Database is out of date. Run `npm run migrate-db` to update.'; exit $EXIT",
+    "diff-db": "sh scripts/diff-db.sh",
     "migrate-db": "prisma migrate dev"
   },
   "//zod": "sveltekit-superforms has a peerDep on zod, but it isn't installed in Docker for some reason",

--- a/scripts/diff-db.sh
+++ b/scripts/diff-db.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env sh
+prisma migrate diff --from-schema-datasource src/lib/prisma/schema.prisma --to-schema-datamodel src/lib/prisma/schema.prisma --exit-code
+EXIT=$?
+[ $EXIT -eq 2 ] && echo '⚠️  Database is out of date. Run `npm run migrate-db` to update.'
+exit $EXIT


### PR DESCRIPTION
It is confusing to see the warning statement in the command execution

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Developer Experience**
  * Improved database schema comparison reporting.
  * Out-of-date databases now display a clear warning with instructions to run the database migration command.
  * Preserved the comparison command’s exit status for reliable automation and checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->