### PR TITLE
Fix langtags refresh on startup

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,10 +46,6 @@ ADMIN_EMAIL=
 
 USER_DATA_TURNSTILE_SECRET_KEY=
 PUBLIC_USER_DATA_TURNSTILE_SITEKEY=
-
-# The langtag refresh process can be very time intensive, and makes a lot of requests to an external server
-# This process is also readded to the queue every time the dev server updates, which means it can quickly have a lot of intances added after every change
-# SKIP_LANGTAG_REFRESH_STARTUP=
 ```
 
 > **Note:** Contact [@sillsdev/scriptoria-developers](https://github.com/orgs/sillsdev/teams/scriptoria-developers/members) for help obtaining the secret values.

--- a/README.md
+++ b/README.md
@@ -46,6 +46,10 @@ ADMIN_EMAIL=
 
 USER_DATA_TURNSTILE_SECRET_KEY=
 PUBLIC_USER_DATA_TURNSTILE_SITEKEY=
+
+# The langtag refresh process can be very time intensive, and makes a lot of requests to an external server
+# This process is also readded to the queue every time the dev server updates, which means it can quickly have a lot of intances added after every change
+# SKIP_LANGTAG_REFRESH_STARTUP=
 ```
 
 > **Note:** Contact [@sillsdev/scriptoria-developers](https://github.com/orgs/sillsdev/teams/scriptoria-developers/members) for help obtaining the secret values.

--- a/src/lib/server/bullmq/BullWorker.ts
+++ b/src/lib/server/bullmq/BullWorker.ts
@@ -183,25 +183,22 @@ export class SystemStartup<J extends BullMQ.StartupJob> extends BullWorker<J> {
       ]
     ] as const;
     if (!building) {
-      Promise.allSettled([
-        getQueues().SystemStartup.drain(true),
-        getQueues().SystemStartup.getActiveCount()
-      ]).then(([_drain, active]) => {
-        const activeCount = active.status === 'fulfilled' ? active.value : 0;
-        console.log(`${activeCount} jobs found in SystemStartup queue on startup`);
-        // allow refresh langtags to be skipped on startup in dev
-        // refresh langtags is a time-intensive operation, and rerunning it after every time a change is made in local dev is very costly on the ldml api server
-        const filteredJobs = startupJobs.filter(
-          (j) =>
-            env.NODE_ENV !== 'development' ||
-            j[1].type !== BullMQ.JobType.System_RefreshLangTags ||
-            !env.SKIP_LANGTAG_REFRESH_STARTUP
-        );
-        this.jobsLeft = filteredJobs.length + activeCount;
-        filteredJobs.forEach(([name, data]) => {
-          getQueues().SystemStartup.add(name, data);
+      getQueues()
+        .SystemStartup.drain(true)
+        .then(() => {
+          // allow refresh langtags to be skipped on startup in dev
+          // refresh langtags is a time-intensive operation, and rerunning it after every time a change is made in local dev is very costly on the ldml api server
+          const filteredJobs = startupJobs.filter(
+            (j) =>
+              env.NODE_ENV !== 'development' ||
+              j[1].type !== BullMQ.JobType.System_RefreshLangTags ||
+              !env.SKIP_LANGTAG_REFRESH_STARTUP
+          );
+          this.jobsLeft = filteredJobs.length;
+          filteredJobs.forEach(([name, data]) => {
+            getQueues().SystemStartup.add(name, data);
+          });
         });
-      });
     }
   }
   async run(job: Job<J>) {

--- a/src/lib/server/bullmq/BullWorker.ts
+++ b/src/lib/server/bullmq/BullWorker.ts
@@ -181,10 +181,19 @@ export class SystemStartup<J extends BullMQ.StartupJob> extends BullWorker<J> {
         }
       ]
     ] as const;
-    startupJobs.forEach(([name, data]) => {
-      getQueues().SystemStartup.add(name, data);
-    });
-    this.jobsLeft = startupJobs.length;
+    if (!building) {
+      Promise.allSettled([
+        getQueues().SystemStartup.drain(true),
+        getQueues().SystemStartup.getActiveCount()
+      ]).then(([_drain, active]) => {
+        const activeCount = active.status === 'fulfilled' ? active.value : 0;
+        console.log(`${activeCount} jobs found in SystemStartup queue on startup`);
+        this.jobsLeft = startupJobs.length + activeCount;
+        startupJobs.forEach(([name, data]) => {
+          getQueues().SystemStartup.add(name, data);
+        });
+      });
+    }
   }
   async run(job: Job<J>) {
     // Close the worker after running the startup jobs

--- a/src/lib/server/bullmq/BullWorker.ts
+++ b/src/lib/server/bullmq/BullWorker.ts
@@ -5,6 +5,7 @@ import * as Executor from '../job-executors';
 import { getQueues, getWorkerConfig } from './queues';
 import * as BullMQ from './types';
 import { building } from '$app/environment';
+import { env } from '$env/dynamic/private';
 import { SSEPageUpdates } from '$lib/projects/listener';
 
 const tracer = trace.getTracer('BullWorker');
@@ -188,8 +189,16 @@ export class SystemStartup<J extends BullMQ.StartupJob> extends BullWorker<J> {
       ]).then(([_drain, active]) => {
         const activeCount = active.status === 'fulfilled' ? active.value : 0;
         console.log(`${activeCount} jobs found in SystemStartup queue on startup`);
-        this.jobsLeft = startupJobs.length + activeCount;
-        startupJobs.forEach(([name, data]) => {
+        // allow refresh langtags to be skipped on startup in dev
+        // refresh langtags is a time-intensive operation, and rerunning it after every time a change is made in local dev is very costly on the ldml api server
+        const filteredJobs = startupJobs.filter(
+          (j) =>
+            env.NODE_ENV !== 'development' ||
+            j[1].type !== BullMQ.JobType.System_RefreshLangTags ||
+            !env.SKIP_LANGTAG_REFRESH_STARTUP
+        );
+        this.jobsLeft = filteredJobs.length + activeCount;
+        filteredJobs.forEach(([name, data]) => {
           getQueues().SystemStartup.add(name, data);
         });
       });

--- a/src/lib/server/bullmq/BullWorker.ts
+++ b/src/lib/server/bullmq/BullWorker.ts
@@ -5,7 +5,6 @@ import * as Executor from '../job-executors';
 import { getQueues, getWorkerConfig } from './queues';
 import * as BullMQ from './types';
 import { building } from '$app/environment';
-import { env } from '$env/dynamic/private';
 import { SSEPageUpdates } from '$lib/projects/listener';
 
 const tracer = trace.getTracer('BullWorker');
@@ -186,16 +185,8 @@ export class SystemStartup<J extends BullMQ.StartupJob> extends BullWorker<J> {
       getQueues()
         .SystemStartup.drain(true)
         .then(() => {
-          // allow refresh langtags to be skipped on startup in dev
-          // refresh langtags is a time-intensive operation, and rerunning it after every time a change is made in local dev is very costly on the ldml api server
-          const filteredJobs = startupJobs.filter(
-            (j) =>
-              env.NODE_ENV !== 'development' ||
-              j[1].type !== BullMQ.JobType.System_RefreshLangTags ||
-              !env.SKIP_LANGTAG_REFRESH_STARTUP
-          );
-          this.jobsLeft = filteredJobs.length;
-          filteredJobs.forEach(([name, data]) => {
+          this.jobsLeft = startupJobs.length;
+          startupJobs.forEach(([name, data]) => {
             getQueues().SystemStartup.add(name, data);
           });
         });

--- a/src/lib/server/job-executors/system/langtags.ts
+++ b/src/lib/server/job-executors/system/langtags.ts
@@ -101,6 +101,8 @@ async function fetchWithLog(url: string, logger: Logger, fetchInit?: RequestInit
   return res;
 }
 
+// timeout after 15s
+const UPDATE_TIMEOUT_MS = 15_000;
 async function shouldUpdate(
   localPath: string,
   remotePath: string,
@@ -116,7 +118,14 @@ async function shouldUpdate(
       const localLastModified = new Date((await stat(localPath)).mtimeMs);
       const res = await fetchWithLog(remotePath, logger, {
         method: 'HEAD',
-        headers: { 'If-Modified-Since': localLastModified.toUTCString() }
+        headers: { 'If-Modified-Since': localLastModified.toUTCString() },
+        signal: AbortSignal.timeout(UPDATE_TIMEOUT_MS)
+      }).catch((e) => {
+        return {
+          status: 500,
+          statusText: String(e),
+          headers: new Headers()
+        };
       });
       if (res.status === 304 || res.status >= 400) {
         // HTTP 304 Not Modified

--- a/src/lib/server/job-executors/system/langtags.ts
+++ b/src/lib/server/job-executors/system/langtags.ts
@@ -118,8 +118,10 @@ async function shouldUpdate(
         method: 'HEAD',
         headers: { 'If-Modified-Since': localLastModified.toUTCString() }
       });
-      if (res.status === 304) {
+      if (res.status === 304 || res.status >= 400) {
         // HTTP 304 Not Modified
+        // HTTP 400+ Client error
+        // HTTP 500+ Server error
         return {
           shouldUpdate: false,
           status: res.status + ' ' + res.statusText

--- a/src/lib/server/job-executors/system/langtags.ts
+++ b/src/lib/server/job-executors/system/langtags.ts
@@ -5,7 +5,7 @@ import { existsSync } from 'fs';
 import { mkdir, readFile, stat, writeFile } from 'fs/promises';
 import { join } from 'path';
 import * as v from 'valibot';
-import type { BullMQ } from '../../bullmq';
+import { BullMQ } from '../../bullmq';
 import { withAlternates } from '$lib/google-play';
 import { addBasicVariants, langtagSchema } from '$lib/ldml';
 import { locales as defaultLocales } from '$lib/paraglide/runtime';
@@ -26,6 +26,31 @@ export async function refreshLangTags(job: Job<BullMQ.System.RefreshLangTags>): 
 
   const log = (msg: string) => job.log(msg);
 
+  const lastUpdatedPath = join(localDir, 'last_updated');
+  let lastUpdatedMS = 0;
+  const startDateMS = Date.now();
+  const thirtyDaysMS = 1000 * 60 * 60 * 24 * 30;
+  const isStartup = job.queueName === BullMQ.QueueName.System_Startup;
+
+  if (isStartup && existsSync(lastUpdatedPath)) {
+    try {
+      lastUpdatedMS = parseInt(String(await readFile(lastUpdatedPath)));
+    } catch (e) {
+      log(`${e}`);
+    }
+  }
+
+  if (isStartup && startDateMS < lastUpdatedMS + thirtyDaysMS) {
+    log(`Last Updated ${new Date(lastUpdatedMS)}`);
+    job.updateProgress(100);
+    return {
+      lastUpdatedMS,
+      __thresholdMS: lastUpdatedMS + thirtyDaysMS,
+      __startDateMS: startDateMS
+    };
+  } else {
+    await writeFile(lastUpdatedPath, String(startDateMS));
+  }
   try {
     job.log(sectionDelim);
 


### PR DESCRIPTION
The `Refresh Langtags` job can be very time-intensive, especially now that we are also handling LDML for nearly 90 GooglePlay locales. In production/staging, this isn't a big problem, except when a new deployment occurs shortly after another one. In local development, however, this can be a really big problem since the dev server restarts (and therefore readds all the startup jobs) each time a change is saved.

Changes:
- On start, drain SystemStartup queue of all waiting jobs
- When running `Refresh Langtags` on startup, check against saved `languages/last_updated` file, which records the last update time in ms. Only refresh if it has been 30 days since the last refresh.
- Timeout shouldUpdate check to 15s

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved startup job handling by allowing the language-tag refresh to be skipped during development when configured.
  - Added timeout and error handling for language-tag update checks, preventing failed requests from triggering unnecessary updates.
  - More reliably handles client and server error responses during language-tag checks.

- **Documentation**
  - Added environment-variable guidance for configuring the language-tag refresh process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->